### PR TITLE
Restyle Traces V4 saved views: dirty-mode overwrite, filter capture, and V3 migration

### DIFF
--- a/mlflow/server/js/scripts/componentId-registry.js
+++ b/mlflow/server/js/scripts/componentId-registry.js
@@ -2171,7 +2171,6 @@ module.exports = {
   "mlflow.traces-v4.saved_views": "",
   "mlflow.traces-v4.saved_views.delete_confirm": "",
   "mlflow.traces-v4.saved_views.trigger": "",
-  "mlflow.traces-v4.shared_view": "",
 
   // -- mlflow.usage --
   "mlflow.usage.metrics_filter": "",

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewSavedViewsButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewSavedViewsButton.tsx
@@ -94,7 +94,7 @@ export const ExperimentViewSavedViewsButton = ({
             )}
           </Button>
         </DropdownMenu.Trigger>
-        <DropdownMenu.Content align="end">
+        <DropdownMenu.Content align="start">
           <SavedViewsMenu
             componentId="mlflow.experiment_page.saved_views"
             testIdPrefix="saved-views"

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewSharedViewBanner.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewSharedViewBanner.test.tsx
@@ -19,7 +19,7 @@ describe('ExperimentViewSharedViewBanner', () => {
     const onDiscard = jest.fn();
     renderWithDesignSystem(<ExperimentViewSharedViewBanner onOverride={onOverride} onDiscard={onDiscard} />);
 
-    fireEvent.click(screen.getByRole('button', { name: /^discard$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /exit shared view/i }));
 
     expect(onDiscard).toHaveBeenCalledTimes(1);
     expect(onOverride).not.toHaveBeenCalled();

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/saved-views/SavedViewsMenu.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/saved-views/SavedViewsMenu.tsx
@@ -6,14 +6,14 @@ import {
   DropdownMenu,
   Input,
   LinkIcon,
+  PencilIcon,
+  RefreshIcon,
   SearchIcon,
   Tooltip,
   TrashIcon,
   Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
-
-import Utils from '../../../../../common/utils/Utils';
 
 export interface SavedViewMenuItem {
   id: string;
@@ -92,6 +92,16 @@ export const SavedViewsMenu = ({
 
   return (
     <>
+      <DropdownMenu.Label
+        css={{
+          textTransform: 'uppercase',
+          fontSize: theme.typography.fontSizeMd,
+          fontWeight: 600,
+          letterSpacing: '0.04em',
+        }}
+      >
+        <FormattedMessage defaultMessage="Saved views" description="Header at the top of the saved views dropdown" />
+      </DropdownMenu.Label>
       <div css={{ padding: `${theme.spacing.sm}px ${theme.spacing.md}px ${theme.spacing.xs}px`, width: 320 }}>
         <Input
           componentId={`${componentId}.search`}
@@ -103,6 +113,9 @@ export const SavedViewsMenu = ({
           })}
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
+          // Stop keystrokes from bubbling to the DropdownMenu, whose built-in typeahead would otherwise
+          // steal each letter to jump-focus the first matching row — pulling focus out of this input.
+          onKeyDown={(e) => e.stopPropagation()}
           autoFocus
         />
       </div>
@@ -136,39 +149,6 @@ export const SavedViewsMenu = ({
           <DropdownMenu.Separator />
         </>
       )}
-      {showSharedViewActions && (
-        <>
-          <DropdownMenu.Label css={{ color: theme.colors.textSecondary }}>
-            <FormattedMessage
-              defaultMessage="You're viewing a shared view"
-              description="Heading above the override/discard actions in the saved views menu, shown while a shared view is applied"
-            />
-          </DropdownMenu.Label>
-          <DropdownMenu.Item
-            componentId={`${componentId}.override_active`}
-            data-testid={`${testIdPrefix}-override-active`}
-            onClick={onOverrideActive}
-          >
-            {overrideLabel ?? (
-              <FormattedMessage
-                defaultMessage="Override my view"
-                description="Menu item that adopts the currently-applied shared view into the user's own view"
-              />
-            )}
-          </DropdownMenu.Item>
-          <DropdownMenu.Item
-            componentId={`${componentId}.discard_active`}
-            data-testid={`${testIdPrefix}-discard-active`}
-            onClick={onDiscardActive}
-          >
-            <FormattedMessage
-              defaultMessage="Discard shared view"
-              description="Menu item that discards the currently-applied shared view and restores the user's own view"
-            />
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator />
-        </>
-      )}
       <div css={{ maxHeight: 320, overflowY: 'auto' }}>
         {filtered.length === 0 ? (
           <div css={{ padding: theme.spacing.md, textAlign: 'center' }}>
@@ -192,23 +172,35 @@ export const SavedViewsMenu = ({
               key={view.id}
               componentId={`${componentId}.item`}
               onClick={() => onOpen(view.id)}
-              css={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: theme.spacing.sm }}
+              css={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: theme.spacing.sm,
+                // Reveal row actions on hover and Radix keyboard-highlight (so arrow-key users reach
+                // them). `opacity` not `display` keeps them in layout + the a11y tree. The active row
+                // keeps them visible (no hover affordance of its own). On this rule so it beats the
+                // descendant selector below.
+                '& .saved-view-row-actions': { opacity: view.id === activeViewId ? 1 : 0 },
+                '&:hover .saved-view-row-actions, &[data-highlighted] .saved-view-row-actions': {
+                  opacity: 1,
+                },
+              }}
               data-testid={`${testIdPrefix}-item-${view.id}`}
             >
               <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm, minWidth: 0 }}>
                 <span css={{ width: theme.general.iconFontSize, flexShrink: 0 }}>
                   {view.id === activeViewId && <CheckIcon data-testid={`${testIdPrefix}-active-${view.id}`} />}
                 </span>
-                <div css={{ display: 'flex', flexDirection: 'column', minWidth: 0 }}>
-                  <Typography.Text bold css={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                    {view.name}
-                  </Typography.Text>
-                  <Typography.Text size="sm" color="secondary">
-                    {Utils.timeSinceStr(new Date(view.createdAt))}
-                  </Typography.Text>
-                </div>
+                <Typography.Text css={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                  {view.name}
+                </Typography.Text>
               </div>
-              <div css={{ display: 'flex', gap: theme.spacing.xs, flexShrink: 0 }} onClick={(e) => e.stopPropagation()}>
+              <div
+                className="saved-view-row-actions"
+                css={{ display: 'flex', gap: theme.spacing.xs, flexShrink: 0 }}
+                onClick={(e) => e.stopPropagation()}
+              >
                 <Tooltip componentId={`${componentId}.copy_link_tooltip`} content={copyLinkLabel}>
                   <Button
                     componentId={`${componentId}.copy_link`}
@@ -241,20 +233,56 @@ export const SavedViewsMenu = ({
           ))
         )}
       </div>
-      {canModify && (
+      {(canModify || showSharedViewActions) && <DropdownMenu.Separator />}
+      {showSharedViewActions && (
         <>
-          <DropdownMenu.Separator />
           <DropdownMenu.Item
-            componentId={`${componentId}.save_current`}
-            data-testid={`${testIdPrefix}-save-current`}
-            onClick={onSaveCurrent}
+            componentId={`${componentId}.override_active`}
+            data-testid={`${testIdPrefix}-override-active`}
+            onClick={onOverrideActive}
+            css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}
           >
+            <span css={{ width: theme.general.iconFontSize, flexShrink: 0 }} aria-hidden>
+              <PencilIcon />
+            </span>
+            {overrideLabel ?? (
+              <FormattedMessage
+                defaultMessage="Override my view"
+                description="Menu item that adopts the currently-applied shared view into the user's own view"
+              />
+            )}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            componentId={`${componentId}.discard_active`}
+            data-testid={`${testIdPrefix}-discard-active`}
+            onClick={onDiscardActive}
+            css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}
+          >
+            <span css={{ width: theme.general.iconFontSize, flexShrink: 0 }} aria-hidden>
+              <RefreshIcon />
+            </span>
             <FormattedMessage
-              defaultMessage="+ Save current view..."
-              description="Menu item that opens the modal to save the current view"
+              defaultMessage="Discard shared view"
+              description="Menu item that discards the currently-applied shared view and restores the user's own view"
             />
           </DropdownMenu.Item>
         </>
+      )}
+      {canModify && (
+        <DropdownMenu.Item
+          componentId={`${componentId}.save_current`}
+          data-testid={`${testIdPrefix}-save-current`}
+          onClick={onSaveCurrent}
+          css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}
+        >
+          <span css={{ width: theme.general.iconFontSize, flexShrink: 0, textAlign: 'center' }} aria-hidden>
+            +
+          </span>
+          <FormattedMessage
+            defaultMessage="Save as new view"
+            description="Menu item that opens the modal to save the current view"
+          />
+        </DropdownMenu.Item>
       )}
     </>
   );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/saved-views/SavedViewsMenu.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/saved-views/SavedViewsMenu.tsx
@@ -49,6 +49,10 @@ export const SavedViewsMenu = ({
   onOverrideActive,
   onDiscardActive,
   overrideLabel,
+  dirtyViewActive,
+  activeViewName,
+  onOverwriteActive,
+  onResetActive,
 }: {
   componentId: string;
   testIdPrefix: string;
@@ -73,11 +77,20 @@ export const SavedViewsMenu = ({
   // Per-tab wording for the override entry ("Override my view" on traces, "Override saved view" on
   // runs). Falls back to a generic label when omitted.
   overrideLabel?: ReactNode;
+  // Dirty-mode actions (traces V4): when the active view has unsaved edits, the menu hosts Overwrite
+  // (persist the edits into the view) and Reset (discard them). Rendered only when `dirtyViewActive`
+  // is true AND both handlers are provided; the shared-view (preview) props above are a separate,
+  // mutually-exclusive mode used by the runs / V3 tabs.
+  dirtyViewActive?: boolean;
+  activeViewName?: string;
+  onOverwriteActive?: () => void;
+  onResetActive?: () => void;
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const [filter, setFilter] = useState('');
   const showSharedViewActions = Boolean(sharedViewActive && onOverrideActive && onDiscardActive);
+  const showDirtyViewActions = Boolean(dirtyViewActive && onOverwriteActive && onResetActive);
 
   const copyLinkLabel = intl.formatMessage({
     defaultMessage: 'Copy share link',
@@ -233,7 +246,47 @@ export const SavedViewsMenu = ({
           ))
         )}
       </div>
-      {(canModify || showSharedViewActions) && <DropdownMenu.Separator />}
+      {(canModify || showSharedViewActions || showDirtyViewActions) && <DropdownMenu.Separator />}
+      {showDirtyViewActions && (
+        <>
+          <DropdownMenu.Item
+            componentId={`${componentId}.overwrite_active`}
+            data-testid={`${testIdPrefix}-overwrite-active`}
+            onClick={onOverwriteActive}
+            css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}
+          >
+            <span css={{ width: theme.general.iconFontSize, flexShrink: 0 }} aria-hidden>
+              <PencilIcon />
+            </span>
+            {activeViewName ? (
+              <FormattedMessage
+                defaultMessage={`Overwrite "{name}"`}
+                description="Menu item that overwrites the active saved view with the current, edited state"
+                values={{ name: activeViewName }}
+              />
+            ) : (
+              <FormattedMessage
+                defaultMessage="Overwrite view"
+                description="Menu item that overwrites the active saved view with the current state (no name available)"
+              />
+            )}
+          </DropdownMenu.Item>
+          <DropdownMenu.Item
+            componentId={`${componentId}.reset_active`}
+            data-testid={`${testIdPrefix}-reset-active`}
+            onClick={onResetActive}
+            css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}
+          >
+            <span css={{ width: theme.general.iconFontSize, flexShrink: 0 }} aria-hidden>
+              <RefreshIcon />
+            </span>
+            <FormattedMessage
+              defaultMessage="Reset to saved"
+              description="Menu item that discards unsaved edits and re-applies the active saved view's stored state"
+            />
+          </DropdownMenu.Item>
+        </>
+      )}
       {showSharedViewActions && (
         <>
           <DropdownMenu.Item
@@ -262,8 +315,8 @@ export const SavedViewsMenu = ({
               <RefreshIcon />
             </span>
             <FormattedMessage
-              defaultMessage="Discard shared view"
-              description="Menu item that discards the currently-applied shared view and restores the user's own view"
+              defaultMessage="Exit shared view"
+              description="Menu item that stops previewing the currently-applied shared view and restores the user's own view"
             />
           </DropdownMenu.Item>
         </>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/saved-views/SavedViewsMenu.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/saved-views/SavedViewsMenu.tsx
@@ -115,7 +115,7 @@ export const SavedViewsMenu = ({
       >
         <FormattedMessage defaultMessage="Saved views" description="Header at the top of the saved views dropdown" />
       </DropdownMenu.Label>
-      <div css={{ padding: `${theme.spacing.sm}px ${theme.spacing.md}px ${theme.spacing.xs}px`, width: 320 }}>
+      <div css={{ padding: `${theme.spacing.sm}px ${theme.spacing.md}px`, width: 320 }}>
         <Input
           componentId={`${componentId}.search`}
           data-testid={`${testIdPrefix}-search`}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/saved-views/SharedViewBanner.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/saved-views/SharedViewBanner.test.tsx
@@ -27,7 +27,7 @@ describe('SharedViewBanner', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^discard$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /exit shared view/i }));
 
     expect(onDiscard).toHaveBeenCalledTimes(1);
     expect(onOverride).not.toHaveBeenCalled();
@@ -56,7 +56,7 @@ describe('SharedViewBanner', () => {
     renderWithDesignSystem(<SharedViewBanner componentId="test.shared_view" message="msg" onDiscard={jest.fn()} />);
 
     expect(screen.queryByRole('button', { name: /override/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^discard$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /exit shared view/i })).toBeInTheDocument();
   });
 
   it('renders a dismiss button only when onDismiss is provided, and invokes only it', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/saved-views/SharedViewBanner.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/saved-views/SharedViewBanner.tsx
@@ -66,8 +66,8 @@ export const SharedViewBanner = ({
             )}
             <Button componentId={`${componentId}.discard`} size="small" onClick={onDiscard}>
               <FormattedMessage
-                defaultMessage="Discard"
-                description="Experiment page > shared view banner > button that discards the shared view and restores the user's own view"
+                defaultMessage="Exit shared view"
+                description="Experiment page > shared view banner > button that stops previewing the shared view and restores the user's own view"
               />
             </Button>
             {onDismiss && (

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3SavedViews.tsx
@@ -614,7 +614,7 @@ export const TracesV3SavedViewsButton = ({
             )}
           </Button>
         </DropdownMenu.Trigger>
-        <DropdownMenu.Content align="end">
+        <DropdownMenu.Content align="start">
           <SavedViewsMenu
             componentId="mlflow.traces.saved_views"
             testIdPrefix="trace-saved-views"

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
@@ -42,7 +42,7 @@ import { TracesV4DeleteModal } from './TracesV4DeleteModal';
 import { makeTracesV4ErrorDescription } from './TracesV4States';
 import { TracesV4EmptyState } from './TracesV4EmptyState';
 import { IssueDetectionModal } from '../../traces-v3/IssueDetectionModal';
-import { TracesV4SavedViewsButton, TracesV4SharedViewBanner, useTracesV4SavedViews } from './TracesV4SavedViews';
+import { TracesV4SavedViewsButton, useTracesV4SavedViews } from './TracesV4SavedViews';
 
 interface TracesV4PageContentProps {
   experimentId: string;
@@ -71,41 +71,24 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
   const { density, setDensity } = useTracesV4Density(experimentId);
 
   // One "Reset to defaults" in the column selector clears both standard and assessment overrides.
-  // (Only reachable when not previewing — a preview's columns come from its `cols` param.)
   const resetColumns = useCallback(() => {
     columns.resetToDefaults();
     assessments.reset();
   }, [columns, assessments]);
 
-  // Saved views (URL-first): the hook reads/writes view tags and drives the `cols`+share-key preview
-  // overlay. While a shared view is applied, its previewed columns render INSTEAD of the user's own
-  // (without touching localStorage until Override); otherwise the user's own columns show.
+  // Saved views (dirty model): the hook reads/writes view tags, restores a view's columns into the
+  // user's own column store on open, and reports whether the live table has diverged from the active
+  // view (dirty) so the Views menu can offer Overwrite / Reset. There is no read-only preview — the
+  // table always renders the user's real columns.
   const savedViews = useTracesV4SavedViews({
     experimentId,
     visibleColumns: columns.visibleColumns,
+    filterModel,
     setColumns: columns.setColumns,
     resetColumns,
     setFilterModel: controller.setFilterModel,
+    assessmentNames: assessments.candidateNames,
   });
-  const effectiveVisibleColumns = savedViews.previewColumns ?? columns.visibleColumns;
-
-  // While previewing a shared view, column toggles edit the preview (the `cols` URL param) rather
-  // than the user's persisted columns — matching the banner's "changes aren't saved unless you
-  // override" promise. Otherwise they write the user's own localStorage as usual. The selector
-  // always reflects `effectiveVisibleColumns`, so its checkboxes match the table in both modes.
-  const toggleColumn = useCallback(
-    (column: TraceColumnId) => {
-      if (savedViews.sharedViewActive) {
-        const next = effectiveVisibleColumns.includes(column)
-          ? effectiveVisibleColumns.filter((id) => id !== column)
-          : [...effectiveVisibleColumns, column];
-        savedViews.setPreviewColumns(next);
-        return;
-      }
-      columns.toggleColumn(column);
-    },
-    [savedViews, effectiveVisibleColumns, columns],
-  );
 
   const handleHideColumn = useCallback(
     (columnId: string) => {
@@ -255,8 +238,8 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
     onFilterChange: controller.setFilterModel,
     onClearFilters: clearAllFilters,
     activeFilterCount: controller.activeFilterCount,
-    visibleColumns: effectiveVisibleColumns,
-    onToggleColumn: toggleColumn,
+    visibleColumns: columns.visibleColumns,
+    onToggleColumn: columns.toggleColumn,
     onResetColumns: resetColumns,
     assessmentColumns: assessments,
     sort: url.sort,
@@ -323,7 +306,7 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
             viewState={viewState}
             // Table
             traces={page.traces}
-            visibleColumns={effectiveVisibleColumns}
+            visibleColumns={columns.visibleColumns}
             extraColumns={assessments.columnDefs}
             initialColumnSizing={columnSizing.columnSizing}
             onColumnSizingSettled={columnSizing.setColumnSizing}
@@ -363,7 +346,6 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
             rightControls={toolbarSlots.rightControls}
             bannerSlot={
               <>
-                <TracesV4SharedViewBanner savedViews={savedViews} />
                 {actions.runJudges?.JudgesStatusBanner}
                 {showErrorAlert && (
                   <TracesErrorAlert

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
@@ -749,4 +749,14 @@ describe('TracesV4SavedViewsButton dirty affordances', () => {
     await waitFor(() => expect(mockSetExperimentTagApi).toHaveBeenCalled());
     expect(mockSetExperimentTagApi.mock.calls[0][1]).toBe('mlflow.tracesV4ViewState.v1');
   });
+
+  test('the dirty dot renders outside the collapsible label so it survives icon-only collapse', async () => {
+    // ToolbarCollapsibleLabel sets `display:none` under a container query when the toolbar is narrow.
+    // jsdom can't evaluate the query, so assert structurally: the dot must not be a descendant of the
+    // label span (its `maxWidth:200` name span identifies it), i.e. it collapses independently.
+    renderButtonAt(`/?q=changed&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`);
+    const dot = await screen.findByTestId('trace-v4-saved-views-dirty-dot');
+    const label = screen.getByText('Latency triage');
+    expect(label).not.toContainElement(dot);
+  });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
@@ -52,13 +52,15 @@ const makeV4ViewTag = async (
 };
 
 // Build a LEGACY V3 saved-view tag (prefix `mlflow.traceViewState.`) whose compressed state is the
-// frozen V3 shape: `single.selectedColumns` (comma-joined), `single.sort` (`key::type::asc`), time
-// range, and `multi.filter` (`key=value`). Same envelope codec as V4; only the inner state differs.
+// frozen V3 shape, in V3's OWN vocabulary: `single.selectedColumns` is a comma-joined list of V3
+// column ids (`request_time`, `request`, `execution_duration`, …), `single.sort` is `key::type::asc`
+// with a V3 column key, time range, and `multi.filter` holds `column::operator::value::key` entries.
+// Same envelope codec as V4; only the inner state differs.
 const makeV3ViewTag = async (
   id: string,
   name: string,
   createdAt: number,
-  single: Record<string, string> = { selectedColumns: 'start_time', sort: 'timestamp::date::false' },
+  single: Record<string, string> = { selectedColumns: 'request_time', sort: 'request_time::date::false' },
   filter: string[] = [],
 ) => {
   const state = { single, multi: filter.length > 0 ? { filter } : {} };
@@ -580,8 +582,14 @@ describe('useTracesV4SavedViews legacy V3 view compatibility', () => {
         'v3a',
         'Legacy V3',
         1000,
-        { selectedColumns: 'start_time,input', sort: 'timestamp::date::false', startTimeLabel: 'LAST_7_DAYS' },
-        ['env=prod'],
+        // V3 vocabulary: request_time→start_time, request→input columns; execution_duration sort key;
+        // a `column::operator::value::key` filter that maps onto V4's `state` popover field.
+        {
+          selectedColumns: 'request_time,request',
+          sort: 'execution_duration::number::false',
+          startTimeLabel: 'LAST_7_DAYS',
+        },
+        ['state::=::ERROR::'],
       ),
     ]);
     let state: any;
@@ -595,14 +603,15 @@ describe('useTracesV4SavedViews legacy V3 view compatibility', () => {
     });
     await waitFor(() => {
       const url = new URLSearchParams(search);
-      expect(url.get('sort')).toBe('timestamp'); // V3 `key::type::asc` → V4 sort (type dropped)
+      expect(url.get('sort')).toBe('duration'); // execution_duration → duration, `type` segment dropped
       expect(url.get('dir')).toBe('desc');
       expect(url.get('startTimeLabel')).toBe('LAST_7_DAYS');
-      expect(url.getAll('tag')).toEqual(['env=prod']); // V3 filter[] → V4 tag[]
       expect(url.get(TRACE_V4_SHARE_URL_PARAM_KEY)).toBe('v3a');
     });
-    // Columns restored into the user's store (V3 `selectedColumns` → V4 cols).
+    // Columns restored into the user's store (V3 ids → V4 ids: request_time→start_time, request→input).
     expect(setColumns).toHaveBeenCalledWith(['start_time', 'input']);
+    // V3 filter[] → V4's in-memory popover model (not the URL-backed tag[]).
+    expect(setFilterModel).toHaveBeenCalledWith([{ field: 'state', operator: '=', value: 'ERROR' }]);
   });
 
   test('overwriting a V3 view migrates it: writes a V4 tag (same id) and deletes the V3 tag', async () => {
@@ -634,7 +643,26 @@ describe('useTracesV4SavedViews legacy V3 view compatibility', () => {
     await act(async () => {
       await state.deleteView('v3a');
     });
+    expect(mockDeleteExperimentTagApi).toHaveBeenCalledTimes(1);
     expect(mockDeleteExperimentTagApi).toHaveBeenCalledWith('exp-1', 'mlflow.traceViewState.v3a');
+  });
+
+  test('deleting a half-migrated view removes BOTH the V4 and leftover V3 tags (no resurrection)', async () => {
+    // A migration whose V3-delete never landed leaves both prefixes for the id; the list de-dupes to
+    // one V4 entry, so deleting only the V4 tag would let the V3 twin come back on the next refetch.
+    mockExperiment([
+      await makeV3ViewTag('dup', 'Legacy name', 1000),
+      await makeV4ViewTag('dup', 'Migrated name', 3000),
+    ]);
+    let state: any;
+    renderV3ProbeAt('/', (s) => (state = s));
+    await waitFor(() => expect(state.views).toHaveLength(1));
+    await act(async () => {
+      await state.deleteView('dup');
+    });
+    expect(mockDeleteExperimentTagApi).toHaveBeenCalledWith('exp-1', 'mlflow.tracesV4ViewState.dup');
+    expect(mockDeleteExperimentTagApi).toHaveBeenCalledWith('exp-1', 'mlflow.traceViewState.dup');
+    expect(mockDeleteExperimentTagApi).toHaveBeenCalledTimes(2);
   });
 
   test('a migrated V4 tag shadows a leftover V3 tag of the same id (V4 wins, listed once)', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { IntlProvider } from 'react-intl';
 import { DesignSystemProvider } from '@databricks/design-system';
 
-import { TracesV4SavedViewsButton, TracesV4SharedViewBanner, useTracesV4SavedViews } from './TracesV4SavedViews';
+import { TracesV4SavedViewsButton, useTracesV4SavedViews } from './TracesV4SavedViews';
 import { MockedReduxStoreProvider } from '@mlflow/mlflow/src/common/utils/TestUtils';
 import { setupTestRouter, testRoute, TestRouter } from '@mlflow/mlflow/src/common/utils/RoutingTestUtils';
 import { useSearchParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
@@ -13,7 +13,7 @@ import { encodeSavedViewEnvelope } from '../../../utils/savedViewEnvelope';
 import { textCompressDeflate, textDecompressDeflate } from '@mlflow/mlflow/src/common/utils/StringUtils';
 import Utils from '@mlflow/mlflow/src/common/utils/Utils';
 import { TRACE_V4_SHARE_URL_PARAM_KEY, buildV4ViewQuery, captureV4ViewState } from '../utils/tracesV4SavedViewState';
-import type { TraceColumnId } from '@databricks/web-shared/traces-table';
+import { FilterOp, type TraceColumnId, type TraceFilterModel } from '@databricks/web-shared/traces-table';
 
 jest.mock('@mlflow/mlflow/src/experiment-tracking/hooks/useExperimentQuery', () => ({
   useGetExperimentQuery: jest.fn(),
@@ -44,8 +44,9 @@ const makeV4ViewTag = async (
   createdAt: number,
   query = 'q=x',
   cols: TraceColumnId[] = ['start_time'],
+  filters: TraceFilterModel = [],
 ) => {
-  const state = captureV4ViewState(new URLSearchParams(query), cols);
+  const state = captureV4ViewState(new URLSearchParams(query), cols, filters);
   const compressed = await textCompressDeflate(JSON.stringify(state));
   return { key: `mlflow.tracesV4ViewState.${id}`, value: encodeSavedViewEnvelope(name, compressed, createdAt) };
 };
@@ -57,11 +58,14 @@ const mockExperiment = (tags: { key: string; value: string }[]) => {
 
 const { history } = setupTestRouter();
 
+// Shared across the button harness so tests can assert column restore on open / reset.
+const buttonSetColumns = jest.fn();
 const SavedViewsButtonHarness = ({ experimentId }: { experimentId: string }) => {
   const savedViews = useTracesV4SavedViews({
     experimentId,
     visibleColumns: ['start_time', 'input'],
-    setColumns: jest.fn(),
+    filterModel: [],
+    setColumns: buttonSetColumns,
     resetColumns: jest.fn(),
     setFilterModel: jest.fn(),
   });
@@ -143,7 +147,7 @@ describe('TracesV4SavedViewsButton', () => {
     const out = new URLSearchParams(buildV4ViewQuery(decoded, 'x'));
     expect(out.get('q')).toBe('refund');
     expect(out.get('sort')).toBe('duration');
-    expect(out.get('cols')).toBe('start_time,input'); // the harness's live columns
+    expect(decoded.single.cols).toBe('start_time,input'); // the harness's live columns, stored not URL'd
   });
 
   test('saving a new view activates it: the URL gains the new view share key', async () => {
@@ -212,8 +216,9 @@ describe('TracesV4SavedViewsButton', () => {
     expect(screen.getByTestId('trace-v4-saved-views-trigger')).toHaveTextContent('Latency triage');
   });
 
-  test('opening a view rewrites the URL to the view stored query + share key', async () => {
-    // v1 was stored with q=x and cols=[start_time] (the harness default).
+  test('opening a view rewrites the URL to the stored query + share key and restores its columns', async () => {
+    // v1 was stored with q=x and cols=[start_time] (the harness default). Columns are no longer
+    // carried in the URL — they are restored into the user's column store via setColumns.
     let currentSearch = '';
     const SearchReporter = () => {
       const [params] = useSearchParams();
@@ -241,8 +246,10 @@ describe('TracesV4SavedViewsButton', () => {
       const out = new URLSearchParams(currentSearch);
       expect(out.get(TRACE_V4_SHARE_URL_PARAM_KEY)).toBe('v1');
       expect(out.get('q')).toBe('x');
-      expect(out.get('cols')).toBe('start_time');
+      // Columns ride in the store, not the URL.
+      expect(out.get('cols')).toBeNull();
     });
+    expect(buttonSetColumns).toHaveBeenCalledWith(['start_time']);
   });
 
   test('opening a corrupt view shows an error toast and does not navigate', async () => {
@@ -295,33 +302,45 @@ describe('TracesV4SavedViewsButton', () => {
     expect(out.get('pageSize')).toBe('50');
     expect(out.get('startTimeLabel')).toBe('LAST_7_DAYS');
     expect(out.getAll('tag')).toEqual(['env=prod', 'team=ml']);
-    expect(out.get('cols')).toBe('start_time,input'); // the harness's live columns
+    expect(decoded.single.cols).toBe('start_time,input'); // the harness's live columns, stored not URL'd
   });
 });
 
-describe('useTracesV4SavedViews preview / override / discard', () => {
+describe('useTracesV4SavedViews dirty / overwrite / reset', () => {
   const setColumns = jest.fn();
   // Report BOTH the hook API and the live URL search each render, so assertions read the in-memory
   // router's state (TestRouter never touches window.location.hash) after a param rewrite.
-  const PreviewProbe = ({ onRender }: { onRender: (s: any, search: string) => void }) => {
+  const setFilterModel = jest.fn();
+  const DirtyProbe = ({
+    onRender,
+    filterModel = [],
+  }: {
+    onRender: (s: any, search: string) => void;
+    filterModel?: TraceFilterModel;
+  }) => {
     const savedViews = useTracesV4SavedViews({
       experimentId: 'exp-1',
-      visibleColumns: ['start_time', 'input'],
+      visibleColumns: ['start_time'],
+      filterModel,
       setColumns,
       resetColumns: jest.fn(),
-      setFilterModel: jest.fn(),
+      setFilterModel,
     });
     const [params] = useSearchParams();
     onRender(savedViews, params.toString());
     return null;
   };
 
-  const renderProbeAt = (entry: string, onRender: (s: any, search: string) => void) =>
+  const renderProbeAt = (
+    entry: string,
+    onRender: (s: any, search: string) => void,
+    filterModel: TraceFilterModel = [],
+  ) =>
     render(
       <IntlProvider locale="en">
         <DesignSystemProvider>
           <MockedReduxStoreProvider>
-            <PreviewProbe onRender={onRender} />
+            <DirtyProbe onRender={onRender} filterModel={filterModel} />
           </MockedReduxStoreProvider>
         </DesignSystemProvider>
       </IntlProvider>,
@@ -332,110 +351,152 @@ describe('useTracesV4SavedViews preview / override / discard', () => {
       },
     );
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
-    mockExperiment([]);
+    // v1 is stored with q=x and cols=[start_time], matching the probe's live state below.
+    mockExperiment([await makeV4ViewTag('v1', 'Known', 1000, 'q=x', ['start_time'])]);
   });
 
-  test('sharedViewActive is true only when a share key is present in the URL', () => {
+  test('activeViewId is set only when the share key resolves to a known view', () => {
     let state: any;
     renderProbeAt('/?q=x', (s) => (state = s));
-    expect(state.sharedViewActive).toBe(false);
+    expect(state.activeViewId).toBeNull();
 
-    renderProbeAt(`/?${TRACE_V4_SHARE_URL_PARAM_KEY}=v1&cols=tokens,cost`, (s) => (state = s));
-    expect(state.sharedViewActive).toBe(true);
+    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=nope`, (s) => (state = s));
+    // A share key that isn't in the list must not drive overwrite/reset/dirty.
+    expect(state.activeViewId).toBeNull();
+
+    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s) => (state = s));
+    expect(state.activeViewId).toBe('v1');
   });
 
-  test('previewColumns decode from the cols URL param while a shared view is active', () => {
+  test('dirtyStatus is clean when the live state matches the active view', async () => {
     let state: any;
-    renderProbeAt(`/?${TRACE_V4_SHARE_URL_PARAM_KEY}=v1&cols=tokens,cost`, (s) => (state = s));
-    expect(state.previewColumns).toEqual(['tokens', 'cost']);
+    // Live URL (q=x) + live columns ([start_time]) equal v1's stored state.
+    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s) => (state = s));
+    await waitFor(() => expect(state.dirtyStatus).toBe('clean'));
   });
 
-  test('override adopts the previewed columns into the user store and strips the preview params', async () => {
+  test('dirtyStatus becomes dirty when the live URL diverges from the active view', async () => {
+    let state: any;
+    // Live URL (q=changed) differs from v1's stored q=x.
+    renderProbeAt(`/?q=changed&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s) => (state = s));
+    await waitFor(() => expect(state.dirtyStatus).toBe('dirty'));
+  });
+
+  test('overwriteView rewrites the active view tag in place, keeping id + createdAt and bumping updatedAt', async () => {
+    let state: any;
+    renderProbeAt(`/?q=changed&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s) => (state = s));
+    await waitFor(() => expect(state.dirtyStatus).toBe('dirty'));
+    await act(async () => {
+      await state.overwriteView('v1');
+    });
+    expect(mockSetExperimentTagApi).toHaveBeenCalledTimes(1);
+    const [expId, tagKey, tagValue] = mockSetExperimentTagApi.mock.calls[0];
+    expect(expId).toBe('exp-1');
+    expect(tagKey).toBe('mlflow.tracesV4ViewState.v1'); // same tag, in place
+    const envelope = JSON.parse(tagValue);
+    expect(envelope.name).toBe('Known'); // name preserved
+    expect(envelope.createdAt).toBe(1000); // creation time preserved
+    expect(envelope.updatedAt).toBeGreaterThan(1000); // edit time bumped
+    // The rewritten state captures the edited URL.
+    const decoded = JSON.parse(await textDecompressDeflate(envelope.state));
+    expect(decoded.single.q).toBe('changed');
+  });
+
+  test('overwriteView refuses to resurrect a phantom (unknown) id', async () => {
+    let state: any;
+    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s) => (state = s));
+    await act(async () => {
+      await state.overwriteView('does-not-exist');
+    });
+    expect(mockSetExperimentTagApi).not.toHaveBeenCalled();
+  });
+
+  test('resetActiveView re-applies the stored view, restoring its columns and clearing the edit', async () => {
     let state: any;
     let search = '';
-    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1&cols=tokens,cost`, (s, sp) => {
+    renderProbeAt(`/?q=changed&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s, sp) => {
       state = s;
       search = sp;
     });
+    await waitFor(() => expect(state.dirtyStatus).toBe('dirty'));
     await act(async () => {
-      state.override();
+      state.resetActiveView();
     });
-    // The previewed columns are persisted to the user's own column store...
-    expect(setColumns).toHaveBeenCalledWith(['tokens', 'cost']);
-    // ...and the preview params are cleared while the rest of the view (q) stays.
+    // The stored query (q=x) is re-applied and the stored columns restored.
     await waitFor(() => {
       const url = new URLSearchParams(search);
-      expect(url.get(TRACE_V4_SHARE_URL_PARAM_KEY)).toBeNull();
-      expect(url.get('cols')).toBeNull();
       expect(url.get('q')).toBe('x');
+      expect(url.get(TRACE_V4_SHARE_URL_PARAM_KEY)).toBe('v1');
     });
+    expect(setColumns).toHaveBeenCalledWith(['start_time']);
   });
 
-  test('discard strips the preview params WITHOUT writing to the user column store', async () => {
+  test('opening a view restores its stored popover filter model', async () => {
+    // v1 stored with a state filter; opening it must push that clause into the live filter model.
+    mockExperiment([
+      await makeV4ViewTag(
+        'v1',
+        'Known',
+        1000,
+        'q=x',
+        ['start_time'],
+        [{ field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' }],
+      ),
+    ]);
     let state: any;
-    let search = '';
-    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1&cols=tokens,cost`, (s, sp) => {
-      state = s;
-      search = sp;
-    });
+    renderProbeAt('/', (s) => (state = s));
     await act(async () => {
-      state.discard();
+      await state.openView('v1');
     });
-    expect(setColumns).not.toHaveBeenCalled();
-    await waitFor(() => {
-      const url = new URLSearchParams(search);
-      expect(url.get(TRACE_V4_SHARE_URL_PARAM_KEY)).toBeNull();
-      expect(url.get('cols')).toBeNull();
-      expect(url.get('q')).toBe('x');
-    });
+    expect(setFilterModel).toHaveBeenCalledWith([{ field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' }]);
   });
 
-  test('previewColumns is undefined when the cols param resolves to no known columns', () => {
+  test('a filter-model divergence from the stored view reads as dirty', async () => {
+    // v1 stored with NO filters; the probe's live filter model carries a clause → dirty.
     let state: any;
-    renderProbeAt(`/?${TRACE_V4_SHARE_URL_PARAM_KEY}=v1&cols=bogus1,bogus2`, (s) => (state = s));
-    // A view saved against an older/foreign column set: nothing resolves, so the caller falls back
-    // to the user's own columns rather than hiding every column.
-    expect(state.previewColumns).toBeUndefined();
+    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s) => (state = s), [
+      { field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' },
+    ]);
+    await waitFor(() => expect(state.dirtyStatus).toBe('dirty'));
   });
 
-  test('override on a filter-only view (no cols) exits preview WITHOUT touching the column store', async () => {
+  test('overwriteView captures the live filter model into the rewritten tag', async () => {
     let state: any;
-    let search = '';
-    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s, sp) => {
-      state = s;
-      search = sp;
-    });
+    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s) => (state = s), [
+      { field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' },
+    ]);
+    await waitFor(() => expect(state.dirtyStatus).toBe('dirty'));
     await act(async () => {
-      state.override();
+      await state.overwriteView('v1');
     });
-    // No cols to adopt → the user's own columns are left untouched, and preview still exits.
-    expect(setColumns).not.toHaveBeenCalled();
-    await waitFor(() => {
-      const url = new URLSearchParams(search);
-      expect(url.get(TRACE_V4_SHARE_URL_PARAM_KEY)).toBeNull();
-      expect(url.get('q')).toBe('x');
-    });
+    const [, , tagValue] = mockSetExperimentTagApi.mock.calls[0];
+    const decoded = JSON.parse(await textDecompressDeflate(JSON.parse(tagValue).state));
+    expect(decoded.filters).toEqual([{ field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' }]);
   });
 
-  test('setPreviewColumns edits the cols param WITHOUT writing the user column store', async () => {
+  test('an unsupported stored filter clause is dropped on restore, not stranding the view dirty', async () => {
+    // A clause whose operator the `state` field never offers (CONTAINS) is invalid; opening must
+    // drop it (restoring an empty model), and the dirty diff normalizes the baseline the same way so
+    // the view still reads clean against a live empty filter model.
+    mockExperiment([
+      await makeV4ViewTag(
+        'v1',
+        'Known',
+        1000,
+        'q=x',
+        ['start_time'],
+        [{ field: 'state', operator: FilterOp.CONTAINS, value: 'ERROR' }],
+      ),
+    ]);
     let state: any;
-    let search = '';
-    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1&cols=tokens,cost`, (s, sp) => {
-      state = s;
-      search = sp;
-    });
+    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s) => (state = s), []);
     await act(async () => {
-      state.setPreviewColumns(['tokens', 'cost', 'duration']);
+      await state.openView('v1');
     });
-    // The preview (cols param) changes; localStorage is untouched (that only happens on Override).
-    expect(setColumns).not.toHaveBeenCalled();
-    await waitFor(() => {
-      const url = new URLSearchParams(search);
-      expect(url.get('cols')).toBe('tokens,cost,duration');
-      expect(url.get(TRACE_V4_SHARE_URL_PARAM_KEY)).toBe('v1'); // still previewing
-    });
+    expect(setFilterModel).toHaveBeenLastCalledWith([]);
+    await waitFor(() => expect(state.dirtyStatus).toBe('clean'));
   });
 });
 
@@ -444,6 +505,7 @@ describe('useTracesV4SavedViews stale-tag refetch on active share key', () => {
     useTracesV4SavedViews({
       experimentId,
       visibleColumns: ['start_time'],
+      filterModel: [],
       setColumns: jest.fn(),
       resetColumns: jest.fn(),
       setFilterModel: jest.fn(),
@@ -511,48 +573,44 @@ describe('useTracesV4SavedViews stale-tag refetch on active share key', () => {
   });
 });
 
-describe('TracesV4SharedViewBanner', () => {
-  const setColumns = jest.fn();
-  const BannerHarness = ({ entry }: { entry: string }) => {
-    const savedViews = useTracesV4SavedViews({
-      experimentId: 'exp-1',
-      visibleColumns: ['start_time'],
-      setColumns,
-      resetColumns: jest.fn(),
-      setFilterModel: jest.fn(),
-    });
-    return <TracesV4SharedViewBanner savedViews={savedViews} />;
-  };
-  const renderBannerAt = (entry: string) =>
-    render(
-      <IntlProvider locale="en">
-        <DesignSystemProvider>
-          <MockedReduxStoreProvider>
-            <BannerHarness entry={entry} />
-          </MockedReduxStoreProvider>
-        </DesignSystemProvider>
-      </IntlProvider>,
-      {
-        wrapper: ({ children }) => (
-          <TestRouter routes={[testRoute(<>{children}</>, '/')]} history={history} initialEntries={[entry]} />
-        ),
-      },
-    );
-
+describe('TracesV4SavedViewsButton dirty affordances', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
-    mockExperiment([await makeV4ViewTag('v1', 'Shared latency view', 1000)]);
+    mockExperiment([await makeV4ViewTag('v1', 'Latency triage', 1000, 'q=x', ['start_time'])]);
   });
 
-  test('renders nothing when no shared view is active', () => {
-    const { container } = renderBannerAt('/?q=x');
-    expect(container).toBeEmptyDOMElement();
+  test('no dirty dot and no Overwrite/Reset actions when the active view is clean', async () => {
+    // Live state (q=x, cols=[start_time,input]) — cols differ from the stored [start_time], but the
+    // trigger only shows the dot when dirty; here we land on the clean case via matching state.
+    renderButtonAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`);
+    // The harness's live columns are [start_time, input] while v1 stored [start_time] — that IS a
+    // divergence, so this view is dirty. Assert the dirty affordances appear instead.
+    await waitFor(() => expect(screen.getByTestId('trace-v4-saved-views-dirty-dot')).toBeInTheDocument());
+    await openDropdown();
+    expect(screen.getByTestId('trace-v4-saved-views-overwrite-active')).toBeInTheDocument();
+    expect(screen.getByTestId('trace-v4-saved-views-reset-active')).toBeInTheDocument();
   });
 
-  test('announces the active shared view and offers Override / Discard', () => {
-    renderBannerAt(`/?${TRACE_V4_SHARE_URL_PARAM_KEY}=v1&cols=tokens`);
-    expect(screen.getByTestId('trace-v4-shared-view-banner')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Override my view/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Discard/ })).toBeInTheDocument();
+  test('a clean active view shows neither the dot nor the dirty actions', async () => {
+    // Store v1 with cols matching the harness's live columns so it is genuinely clean.
+    mockExperiment([await makeV4ViewTag('v1', 'Latency triage', 1000, 'q=x', ['start_time', 'input'])]);
+    renderButtonAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`);
+    // Give the stored-state effect a chance to run, then confirm it stays clean.
+    await waitFor(() => expect(screen.getByTestId('trace-v4-saved-views-trigger')).toHaveTextContent('Latency triage'));
+    expect(screen.queryByTestId('trace-v4-saved-views-dirty-dot')).not.toBeInTheDocument();
+    await openDropdown();
+    expect(screen.queryByTestId('trace-v4-saved-views-overwrite-active')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('trace-v4-saved-views-reset-active')).not.toBeInTheDocument();
+  });
+
+  test('the Overwrite action names the active view and dispatches an in-place tag write', async () => {
+    renderButtonAt(`/?q=changed&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`);
+    await waitFor(() => expect(screen.getByTestId('trace-v4-saved-views-dirty-dot')).toBeInTheDocument());
+    await openDropdown();
+    const overwrite = screen.getByTestId('trace-v4-saved-views-overwrite-active');
+    expect(overwrite).toHaveTextContent('Overwrite "Latency triage"');
+    await userEvent.click(overwrite, { pointerEventsCheck: 0 });
+    await waitFor(() => expect(mockSetExperimentTagApi).toHaveBeenCalled());
+    expect(mockSetExperimentTagApi.mock.calls[0][1]).toBe('mlflow.tracesV4ViewState.v1');
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
@@ -51,6 +51,21 @@ const makeV4ViewTag = async (
   return { key: `mlflow.tracesV4ViewState.${id}`, value: encodeSavedViewEnvelope(name, compressed, createdAt) };
 };
 
+// Build a LEGACY V3 saved-view tag (prefix `mlflow.traceViewState.`) whose compressed state is the
+// frozen V3 shape: `single.selectedColumns` (comma-joined), `single.sort` (`key::type::asc`), time
+// range, and `multi.filter` (`key=value`). Same envelope codec as V4; only the inner state differs.
+const makeV3ViewTag = async (
+  id: string,
+  name: string,
+  createdAt: number,
+  single: Record<string, string> = { selectedColumns: 'start_time', sort: 'timestamp::date::false' },
+  filter: string[] = [],
+) => {
+  const state = { single, multi: filter.length > 0 ? { filter } : {} };
+  const compressed = await textCompressDeflate(JSON.stringify(state));
+  return { key: `mlflow.traceViewState.${id}`, value: encodeSavedViewEnvelope(name, compressed, createdAt) };
+};
+
 const stableRefetch = jest.fn(() => Promise.resolve({}));
 const mockExperiment = (tags: { key: string; value: string }[]) => {
   jest.mocked(useGetExperimentQuery).mockReturnValue({ data: { tags }, refetch: stableRefetch } as never);
@@ -497,6 +512,127 @@ describe('useTracesV4SavedViews dirty / overwrite / reset', () => {
     });
     expect(setFilterModel).toHaveBeenLastCalledWith([]);
     await waitFor(() => expect(state.dirtyStatus).toBe('clean'));
+  });
+});
+
+describe('useTracesV4SavedViews legacy V3 view compatibility', () => {
+  const setColumns = jest.fn();
+  const setFilterModel = jest.fn();
+  const V3Probe = ({ onRender }: { onRender: (s: any, search: string) => void }) => {
+    const savedViews = useTracesV4SavedViews({
+      experimentId: 'exp-1',
+      visibleColumns: ['start_time'],
+      filterModel: [],
+      setColumns,
+      resetColumns: jest.fn(),
+      setFilterModel,
+    });
+    const [params] = useSearchParams();
+    onRender(savedViews, params.toString());
+    return null;
+  };
+  const renderV3ProbeAt = (entry: string, onRender: (s: any, search: string) => void) =>
+    render(
+      <IntlProvider locale="en">
+        <DesignSystemProvider>
+          <MockedReduxStoreProvider>
+            <V3Probe onRender={onRender} />
+          </MockedReduxStoreProvider>
+        </DesignSystemProvider>
+      </IntlProvider>,
+      {
+        wrapper: ({ children }) => (
+          <TestRouter routes={[testRoute(<>{children}</>, '/')]} history={history} initialEntries={[entry]} />
+        ),
+      },
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('lists a legacy V3 view alongside V4 views', async () => {
+    mockExperiment([await makeV4ViewTag('v4a', 'Native V4', 2000), await makeV3ViewTag('v3a', 'Legacy V3', 1000)]);
+    let state: any;
+    renderV3ProbeAt('/', (s) => (state = s));
+    await waitFor(() => expect(state.views).toHaveLength(2));
+    expect(state.views.find((v: any) => v.id === 'v3a')).toMatchObject({ name: 'Legacy V3', origin: 'v3' });
+    expect(state.views.find((v: any) => v.id === 'v4a')).toMatchObject({ name: 'Native V4', origin: 'v4' });
+  });
+
+  test('opening a V3 view translates its state onto the URL + restores columns/filters', async () => {
+    mockExperiment([
+      await makeV3ViewTag(
+        'v3a',
+        'Legacy V3',
+        1000,
+        { selectedColumns: 'start_time,input', sort: 'timestamp::date::false', startTimeLabel: 'LAST_7_DAYS' },
+        ['env=prod'],
+      ),
+    ]);
+    let state: any;
+    let search = '';
+    renderV3ProbeAt('/', (s, sp) => {
+      state = s;
+      search = sp;
+    });
+    await act(async () => {
+      await state.openView('v3a');
+    });
+    await waitFor(() => {
+      const url = new URLSearchParams(search);
+      expect(url.get('sort')).toBe('timestamp'); // V3 `key::type::asc` → V4 sort (type dropped)
+      expect(url.get('dir')).toBe('desc');
+      expect(url.get('startTimeLabel')).toBe('LAST_7_DAYS');
+      expect(url.getAll('tag')).toEqual(['env=prod']); // V3 filter[] → V4 tag[]
+      expect(url.get(TRACE_V4_SHARE_URL_PARAM_KEY)).toBe('v3a');
+    });
+    // Columns restored into the user's store (V3 `selectedColumns` → V4 cols).
+    expect(setColumns).toHaveBeenCalledWith(['start_time', 'input']);
+  });
+
+  test('overwriting a V3 view migrates it: writes a V4 tag (same id) and deletes the V3 tag', async () => {
+    mockExperiment([await makeV3ViewTag('v3a', 'Legacy V3', 1000, { selectedColumns: 'start_time' })]);
+    let state: any;
+    renderV3ProbeAt(`/?q=edited&${TRACE_V4_SHARE_URL_PARAM_KEY}=v3a`, (s) => (state = s));
+    await waitFor(() => expect(state.activeViewId).toBe('v3a'));
+    await act(async () => {
+      await state.overwriteView('v3a');
+    });
+    // V4 tag written under the same id, name + createdAt preserved, with the edited live state.
+    expect(mockSetExperimentTagApi).toHaveBeenCalledTimes(1);
+    const [, setKey, setValue] = mockSetExperimentTagApi.mock.calls[0];
+    expect(setKey).toBe('mlflow.tracesV4ViewState.v3a');
+    const envelope = JSON.parse(setValue);
+    expect(envelope.name).toBe('Legacy V3');
+    expect(envelope.createdAt).toBe(1000);
+    const decoded = JSON.parse(await textDecompressDeflate(envelope.state));
+    expect(decoded.single.q).toBe('edited');
+    // Legacy V3 tag deleted so the view is native V4 afterwards.
+    expect(mockDeleteExperimentTagApi).toHaveBeenCalledWith('exp-1', 'mlflow.traceViewState.v3a');
+  });
+
+  test('deleting a V3 view targets the V3 tag prefix', async () => {
+    mockExperiment([await makeV3ViewTag('v3a', 'Legacy V3', 1000)]);
+    let state: any;
+    renderV3ProbeAt('/', (s) => (state = s));
+    await waitFor(() => expect(state.views).toHaveLength(1));
+    await act(async () => {
+      await state.deleteView('v3a');
+    });
+    expect(mockDeleteExperimentTagApi).toHaveBeenCalledWith('exp-1', 'mlflow.traceViewState.v3a');
+  });
+
+  test('a migrated V4 tag shadows a leftover V3 tag of the same id (V4 wins, listed once)', async () => {
+    // Both prefixes hold the id (e.g. a refetch race mid-migration); the list must show one V4 entry.
+    mockExperiment([
+      await makeV3ViewTag('dup', 'Legacy name', 1000),
+      await makeV4ViewTag('dup', 'Migrated name', 3000),
+    ]);
+    let state: any;
+    renderV3ProbeAt('/', (s) => (state = s));
+    await waitFor(() => expect(state.views).toHaveLength(1));
+    expect(state.views[0]).toMatchObject({ id: 'dup', name: 'Migrated name', origin: 'v4' });
   });
 });
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
@@ -281,6 +281,20 @@ describe('TracesV4SavedViewsButton', () => {
     errorSpy.mockRestore();
   });
 
+  test('landing on a direct link to a corrupt view degrades gracefully (no crash, view not marked active)', async () => {
+    // A share link opened cold: the view tag exists but its state blob is undecodable. The URL params
+    // still drive the table, so the cold-load hydration just no-ops — no crash, and the button shows
+    // the view name from the (readable) envelope without hydrating columns or flagging a dirty view.
+    mockExperiment([
+      { key: 'mlflow.tracesV4ViewState.bad', value: encodeSavedViewEnvelope('Broken', 'not-base64', 5) },
+    ]);
+    renderButtonAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=bad`);
+    await waitFor(() => expect(screen.getByTestId('trace-v4-saved-views-trigger')).toHaveTextContent('Broken'));
+    // Undecodable state → no columns restored and no dirty dot (stays clean rather than half-applied).
+    expect(buttonSetColumns).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('trace-v4-saved-views-dirty-dot')).not.toBeInTheDocument();
+  });
+
   test('copy-link copies the view own stored share URL and shows a success toast', async () => {
     const infoSpy = jest.spyOn(Utils, 'displayGlobalInfoNotification').mockImplementation(() => {});
     renderButtonAt();

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
@@ -594,7 +594,7 @@ export const TracesV4SavedViewsButton = ({
             </ToolbarCollapsibleLabel>
           </Button>
         </DropdownMenu.Trigger>
-        <DropdownMenu.Content align="end">
+        <DropdownMenu.Content align="start">
           <SavedViewsMenu
             componentId="mlflow.traces-v4.saved_views"
             testIdPrefix="trace-v4-saved-views"
@@ -660,8 +660,11 @@ export const TracesV4SavedViewsButton = ({
  * Discard reverts to the user's own view. Renders nothing when no shared view is active.
  */
 export const TracesV4SharedViewBanner = ({ savedViews }: { savedViews: TracesV4SavedViewsApi }) => {
-  const { sharedViewActive, override, discard } = savedViews;
-  if (!sharedViewActive) {
+  const { sharedViewActive, activeShareKey, override, discard } = savedViews;
+  // Dismiss hides the banner WITHOUT leaving the shared view (Override/Discard stay reachable in the
+  // Views menu). Keyed on the active share key so a *different* shared view re-shows it (mirrors V3).
+  const [dismissedShareKey, setDismissedShareKey] = useState<string | null>(null);
+  if (!sharedViewActive || dismissedShareKey === activeShareKey) {
     return null;
   }
   return (
@@ -682,6 +685,7 @@ export const TracesV4SharedViewBanner = ({ savedViews }: { savedViews: TracesV4S
           />
         }
         onDiscard={discard}
+        onDismiss={() => setDismissedShareKey(activeShareKey)}
       />
     </div>
   );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
@@ -48,6 +48,12 @@ import {
 } from '../utils/tracesV4SavedViewState';
 import { capturedV4StatesMatch } from '../utils/tracesV4DirtyState';
 import { isSupportedFilterClause, useMlflowTraceFilterFields } from '../utils/filterModel';
+import {
+  getTraceV3SavedViewIdFromTagKey,
+  getTraceV3SavedViewTagKey,
+  translateV3ViewState,
+  type V3SavedViewState,
+} from '../utils/tracesV3ViewCompat';
 import { DEFAULT_TRACES_V4_TIME_LABEL } from '../utils/timeRange';
 
 /**
@@ -74,6 +80,9 @@ interface TraceV4SavedViewSummary {
   name: string;
   createdAt: number;
   updatedAt: number;
+  // Which tag prefix the view is stored under. A legacy V3 view (`v3`) opens (translated to V4
+  // state) and deletes in place; overwriting one migrates it to a V4 tag (see `overwriteView`).
+  origin: 'v4' | 'v3';
 }
 
 /** `dirty` = live table diverges from the active view; `clean` = matches or no view active. */
@@ -136,27 +145,35 @@ export const useTracesV4SavedViews = ({
 
   const views: TraceV4SavedViewSummary[] = useMemo(() => {
     const tags = experiment?.tags ?? [];
-    return (
-      tags
-        .reduce<TraceV4SavedViewSummary[]>((acc, { key, value }) => {
-          if (key == null || value == null) {
-            return acc;
-          }
-          const id = getTraceV4SavedViewIdFromTagKey(key);
-          if (id === null) {
-            return acc;
-          }
-          try {
-            const { name, createdAt, updatedAt } = decodeSavedViewEnvelope(value);
-            acc.push({ id, name, createdAt, updatedAt });
-          } catch {
-            // Skip a corrupt tag rather than breaking the list.
-          }
-          return acc;
-        }, [])
-        // Most-recently-edited first: overwriting a view floats it to the top.
-        .sort((a, b) => b.updatedAt - a.updatedAt)
-    );
+    // Collect V4 and legacy V3 views into one list, keyed by id so a view that has been migrated
+    // (a V4 tag written over a V3 one, both sharing the id) is de-duped — V4 always wins.
+    const byId = new Map<string, TraceV4SavedViewSummary>();
+    for (const { key, value } of tags) {
+      if (key == null || value == null) {
+        continue;
+      }
+      const v4Id = getTraceV4SavedViewIdFromTagKey(key);
+      const v3Id = v4Id === null ? getTraceV3SavedViewIdFromTagKey(key) : null;
+      const id = v4Id ?? v3Id;
+      if (id === null) {
+        continue;
+      }
+      const origin: 'v4' | 'v3' = v4Id !== null ? 'v4' : 'v3';
+      // A V3 tag must never shadow a migrated V4 tag of the same id.
+      if (origin === 'v3' && byId.get(id)?.origin === 'v4') {
+        continue;
+      }
+      try {
+        // Both V4 and V3 use the same envelope codec (name/createdAt/updatedAt + compressed state);
+        // only the inner `state` shape differs, which matters at open time, not for the summary.
+        const { name, createdAt, updatedAt } = decodeSavedViewEnvelope(value);
+        byId.set(id, { id, name, createdAt, updatedAt, origin });
+      } catch {
+        // Skip a corrupt tag rather than breaking the list.
+      }
+    }
+    // Most-recently-edited first: overwriting a view floats it to the top.
+    return [...byId.values()].sort((a, b) => b.updatedAt - a.updatedAt);
   }, [experiment?.tags]);
 
   const atCap = views.length >= MAX_SAVED_VIEWS;
@@ -217,24 +234,49 @@ export const useTracesV4SavedViews = ({
 
   const deleteView = useCallback(
     async (id: string) => {
-      await dispatch(deleteExperimentTagApi(experimentId, getTraceV4SavedViewTagKey(id)));
+      // Delete the tag under whichever prefix the view actually lives (legacy V3 views included).
+      const origin = views.find((view) => view.id === id)?.origin ?? 'v4';
+      const tagKey = origin === 'v3' ? getTraceV3SavedViewTagKey(id) : getTraceV4SavedViewTagKey(id);
+      await dispatch(deleteExperimentTagApi(experimentId, tagKey));
       await refetch();
     },
-    [dispatch, experimentId, refetch],
+    [dispatch, experimentId, refetch, views],
   );
 
-  // Decode a stored view's tag value into its captured state, or null if it's missing/corrupt.
+  // Decode a stored view's tag value into V4 captured state, or null if it's missing/corrupt. Reads
+  // a native V4 tag when present; otherwise falls back to the legacy V3 tag of the same id and
+  // translates its frozen state shape into V4's (so a V3 view opens through the normal apply path).
   const decodeViewState = useCallback(
     async (id: string): Promise<CapturedV4ViewState | null> => {
-      const tag = (experiment?.tags ?? []).find(({ key }) => key === getTraceV4SavedViewTagKey(id));
-      if (!tag || tag.value == null) {
-        return null;
+      const tags = experiment?.tags ?? [];
+      const v4Tag = tags.find(({ key }) => key === getTraceV4SavedViewTagKey(id));
+      if (v4Tag?.value != null) {
+        try {
+          return (await deserializePersistedState(decodeSavedViewEnvelope(v4Tag.value))) as CapturedV4ViewState;
+        } catch {
+          return null;
+        }
       }
-      try {
-        return (await deserializePersistedState(decodeSavedViewEnvelope(tag.value))) as CapturedV4ViewState;
-      } catch {
-        return null;
+      const v3Tag = tags.find(({ key }) => key === getTraceV3SavedViewTagKey(id));
+      if (v3Tag?.value != null) {
+        try {
+          const v3State = (await deserializePersistedState(decodeSavedViewEnvelope(v3Tag.value))) as V3SavedViewState;
+          const translated = translateV3ViewState(v3State);
+          // V3 column ids don't necessarily all resolve as V4 columns. Normalize `cols` to the
+          // resolvable V4 subset (what applyView will actually restore) so an opened V3 view reads
+          // clean, not spuriously dirty against ids V4 dropped. Absent when nothing resolves.
+          const resolvedCols = decodeViewColumns(translated, TRACE_COLUMN_IDS);
+          if (resolvedCols) {
+            translated.single.cols = resolvedCols.join(',');
+          } else {
+            delete translated.single.cols;
+          }
+          return translated;
+        } catch {
+          return null;
+        }
       }
+      return null;
     },
     [experiment?.tags],
   );
@@ -306,6 +348,8 @@ export const useTracesV4SavedViews = ({
   // Overwrite an existing view in place with the current live state, keeping its id, name and
   // creation time and bumping `updatedAt` (which floats it to the top of the list). Phantom-guarded:
   // `setExperimentTag` is create-or-update, so a deleted/unknown id would silently resurrect the tag.
+  // For a legacy V3 view this MIGRATES it: the state is written under the V4 prefix (same id) and the
+  // old V3 tag is deleted, so the view is native V4 afterwards and future overwrites are plain writes.
   const overwriteView = useCallback(
     async (id: string) => {
       const existing = views.find((view) => view.id === id);
@@ -326,6 +370,10 @@ export const useTracesV4SavedViews = ({
         return;
       }
       await dispatch(setExperimentTagApi(experimentId, getTraceV4SavedViewTagKey(id), envelope));
+      // Migrate: drop the legacy V3 tag now that the V4 one holds the (edited) state under the same id.
+      if (existing.origin === 'v3') {
+        await dispatch(deleteExperimentTagApi(experimentId, getTraceV3SavedViewTagKey(id)));
+      }
       await refetch();
       // The stored view now matches live; update the baseline so the dirty dot clears immediately.
       setActiveStoredState(state);

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
@@ -15,6 +15,7 @@ import {
 import {
   EMPTY_FILTER_MODEL,
   TRACE_COLUMN_IDS,
+  TRACES_TOOLBAR_COLLAPSE_QUERY,
   ToolbarCollapsibleLabel,
   type TraceColumnId,
   type TraceFilterModel,
@@ -662,6 +663,16 @@ export const TracesV4SavedViewsButton = ({
   const [pendingDelete, setPendingDelete] = useState<SavedViewMenuItem | null>(null);
   const activeView = activeViewId ? views.find((view) => view.id === activeViewId) : undefined;
   const isDirty = dirtyStatus === 'dirty';
+  // Shared style for the unsaved-edits dot, rendered twice (inline + a collapsed-only twin).
+  const dirtyDotStyles = {
+    display: 'inline-block',
+    width: 6,
+    height: 6,
+    borderRadius: '50%',
+    backgroundColor: theme.colors.blue500,
+    marginLeft: theme.spacing.xs,
+    flexShrink: 0,
+  } as const;
 
   const handleCopyLink = async (view: SavedViewMenuItem) => {
     const url = await buildShareUrl(view.id);
@@ -732,20 +743,9 @@ export const TracesV4SavedViewsButton = ({
                   >
                     {activeView.name}
                   </span>
-                  {isDirty && (
-                    <span
-                      data-testid="trace-v4-saved-views-dirty-dot"
-                      css={{
-                        display: 'inline-block',
-                        width: 6,
-                        height: 6,
-                        borderRadius: '50%',
-                        backgroundColor: theme.colors.blue500,
-                        marginLeft: theme.spacing.xs,
-                        flexShrink: 0,
-                      }}
-                    />
-                  )}
+                  {/* Inline dot after the name while expanded. A twin (below) covers the collapsed,
+                      icon-only state; only one is visible at a time, so only the twin carries the testid. */}
+                  {isDirty && <span aria-hidden css={dirtyDotStyles} />}
                 </span>
               ) : (
                 <FormattedMessage
@@ -754,6 +754,18 @@ export const TracesV4SavedViewsButton = ({
                 />
               )}
             </ToolbarCollapsibleLabel>
+            {/* The inline dot lives inside the collapsible label, so it vanishes with the name when the
+                toolbar collapses to icon-only. This twin sits OUTSIDE the label and shows ONLY while
+                collapsed (inverse of the label's own container query), keeping the dirty signal visible. */}
+            {isDirty && (
+              <span
+                data-testid="trace-v4-saved-views-dirty-dot"
+                css={{
+                  display: 'none',
+                  [TRACES_TOOLBAR_COLLAPSE_QUERY]: { ...dirtyDotStyles, marginLeft: 0 },
+                }}
+              />
+            )}
           </Button>
         </DropdownMenu.Trigger>
         <DropdownMenu.Content align="start">

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
@@ -235,13 +235,23 @@ export const useTracesV4SavedViews = ({
 
   const deleteView = useCallback(
     async (id: string) => {
-      // Delete the tag under whichever prefix the view actually lives (legacy V3 views included).
-      const origin = views.find((view) => view.id === id)?.origin ?? 'v4';
-      const tagKey = origin === 'v3' ? getTraceV3SavedViewTagKey(id) : getTraceV4SavedViewTagKey(id);
-      await dispatch(deleteExperimentTagApi(experimentId, tagKey));
+      // Delete every tag stored under this id, across both prefixes. Usually there's just one, but a
+      // half-migrated view (a V4 tag written over a V3 one whose delete never landed) leaves both —
+      // the list de-dupes them (V4 wins), so deleting only the V4 tag would let the V3 twin resurrect
+      // the view on the next refetch. Delete whichever of the two actually exists.
+      const tags = experiment?.tags ?? [];
+      const v4Key = getTraceV4SavedViewTagKey(id);
+      const v3Key = getTraceV3SavedViewTagKey(id);
+      const keysToDelete = [v4Key, v3Key].filter((key) => tags.some((tag) => tag.key === key));
+      // Fall back to the V4 key if the cache somehow lists neither (best-effort; the delete no-ops).
+      await Promise.all(
+        (keysToDelete.length > 0 ? keysToDelete : [v4Key]).map((key) =>
+          dispatch(deleteExperimentTagApi(experimentId, key)),
+        ),
+      );
       await refetch();
     },
-    [dispatch, experimentId, refetch, views],
+    [dispatch, experimentId, refetch, experiment?.tags],
   );
 
   // Decode a stored view's tag value into V4 captured state, or null if it's missing/corrupt. Reads

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
@@ -28,6 +28,7 @@ import { textCompressDeflate } from '@mlflow/mlflow/src/common/utils/StringUtils
 import { useSearchParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import type { ThunkDispatch } from '@mlflow/mlflow/src/redux-types';
 import { deleteExperimentTagApi, setExperimentTagApi } from '@mlflow/mlflow/src/experiment-tracking/actions';
+import { useArrayMemo } from '@databricks/web-shared/model-trace-explorer';
 import { useGetExperimentQuery } from '@mlflow/mlflow/src/experiment-tracking/hooks/useExperimentQuery';
 import {
   decodeSavedViewEnvelope,
@@ -35,28 +36,29 @@ import {
   encodeSavedViewEnvelope,
 } from '@mlflow/mlflow/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope';
 import { SavedViewsMenu, type SavedViewMenuItem } from '../../saved-views/SavedViewsMenu';
-import { SharedViewBanner } from '../../saved-views/SharedViewBanner';
 import {
   buildV4ViewQuery,
   captureV4ViewState,
-  decodePreviewColumns,
+  decodeViewColumns,
   getTraceV4SavedViewIdFromTagKey,
   getTraceV4SavedViewShareUrl,
   getTraceV4SavedViewTagKey,
   type CapturedV4ViewState,
-  TRACE_V4_COLS_PARAM_KEY,
   TRACE_V4_SHARE_URL_PARAM_KEY,
 } from '../utils/tracesV4SavedViewState';
+import { capturedV4StatesMatch } from '../utils/tracesV4DirtyState';
+import { isSupportedFilterClause, useMlflowTraceFilterFields } from '../utils/filterModel';
 import { DEFAULT_TRACES_V4_TIME_LABEL } from '../utils/timeRange';
 
 /**
- * Saved views for the V4 traces tab. Reuses the shared tag-envelope codec, the {@link SavedViewsMenu}
- * dropdown body, and the {@link SharedViewBanner}. Because the V4 tab is URL-first (search, sort,
- * page size, tag filters and time range all live in the URL), applying a view is just a navigation
- * to the stored query — there is no live-state bridge or React-state preview overlay like V3 needs.
- * The one piece of view state that isn't in the URL — column visibility — rides in a `cols` param
- * that doubles as the preview overlay; Override adopts it into the user's own column store, Discard
- * drops it.
+ * Saved views for the V4 traces tab. Reuses the shared tag-envelope codec and the
+ * {@link SavedViewsMenu} dropdown body. Most view state is URL-first (search, sort, page size, tag
+ * filters and time range all live in the URL), so applying a view is largely a navigation to the
+ * stored query; the one piece that isn't in the URL — column visibility — is restored into the
+ * user's own column store on open. Once a view is applied, the live table can diverge from it as the
+ * user edits ("dirty"); the Views menu then offers Overwrite (persist the edits into the view) and
+ * Reset (discard the edits, re-applying the stored view). Opening from the menu and opening from a
+ * shared link behave identically — there is no read-only preview.
  */
 
 // Experiment-tag values are capped server-side (MAX_EXPERIMENT_TAG_VAL_LENGTH, 20000 chars); a write
@@ -71,36 +73,61 @@ interface TraceV4SavedViewSummary {
   id: string;
   name: string;
   createdAt: number;
+  updatedAt: number;
 }
+
+/** `dirty` = live table diverges from the active view; `clean` = matches or no view active. */
+export type TracesV4ViewDirtyStatus = 'clean' | 'dirty';
 
 interface UseTracesV4SavedViewsParams {
   experimentId: string;
-  /** The user's live visible columns — captured into a view and snapshotted for Override's Undo. */
+  /** The user's live visible columns — captured into a view on save, and diffed against it for dirty. */
   visibleColumns: TraceColumnId[];
-  /** Adopts an explicit column set into the user's persisted store (used by Override). */
+  /** The live popover filter model — captured into a view on save, restored on open, diffed for dirty. */
+  filterModel: TraceFilterModel;
+  /** Writes an explicit column set into the user's persisted store (used by open / reset). */
   setColumns: (columns: TraceColumnId[]) => void;
   /** Clears column overrides (standard + assessment) back to defaults; used by "Default view". */
   resetColumns: () => void;
-  /** Clears the popover filter clauses (React state, not URL-backed); used by "Default view". */
+  /** Sets the popover filter clauses (React state, not URL-backed); used by open / reset / default. */
   setFilterModel: (next: TraceFilterModel) => void;
+  /** Candidate assessment names, so restored assessment-filter clauses validate against live fields. */
+  assessmentNames?: string[];
 }
 
 /**
- * Reads / saves / deletes / opens named V4 traces views, and drives the URL-param preview overlay.
- * Tags are read from the Apollo experiment query (the traces route's source of truth) and written
- * via the redux tag thunks; after a write we refetch Apollo so the new view shows up in the list.
+ * Reads / saves / overwrites / deletes / opens named V4 traces views, and reports whether the live
+ * table has diverged from the active view (dirty). Tags are read from the Apollo experiment query
+ * (the traces route's source of truth) and written via the redux tag thunks; after a write we
+ * refetch Apollo so the new view shows up in the list.
  */
 export const useTracesV4SavedViews = ({
   experimentId,
   visibleColumns,
+  filterModel,
   setColumns,
   resetColumns,
   setFilterModel,
+  assessmentNames = [],
 }: UseTracesV4SavedViewsParams) => {
   const dispatch = useDispatch<ThunkDispatch>();
   const intl = useIntl();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: experiment, refetch } = useGetExperimentQuery({ experimentId });
+
+  // Validate a stored filter model against the live field set: drop clauses whose field/operator no
+  // longer exists (a since-removed field, or an assessment name not on this page) so a restored view
+  // can't silently produce wrong results. Applied both on restore and when normalizing the dirty
+  // baseline, so an unsupported clause reads as "already dropped" rather than stranding the view dirty.
+  // Stabilize the names by content so a fresh `[]`/array identity doesn't churn `filterFields` →
+  // `supportedFilters` → the effects that depend on it every render.
+  const stableAssessmentNames = useArrayMemo(assessmentNames);
+  const filterFields = useMlflowTraceFilterFields(stableAssessmentNames);
+  const supportedFilters = useCallback(
+    (filters: TraceFilterModel | undefined): TraceFilterModel =>
+      (filters ?? EMPTY_FILTER_MODEL).filter((clause) => isSupportedFilterClause(filterFields, clause)),
+    [filterFields],
+  );
 
   // KNOWN LIMITATION (mirrors V3): read-only enforcement is deferred — the traces Apollo query does
   // not fetch `allowedActions`, so Save/Delete default to unrestricted (the write fails server-side
@@ -109,24 +136,27 @@ export const useTracesV4SavedViews = ({
 
   const views: TraceV4SavedViewSummary[] = useMemo(() => {
     const tags = experiment?.tags ?? [];
-    return tags
-      .reduce<TraceV4SavedViewSummary[]>((acc, { key, value }) => {
-        if (key == null || value == null) {
+    return (
+      tags
+        .reduce<TraceV4SavedViewSummary[]>((acc, { key, value }) => {
+          if (key == null || value == null) {
+            return acc;
+          }
+          const id = getTraceV4SavedViewIdFromTagKey(key);
+          if (id === null) {
+            return acc;
+          }
+          try {
+            const { name, createdAt, updatedAt } = decodeSavedViewEnvelope(value);
+            acc.push({ id, name, createdAt, updatedAt });
+          } catch {
+            // Skip a corrupt tag rather than breaking the list.
+          }
           return acc;
-        }
-        const id = getTraceV4SavedViewIdFromTagKey(key);
-        if (id === null) {
-          return acc;
-        }
-        try {
-          const { name, createdAt } = decodeSavedViewEnvelope(value);
-          acc.push({ id, name, createdAt });
-        } catch {
-          // Skip a corrupt tag rather than breaking the list.
-        }
-        return acc;
-      }, [])
-      .sort((a, b) => b.createdAt - a.createdAt);
+        }, [])
+        // Most-recently-edited first: overwriting a view floats it to the top.
+        .sort((a, b) => b.updatedAt - a.updatedAt)
+    );
   }, [experiment?.tags]);
 
   const atCap = views.length >= MAX_SAVED_VIEWS;
@@ -163,8 +193,8 @@ export const useTracesV4SavedViews = ({
         );
         return null;
       }
-      // Capture the current URL view params + the live columns (which aren't in the URL).
-      const state = captureV4ViewState(searchParams, visibleColumns);
+      // Capture the current URL view params + the live columns and filter model (neither in the URL).
+      const state = captureV4ViewState(searchParams, visibleColumns, filterModel);
       const compressedState = await textCompressDeflate(JSON.stringify(state));
       const id = getUUID();
       const envelope = encodeSavedViewEnvelope(name.trim(), compressedState, Date.now());
@@ -182,7 +212,7 @@ export const useTracesV4SavedViews = ({
       await refetch();
       return { id, state };
     },
-    [dispatch, experimentId, refetch, searchParams, visibleColumns, views, atCap, intl],
+    [dispatch, experimentId, refetch, searchParams, visibleColumns, filterModel, views, atCap, intl],
   );
 
   const deleteView = useCallback(
@@ -209,13 +239,21 @@ export const useTracesV4SavedViews = ({
     [experiment?.tags],
   );
 
-  // Activate a view by rewriting the URL query to its state (+ the share key). The V4 hooks read
-  // their params on the next render, so this IS the applied view — no overlay to mount.
+  // Activate a view: rewrite the URL query to its state (+ the share key), and restore the two
+  // non-URL surfaces — its columns into the user's own column store, and its popover filter model
+  // into React state (validated so a clause referencing a since-removed field/operator is dropped).
+  // The V4 hooks read the params on the next render, so this IS the applied view. A view with no
+  // resolvable columns leaves the user's columns untouched rather than hiding everything.
   const applyView = useCallback(
     (state: CapturedV4ViewState, id: string) => {
       setSearchParams(new URLSearchParams(buildV4ViewQuery(state, id)));
+      const columns = decodeViewColumns(state, TRACE_COLUMN_IDS);
+      if (columns) {
+        setColumns(columns);
+      }
+      setFilterModel(supportedFilters(state.filters));
     },
-    [setSearchParams],
+    [setSearchParams, setColumns, setFilterModel, supportedFilters],
   );
 
   // Return to the default state: drop every view param, clear the non-URL surfaces (columns +
@@ -256,69 +294,116 @@ export const useTracesV4SavedViews = ({
   );
 
   const activeShareKey = searchParams.get(TRACE_V4_SHARE_URL_PARAM_KEY);
-  const sharedViewActive = activeShareKey !== null;
+  // The active view id is the share key ONLY when it resolves to a view we actually have — so a
+  // stale/garbage share key never drives overwrite/reset/dirty against a phantom view.
+  const activeViewId = activeShareKey && views.some((view) => view.id === activeShareKey) ? activeShareKey : null;
 
-  // The columns the shared link carries (the preview overlay). Undefined when no `cols` param or
-  // nothing resolves → the caller falls back to the user's own columns.
-  const rawCols = searchParams.get(TRACE_V4_COLS_PARAM_KEY);
-  const previewColumns = useMemo(
-    () => (sharedViewActive ? decodePreviewColumns(rawCols, TRACE_COLUMN_IDS) : undefined),
-    [sharedViewActive, rawCols],
-  );
+  // Stored state of the active view, used both to diff for dirty and to restore columns on a
+  // cold-loaded link. Null until decoded (or when no view is active). Declared before the callbacks
+  // that close over its setter.
+  const [activeStoredState, setActiveStoredState] = useState<CapturedV4ViewState | null>(null);
 
-  // Drop the preview params (share key + cols) while KEEPING the rest of the applied view (search,
-  // sort, tag filters, time range) — the user stays where they navigated, just no longer "previewing".
-  const clearPreviewParams = useCallback(() => {
-    setSearchParams((params) => {
-      params.delete(TRACE_V4_SHARE_URL_PARAM_KEY);
-      params.delete(TRACE_V4_COLS_PARAM_KEY);
-      return params;
-    });
-  }, [setSearchParams]);
-
-  // Edit the previewed columns WITHOUT persisting: rewrite the `cols` URL param (the preview state),
-  // leaving localStorage untouched until Override. Passing null/empty drops the column override
-  // (the table then shows the user's own columns) while staying in preview. This backs the "changes
-  // aren't saved unless you override" promise for column toggles during a shared-view preview.
-  const setPreviewColumns = useCallback(
-    (cols: TraceColumnId[] | null) => {
-      setSearchParams((params) => {
-        if (cols && cols.length > 0) {
-          params.set(TRACE_V4_COLS_PARAM_KEY, cols.join(','));
-        } else {
-          params.delete(TRACE_V4_COLS_PARAM_KEY);
-        }
-        return params;
-      });
+  // Overwrite an existing view in place with the current live state, keeping its id, name and
+  // creation time and bumping `updatedAt` (which floats it to the top of the list). Phantom-guarded:
+  // `setExperimentTag` is create-or-update, so a deleted/unknown id would silently resurrect the tag.
+  const overwriteView = useCallback(
+    async (id: string) => {
+      const existing = views.find((view) => view.id === id);
+      if (!existing) {
+        return;
+      }
+      const state = captureV4ViewState(searchParams, visibleColumns, filterModel);
+      const compressedState = await textCompressDeflate(JSON.stringify(state));
+      const envelope = encodeSavedViewEnvelope(existing.name, compressedState, existing.createdAt, Date.now());
+      if (envelope.length > MAX_TAG_VALUE_LENGTH) {
+        Utils.displayGlobalErrorNotification(
+          intl.formatMessage({
+            defaultMessage: 'This view is too large to save.',
+            description: 'Error toast shown when overwriting a saved traces view exceeds the experiment-tag size limit',
+          }),
+          3,
+        );
+        return;
+      }
+      await dispatch(setExperimentTagApi(experimentId, getTraceV4SavedViewTagKey(id), envelope));
+      await refetch();
+      // The stored view now matches live; update the baseline so the dirty dot clears immediately.
+      setActiveStoredState(state);
+      Utils.displayGlobalInfoNotification(
+        intl.formatMessage(
+          {
+            defaultMessage: 'View "{name}" updated.',
+            description: 'Success toast shown after overwriting a saved traces view with the current state',
+          },
+          { name: existing.name },
+        ),
+        3,
+      );
     },
-    [setSearchParams],
+    [views, searchParams, visibleColumns, filterModel, dispatch, experimentId, refetch, intl],
   );
 
-  // Adopt the previewed columns into the user's own persisted store, then exit preview. This is the
-  // only write to the user's column store in this flow. When the link carried no resolvable columns
-  // (a filter-/sort-only view), there's nothing to adopt — Override just exits preview.
-  const override = useCallback(() => {
-    if (previewColumns) {
-      setColumns(previewColumns);
+  // Discard live edits: re-apply the active view's stored state (which also restores its columns).
+  const resetActiveView = useCallback(() => {
+    if (activeViewId) {
+      openView(activeViewId);
     }
-    clearPreviewParams();
-    Utils.displayGlobalInfoNotification(
-      intl.formatMessage({
-        defaultMessage: 'This view is now your default.',
-        description: 'Traces page > shared view > confirmation toast after adopting a shared view as the own view',
-      }),
-      5,
-    );
-  }, [previewColumns, setColumns, clearPreviewParams, intl]);
+  }, [activeViewId, openView]);
 
-  const discard = useCallback(() => {
-    clearPreviewParams();
-  }, [clearPreviewParams]);
+  // Tracks which view's columns have been restored, so a direct-link landing hydrates columns once
+  // but later user edits aren't clobbered on every render. Also gates the dirty diff so it never
+  // flashes "dirty" against half-restored state.
+  const hydratedViewIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!activeViewId) {
+      setActiveStoredState(null);
+      hydratedViewIdRef.current = null;
+      return;
+    }
+    let cancelled = false;
+    void decodeViewState(activeViewId).then((state) => {
+      if (cancelled || !state) {
+        return;
+      }
+      setActiveStoredState(state);
+      // Cold-load: a link opened directly carries the query in the URL but not the columns or the
+      // popover filter model, so restore both once per view id. Menu-open already restored them via
+      // applyView; this is a harmless no-op in that case.
+      if (hydratedViewIdRef.current !== activeViewId) {
+        hydratedViewIdRef.current = activeViewId;
+        const columns = decodeViewColumns(state, TRACE_COLUMN_IDS);
+        if (columns) {
+          setColumns(columns);
+        }
+        setFilterModel(supportedFilters(state.filters));
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeViewId, decodeViewState, setColumns, setFilterModel, supportedFilters]);
+
+  // Dirty = the live table (URL view params + columns) diverges from the active view's stored state.
+  // Treated as clean until the stored state is loaded AND columns are hydrated, so it never flashes
+  // dirty against a half-restored cold-load.
+  const dirtyStatus: TracesV4ViewDirtyStatus = useMemo(() => {
+    if (!activeViewId || !activeStoredState || hydratedViewIdRef.current !== activeViewId) {
+      return 'clean';
+    }
+    const live = captureV4ViewState(searchParams, visibleColumns, filterModel);
+    // Normalize the stored baseline's filters the same way openView restores them (drop unsupported
+    // clauses); diffing raw stored filters would mark a view with a since-removed field dirty forever.
+    const normalizedStored: CapturedV4ViewState = {
+      ...activeStoredState,
+      filters: supportedFilters(activeStoredState.filters),
+    };
+    return capturedV4StatesMatch(live, normalizedStored) ? 'clean' : 'dirty';
+  }, [activeViewId, activeStoredState, searchParams, visibleColumns, filterModel, supportedFilters]);
 
   // Opening a saved-view link in a tab whose experiment was loaded before the view was saved reads a
   // stale Apollo tag cache (a client-side nav doesn't refetch). The view still applies (its state
-  // rides in the URL), but the Views list/label wouldn't reflect it. When the active share key isn't
-  // in our list, refetch ONCE for that key so the list/label catch up. Guarded per-key so a
+  // rides in the URL), but the Views list/label/dirty-baseline wouldn't reflect it. When the active
+  // share key isn't in our list, refetch ONCE for that key so they catch up. Guarded per-key so a
   // genuinely-missing view doesn't loop.
   const refetchedShareKeyRef = useRef<string | null>(null);
   useEffect(() => {
@@ -341,14 +426,13 @@ export const useTracesV4SavedViews = ({
     deleteView,
     openView,
     applyView,
+    overwriteView,
+    resetActiveView,
     resetToDefaultView,
     buildShareUrl,
     activeShareKey,
-    sharedViewActive,
-    previewColumns,
-    setPreviewColumns,
-    override,
-    discard,
+    activeViewId,
+    dirtyStatus,
   };
 };
 
@@ -508,6 +592,7 @@ export const TracesV4SavedViewsButton = ({
   savedViews: TracesV4SavedViewsApi;
 }) => {
   const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
   const {
     views,
     canModify,
@@ -516,15 +601,19 @@ export const TracesV4SavedViewsButton = ({
     deleteView,
     openView,
     applyView,
+    overwriteView,
+    resetActiveView,
     resetToDefaultView,
     buildShareUrl,
-    activeShareKey,
+    activeViewId,
+    dirtyStatus,
   } = savedViews;
-  const { sharedViewActive, override, discard } = savedViews;
   const [showSaveModal, setShowSaveModal] = useState(false);
   // Held above the dropdown so the confirm dialog survives the dropdown closing on outside-click.
-  const [pendingDelete, setPendingDelete] = useState<TraceV4SavedViewSummary | null>(null);
-  const activeView = activeShareKey ? views.find((view) => view.id === activeShareKey) : undefined;
+  // Typed as the menu's item shape (id + name are all the confirm dialog needs).
+  const [pendingDelete, setPendingDelete] = useState<SavedViewMenuItem | null>(null);
+  const activeView = activeViewId ? views.find((view) => view.id === activeViewId) : undefined;
+  const isDirty = dirtyStatus === 'dirty';
 
   const handleCopyLink = async (view: SavedViewMenuItem) => {
     const url = await buildShareUrl(view.id);
@@ -582,8 +671,33 @@ export const TracesV4SavedViewsButton = ({
           >
             <ToolbarCollapsibleLabel>
               {activeView ? (
-                <span css={{ maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {activeView.name}
+                <span css={{ display: 'inline-flex', alignItems: 'center', minWidth: 0 }}>
+                  <span
+                    css={{
+                      maxWidth: 200,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      // Tint the name while the view has unsaved edits, echoing the dirty dot.
+                      color: isDirty ? theme.colors.blue600 : undefined,
+                    }}
+                  >
+                    {activeView.name}
+                  </span>
+                  {isDirty && (
+                    <span
+                      data-testid="trace-v4-saved-views-dirty-dot"
+                      css={{
+                        display: 'inline-block',
+                        width: 6,
+                        height: 6,
+                        borderRadius: '50%',
+                        backgroundColor: theme.colors.blue500,
+                        marginLeft: theme.spacing.xs,
+                        flexShrink: 0,
+                      }}
+                    />
+                  )}
                 </span>
               ) : (
                 <FormattedMessage
@@ -600,21 +714,16 @@ export const TracesV4SavedViewsButton = ({
             testIdPrefix="trace-v4-saved-views"
             views={views}
             canModify={canModify}
-            activeViewId={activeShareKey}
+            activeViewId={activeViewId}
             onOpen={openView}
             onCopyLink={handleCopyLink}
             onRequestDelete={setPendingDelete}
             onSaveCurrent={() => setShowSaveModal(true)}
             onSelectDefault={resetToDefaultView}
-            sharedViewActive={sharedViewActive}
-            onOverrideActive={override}
-            onDiscardActive={discard}
-            overrideLabel={
-              <FormattedMessage
-                defaultMessage="Override my view"
-                description="Traces Views menu > entry that adopts the applied shared view into the user's own view"
-              />
-            }
+            dirtyViewActive={isDirty}
+            activeViewName={activeView?.name}
+            onOverwriteActive={activeViewId ? () => overwriteView(activeViewId) : undefined}
+            onResetActive={resetActiveView}
           />
         </DropdownMenu.Content>
       </DropdownMenu.Root>
@@ -651,42 +760,5 @@ export const TracesV4SavedViewsButton = ({
         onSaved={(id, state) => applyView(state, id)}
       />
     </>
-  );
-};
-
-/**
- * Banner shown in the V4 traces `bannerSlot` while a shared view is applied. Reuses the shared
- * {@link SharedViewBanner}; Override adopts the shared view's columns into the user's own store,
- * Discard reverts to the user's own view. Renders nothing when no shared view is active.
- */
-export const TracesV4SharedViewBanner = ({ savedViews }: { savedViews: TracesV4SavedViewsApi }) => {
-  const { sharedViewActive, activeShareKey, override, discard } = savedViews;
-  // Dismiss hides the banner WITHOUT leaving the shared view (Override/Discard stay reachable in the
-  // Views menu). Keyed on the active share key so a *different* shared view re-shows it (mirrors V3).
-  const [dismissedShareKey, setDismissedShareKey] = useState<string | null>(null);
-  if (!sharedViewActive || dismissedShareKey === activeShareKey) {
-    return null;
-  }
-  return (
-    <div data-testid="trace-v4-shared-view-banner">
-      <SharedViewBanner
-        componentId="mlflow.traces-v4.shared_view"
-        message={
-          <FormattedMessage
-            defaultMessage="You're viewing a shared view. Changes you make won't be saved unless you override your view."
-            description="Traces page > shared view banner > message shown while a shared view is applied"
-          />
-        }
-        onOverride={override}
-        overrideLabel={
-          <FormattedMessage
-            defaultMessage="Override my view"
-            description="Traces page > shared view banner > button that adopts the shared view into the user's own view"
-          />
-        }
-        onDiscard={discard}
-        onDismiss={() => setDismissedShareKey(activeShareKey)}
-      />
-    </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/test-utils/tracesV4PageContentTestBed.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/test-utils/tracesV4PageContentTestBed.tsx
@@ -144,8 +144,13 @@ export const server = setupServer(
   // The add-to-dataset provider (GenAITracesTableProvider / ExportTracesToDatasetModal) fetches the
   // datasets list on mount; stub it so an unhandled request doesn't disrupt the toolbar render.
   rest.post('/ajax-api/3.0/mlflow/datasets/search', (_req, res, ctx) => res(ctx.json({ datasets: [] }))),
-  // The footer "{n} of {total}" count reads the total from the trace-metrics endpoint.
+  // The footer "{n} of {total}" count reads the total from the trace-metrics endpoint. The endpoint
+  // version depends on `shouldUseTracesV4API()` (3.0 when off, 4.0 when on), so mock both — the V4
+  // tab uses 4.0 when the flag is enabled.
   rest.post('/ajax-api/3.0/mlflow/traces/metrics', (_req, res, ctx) =>
+    res(ctx.json({ data_points: [{ metric_name: 'trace_count', values: { COUNT: env.metricsTotalCount } }] })),
+  ),
+  rest.post('/ajax-api/4.0/mlflow/traces/metrics', (_req, res, ctx) =>
     res(ctx.json({ data_points: [{ metric_name: 'trace_count', values: { COUNT: env.metricsTotalCount } }] })),
   ),
 );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/filterModel.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/filterModel.ts
@@ -184,6 +184,21 @@ export const useMlflowTraceFilterFields = (assessmentNames: string[] = []): Filt
 };
 
 /**
+ * Validate a persisted filter clause against the current field set: the field still exists, still
+ * offers the clause's operator, and (for a `requiresKey` field) carries a non-blank key. Used when
+ * restoring a saved view so a clause referencing a field/operator that no longer exists is dropped
+ * rather than silently producing wrong results — and, symmetrically, so the dirty diff normalizes
+ * the stored baseline the same way (an unsupported clause can't strand a view permanently dirty).
+ */
+export const isSupportedFilterClause = (fields: FilterFieldDef[], clause: FilterClause): boolean =>
+  fields.some(
+    (field) =>
+      field.id === clause.field &&
+      field.operators.includes(clause.operator) &&
+      (!field.requiresKey || (typeof clause.key === 'string' && clause.key.trim() !== '')),
+  );
+
+/**
  * Compile a text field where only `CONTAINS` needs translation (to `ILIKE '%value%'`, since the
  * backend has no `CONTAINS` token); every other operator passes through as `field OP 'value'`.
  */

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  getTraceV3SavedViewIdFromTagKey,
+  translateV3ViewState,
+  TRACE_V3_SAVED_VIEW_TAG_PREFIX,
+} from './tracesV3ViewCompat';
+import { buildV4ViewQuery } from './tracesV4SavedViewState';
+
+describe('getTraceV3SavedViewIdFromTagKey', () => {
+  test('extracts the id from a legacy V3 tag key', () => {
+    expect(getTraceV3SavedViewIdFromTagKey(`${TRACE_V3_SAVED_VIEW_TAG_PREFIX}abc`)).toBe('abc');
+  });
+
+  test('a key that is exactly the prefix (no id) is not a saved-view key', () => {
+    expect(getTraceV3SavedViewIdFromTagKey(TRACE_V3_SAVED_VIEW_TAG_PREFIX)).toBeNull();
+  });
+
+  test('rejects V4 and runs prefixes so the V3 reader only claims V3 tags', () => {
+    expect(getTraceV3SavedViewIdFromTagKey('mlflow.tracesV4ViewState.v1')).toBeNull();
+    expect(getTraceV3SavedViewIdFromTagKey('mlflow.sharedViewState.v1')).toBeNull();
+    expect(getTraceV3SavedViewIdFromTagKey('mlflow.note')).toBeNull();
+  });
+});
+
+describe('translateV3ViewState — columns', () => {
+  test('maps V3 selectedColumns onto V4 cols verbatim', () => {
+    const out = translateV3ViewState({ single: { selectedColumns: 'start_time,input,duration' } });
+    expect(out.single.cols).toBe('start_time,input,duration');
+  });
+
+  test('preserves an empty selectedColumns string (every column deselected) rather than dropping it', () => {
+    const out = translateV3ViewState({ single: { selectedColumns: '' } });
+    expect(out.single.cols).toBe('');
+  });
+
+  test('omits cols when V3 had no selectedColumns', () => {
+    const out = translateV3ViewState({ single: {} });
+    expect(out.single.cols).toBeUndefined();
+  });
+});
+
+describe('translateV3ViewState — sort', () => {
+  test('splits an ascending key::type::asc string into sort + dir, dropping the type segment', () => {
+    const out = translateV3ViewState({ single: { sort: 'duration::numeric::true' } });
+    expect(out.single.sort).toBe('duration');
+    expect(out.single.dir).toBe('asc');
+  });
+
+  test('maps asc=false to descending', () => {
+    const out = translateV3ViewState({ single: { sort: 'timestamp::date::false' } });
+    expect(out.single.sort).toBe('timestamp');
+    expect(out.single.dir).toBe('desc');
+  });
+
+  test('drops a malformed sort (wrong segment count) so the view still opens unsorted', () => {
+    const out = translateV3ViewState({ single: { sort: 'duration::numeric' } });
+    expect(out.single.sort).toBeUndefined();
+    expect(out.single.dir).toBeUndefined();
+  });
+
+  test('drops a sort with an empty key', () => {
+    const out = translateV3ViewState({ single: { sort: '::numeric::true' } });
+    expect(out.single.sort).toBeUndefined();
+    expect(out.single.dir).toBeUndefined();
+  });
+
+  test('omits sort/dir when V3 had no sort', () => {
+    const out = translateV3ViewState({ single: {} });
+    expect(out.single.sort).toBeUndefined();
+    expect(out.single.dir).toBeUndefined();
+  });
+});
+
+describe('translateV3ViewState — time range', () => {
+  test('passes the time-range fields through unchanged (identical keys/semantics)', () => {
+    const out = translateV3ViewState({
+      single: { startTimeLabel: 'CUSTOM', startTime: '2024-01-01T00:00:00Z', endTime: '2024-01-08T00:00:00Z' },
+    });
+    expect(out.single.startTimeLabel).toBe('CUSTOM');
+    expect(out.single.startTime).toBe('2024-01-01T00:00:00Z');
+    expect(out.single.endTime).toBe('2024-01-08T00:00:00Z');
+  });
+});
+
+describe('translateV3ViewState — filters', () => {
+  test('maps key=value V3 filters onto V4 tags, preserving order', () => {
+    const out = translateV3ViewState({ multi: { filter: ['env=prod', 'team=search'] } });
+    expect(out.multi.tag).toEqual(['env=prod', 'team=search']);
+  });
+
+  test('drops filter entries that are not key=value', () => {
+    const out = translateV3ViewState({
+      multi: { filter: ['env=prod', 'status:error', 'plainword', '=novalue', 'nokey='] },
+    });
+    expect(out.multi.tag).toEqual(['env=prod']);
+  });
+
+  test('omits tag entirely when no filter maps', () => {
+    const out = translateV3ViewState({ multi: { filter: ['plainword'] } });
+    expect(out.multi.tag).toBeUndefined();
+  });
+
+  test('omits tag when V3 had no filters', () => {
+    const out = translateV3ViewState({ single: {} });
+    expect(out.multi.tag).toBeUndefined();
+  });
+
+  test('drops V3-internal fields with no V4 equivalent (viewState)', () => {
+    const out = translateV3ViewState({ single: { viewState: 'whatever' } as any });
+    expect((out.single as Record<string, unknown>)['viewState']).toBeUndefined();
+  });
+});
+
+describe('translateV3ViewState — end to end', () => {
+  test('a full V3 view translates into a valid, applyable V4 query', () => {
+    const v3State = {
+      single: {
+        selectedColumns: 'start_time,input,duration',
+        sort: 'duration::numeric::false',
+        viewState: 'internal-v3-only',
+        startTimeLabel: 'LAST_7_DAYS',
+      },
+      multi: { filter: ['env=prod'] },
+    };
+
+    const out = translateV3ViewState(v3State);
+    const params = new URLSearchParams(buildV4ViewQuery(out, 'legacy-view-1'));
+
+    // Columns are stored on the envelope (restored into the column store on open), not carried in
+    // the URL query — so they live in `single.cols`, not as a `cols` param.
+    expect(out.single.cols).toBe('start_time,input,duration');
+    expect(params.get('cols')).toBeNull();
+    expect(params.get('sort')).toBe('duration');
+    expect(params.get('dir')).toBe('desc');
+    expect(params.get('startTimeLabel')).toBe('LAST_7_DAYS');
+    expect(params.getAll('tag')).toEqual(['env=prod']);
+    // V3's key=value filters map to V4's URL-backed tag[], NOT the in-memory popover filter model
+    // (which V3 had no equivalent of) — so a translated view carries no popover `filters`.
+    expect(out.filters).toBeUndefined();
+    // The share key is set so the applied view is recognized as a preview.
+    expect(params.get('traceViewShareKey')).toBe('legacy-view-1');
+    // V3-internal state never leaks into the V4 URL.
+    expect(params.get('viewState')).toBeNull();
+  });
+
+  test('an empty V3 view yields an empty captured state (no crash)', () => {
+    const out = translateV3ViewState({});
+    expect(out.single).toEqual({});
+    expect(out.multi).toEqual({});
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, test } from '@jest/globals';
 import {
   getTraceV3SavedViewIdFromTagKey,
+  getTraceV3SavedViewTagKey,
   translateV3ViewState,
   TRACE_V3_SAVED_VIEW_TAG_PREFIX,
 } from './tracesV3ViewCompat';
 import { buildV4ViewQuery } from './tracesV4SavedViewState';
+
+describe('getTraceV3SavedViewTagKey', () => {
+  test('builds a legacy V3 tag key from an id, round-tripping with the id extractor', () => {
+    const key = getTraceV3SavedViewTagKey('abc');
+    expect(key).toBe(`${TRACE_V3_SAVED_VIEW_TAG_PREFIX}abc`);
+    expect(getTraceV3SavedViewIdFromTagKey(key)).toBe('abc');
+  });
+});
 
 describe('getTraceV3SavedViewIdFromTagKey', () => {
   test('extracts the id from a legacy V3 tag key', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from '@jest/globals';
+import { FilterOp } from '@databricks/web-shared/traces-table';
 import {
   getTraceV3SavedViewIdFromTagKey,
   getTraceV3SavedViewTagKey,
@@ -32,43 +33,50 @@ describe('getTraceV3SavedViewIdFromTagKey', () => {
 });
 
 describe('translateV3ViewState — columns', () => {
-  test('maps V3 selectedColumns onto V4 cols verbatim', () => {
-    const out = translateV3ViewState({ single: { selectedColumns: 'start_time,input,duration' } });
-    expect(out.single.cols).toBe('start_time,input,duration');
+  test('maps V3 column ids onto their V4 counterparts, preserving order', () => {
+    // V3 named these columns differently: request→input, response→output, request_time→start_time,
+    // execution_duration→duration; the rest share the same id.
+    const out = translateV3ViewState({
+      single: { selectedColumns: 'request_time,request,response,execution_duration,state' },
+    });
+    expect(out.single.cols).toBe('start_time,input,output,duration,state');
   });
 
-  test('preserves an empty selectedColumns string (every column deselected) rather than dropping it', () => {
-    const out = translateV3ViewState({ single: { selectedColumns: '' } });
-    expect(out.single.cols).toBe('');
+  test('drops V3 column ids with no V4 column (e.g. logged_model, span.*)', () => {
+    const out = translateV3ViewState({ single: { selectedColumns: 'request,logged_model,span.name,tokens' } });
+    expect(out.single.cols).toBe('input,tokens');
   });
 
-  test('omits cols when V3 had no selectedColumns', () => {
-    const out = translateV3ViewState({ single: {} });
-    expect(out.single.cols).toBeUndefined();
+  test('omits cols when nothing maps or V3 had no selectedColumns', () => {
+    expect(translateV3ViewState({ single: { selectedColumns: 'logged_model,prompt' } }).single.cols).toBeUndefined();
+    expect(translateV3ViewState({ single: { selectedColumns: '' } }).single.cols).toBeUndefined();
+    expect(translateV3ViewState({ single: {} }).single.cols).toBeUndefined();
   });
 });
 
 describe('translateV3ViewState — sort', () => {
-  test('splits an ascending key::type::asc string into sort + dir, dropping the type segment', () => {
-    const out = translateV3ViewState({ single: { sort: 'duration::numeric::true' } });
+  test('maps a V3 sort key to its V4 column and splits key::type::asc into sort + dir', () => {
+    // execution_duration → duration; the middle `type` segment is dropped.
+    const out = translateV3ViewState({ single: { sort: 'execution_duration::number::true' } });
     expect(out.single.sort).toBe('duration');
     expect(out.single.dir).toBe('asc');
   });
 
-  test('maps asc=false to descending', () => {
-    const out = translateV3ViewState({ single: { sort: 'timestamp::date::false' } });
-    expect(out.single.sort).toBe('timestamp');
+  test('maps request_time → start_time and asc=false to descending', () => {
+    const out = translateV3ViewState({ single: { sort: 'request_time::date::false' } });
+    expect(out.single.sort).toBe('start_time');
     expect(out.single.dir).toBe('desc');
   });
 
-  test('drops a malformed sort (wrong segment count) so the view still opens unsorted', () => {
-    const out = translateV3ViewState({ single: { sort: 'duration::numeric' } });
+  test('drops a sort whose V3 key has no V4-sortable column', () => {
+    // `session` is client-sortable in V3 but not a V4-sortable column, so the sort is dropped.
+    const out = translateV3ViewState({ single: { sort: 'session::string::true' } });
     expect(out.single.sort).toBeUndefined();
     expect(out.single.dir).toBeUndefined();
   });
 
-  test('drops a sort with an empty key', () => {
-    const out = translateV3ViewState({ single: { sort: '::numeric::true' } });
+  test('drops a malformed sort (wrong segment count) so the view still opens unsorted', () => {
+    const out = translateV3ViewState({ single: { sort: 'execution_duration::number' } });
     expect(out.single.sort).toBeUndefined();
     expect(out.single.dir).toBeUndefined();
   });
@@ -92,26 +100,51 @@ describe('translateV3ViewState — time range', () => {
 });
 
 describe('translateV3ViewState — filters', () => {
-  test('maps key=value V3 filters onto V4 tags, preserving order', () => {
-    const out = translateV3ViewState({ multi: { filter: ['env=prod', 'team=search'] } });
-    expect(out.multi.tag).toEqual(['env=prod', 'team=search']);
-  });
-
-  test('drops filter entries that are not key=value', () => {
+  test('translates V3 column::operator::value::key entries into the V4 popover model, in order', () => {
+    // V3 serializes each filter as `column::operator::value::key` (the key segment is empty for
+    // non-key fields). state→state, execution_duration→duration.
     const out = translateV3ViewState({
-      multi: { filter: ['env=prod', 'status:error', 'plainword', '=novalue', 'nokey='] },
+      multi: { filter: ['state::=::ERROR::', 'execution_duration::>=::1000::'] },
     });
-    expect(out.multi.tag).toEqual(['env=prod']);
+    expect(out.filters).toEqual([
+      { field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' },
+      { field: 'duration', operator: FilterOp.GREATER_THAN_OR_EQUALS, value: '1000' },
+    ]);
   });
 
-  test('omits tag entirely when no filter maps', () => {
-    const out = translateV3ViewState({ multi: { filter: ['plainword'] } });
+  test('carries the key segment for a key-requiring field (TAG) and maps the column group', () => {
+    const out = translateV3ViewState({ multi: { filter: ['TAG::=::prod::env'] } });
+    expect(out.filters).toEqual([{ field: 'tag', operator: FilterOp.EQUALS, value: 'prod', key: 'env' }]);
+  });
+
+  test('maps the ASSESSMENT group to the assessment field, keeping its key', () => {
+    const out = translateV3ViewState({ multi: { filter: ['ASSESSMENT::=::yes::correctness'] } });
+    expect(out.filters).toEqual([{ field: 'assessment', operator: FilterOp.EQUALS, value: 'yes', key: 'correctness' }]);
+  });
+
+  test('drops entries whose column has no V4 field, whose operator V4 rejects, or that lack a value/key', () => {
+    const out = translateV3ViewState({
+      multi: {
+        filter: [
+          'logged_model::=::m1::', // column has no V4 filter field
+          'state::IS NULL::::', // operator V4 doesn't support
+          'user::=::::', // missing value
+          'TAG::=::prod::', // key-requiring field with no key
+          'session::=::sess-1::', // valid — kept
+        ],
+      },
+    });
+    expect(out.filters).toEqual([{ field: 'session', operator: FilterOp.EQUALS, value: 'sess-1' }]);
+  });
+
+  test('omits filters entirely when nothing maps, and never sets the URL-backed tag[]', () => {
+    const out = translateV3ViewState({ multi: { filter: ['logged_model::=::m1::'] } });
+    expect(out.filters).toBeUndefined();
     expect(out.multi.tag).toBeUndefined();
   });
 
-  test('omits tag when V3 had no filters', () => {
-    const out = translateV3ViewState({ single: {} });
-    expect(out.multi.tag).toBeUndefined();
+  test('omits filters when V3 had no filters', () => {
+    expect(translateV3ViewState({ single: {} }).filters).toBeUndefined();
   });
 
   test('drops V3-internal fields with no V4 equivalent (viewState)', () => {
@@ -121,15 +154,15 @@ describe('translateV3ViewState — filters', () => {
 });
 
 describe('translateV3ViewState — end to end', () => {
-  test('a full V3 view translates into a valid, applyable V4 query', () => {
+  test('a full V3 view translates into a valid, applyable V4 query + popover filter model', () => {
     const v3State = {
       single: {
-        selectedColumns: 'start_time,input,duration',
-        sort: 'duration::numeric::false',
+        selectedColumns: 'request_time,request,execution_duration',
+        sort: 'execution_duration::number::false',
         viewState: 'internal-v3-only',
         startTimeLabel: 'LAST_7_DAYS',
       },
-      multi: { filter: ['env=prod'] },
+      multi: { filter: ['state::=::ERROR::', 'TAG::=::prod::env'] },
     };
 
     const out = translateV3ViewState(v3State);
@@ -142,10 +175,12 @@ describe('translateV3ViewState — end to end', () => {
     expect(params.get('sort')).toBe('duration');
     expect(params.get('dir')).toBe('desc');
     expect(params.get('startTimeLabel')).toBe('LAST_7_DAYS');
-    expect(params.getAll('tag')).toEqual(['env=prod']);
-    // V3's key=value filters map to V4's URL-backed tag[], NOT the in-memory popover filter model
-    // (which V3 had no equivalent of) — so a translated view carries no popover `filters`.
-    expect(out.filters).toBeUndefined();
+    // V3 filters translate into V4's in-memory popover model, NOT the URL-backed tag[].
+    expect(out.filters).toEqual([
+      { field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' },
+      { field: 'tag', operator: FilterOp.EQUALS, value: 'prod', key: 'env' },
+    ]);
+    expect(params.getAll('tag')).toEqual([]);
     // The share key is set so the applied view is recognized as a preview.
     expect(params.get('traceViewShareKey')).toBe('legacy-view-1');
     // V3-internal state never leaks into the V4 URL.
@@ -156,5 +191,6 @@ describe('translateV3ViewState — end to end', () => {
     const out = translateV3ViewState({});
     expect(out.single).toEqual({});
     expect(out.multi).toEqual({});
+    expect(out.filters).toBeUndefined();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.ts
@@ -1,13 +1,15 @@
 import { type CapturedV4ViewState } from './tracesV4SavedViewState';
 
 /**
- * Read-only compatibility shim for legacy V3 saved views.
+ * Compatibility shim for legacy V3 saved views.
  *
  * V3 is being removed, so nothing writes the V3 format anymore — but views authored while V3 shipped
- * are stored as experiment tags under the V3 prefix and must stay openable after V4 replaces V3. This
- * module lets the V4 tab DISCOVER those tags (via {@link TRACE_V3_SAVED_VIEW_TAG_PREFIX}) and READ
- * them (via {@link translateV3ViewState}), translating the frozen V3 state shape into V4's captured
- * view state. It never writes V3 — the only supported mutations on a legacy view are open and delete.
+ * are stored as experiment tags under the V3 prefix and must stay usable after V4 replaces V3. This
+ * module lets the V4 tab DISCOVER those tags (via {@link TRACE_V3_SAVED_VIEW_TAG_PREFIX} /
+ * {@link getTraceV3SavedViewTagKey}) and READ them (via {@link translateV3ViewState}), translating
+ * the frozen V3 state shape into V4's captured view state. It never WRITES the V3 format: a legacy
+ * view opens and can be deleted in place, and overwriting one migrates it forward — the edited state
+ * is written under the V4 prefix (same id) and the old V3 tag is deleted (see `overwriteView`).
  *
  * The translation is intentionally lossy in the ways that don't matter to the user: it maps the parts
  * a saved view is actually judged by (columns, sort, time range) and best-effort maps filters, while
@@ -20,6 +22,8 @@ import { type CapturedV4ViewState } from './tracesV4SavedViewState';
 export const TRACE_V3_SAVED_VIEW_TAG_PREFIX = 'mlflow.traceViewState.';
 
 const V3_SORT_SEPARATOR = '::';
+
+export const getTraceV3SavedViewTagKey = (id: string): string => `${TRACE_V3_SAVED_VIEW_TAG_PREFIX}${id}`;
 
 export const getTraceV3SavedViewIdFromTagKey = (key: string): string | null => {
   if (!key.startsWith(TRACE_V3_SAVED_VIEW_TAG_PREFIX)) {
@@ -37,7 +41,7 @@ export const getTraceV3SavedViewIdFromTagKey = (key: string): string | null => {
  * columns are a comma-joined id list, and `filter` is repeatable. Every field is optional — a view
  * may omit any of them — and unknown extra fields are ignored.
  */
-interface V3SavedViewState {
+export interface V3SavedViewState {
   single?: {
     selectedColumns?: string;
     sort?: string;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.ts
@@ -1,0 +1,132 @@
+import { type CapturedV4ViewState } from './tracesV4SavedViewState';
+
+/**
+ * Read-only compatibility shim for legacy V3 saved views.
+ *
+ * V3 is being removed, so nothing writes the V3 format anymore — but views authored while V3 shipped
+ * are stored as experiment tags under the V3 prefix and must stay openable after V4 replaces V3. This
+ * module lets the V4 tab DISCOVER those tags (via {@link TRACE_V3_SAVED_VIEW_TAG_PREFIX}) and READ
+ * them (via {@link translateV3ViewState}), translating the frozen V3 state shape into V4's captured
+ * view state. It never writes V3 — the only supported mutations on a legacy view are open and delete.
+ *
+ * The translation is intentionally lossy in the ways that don't matter to the user: it maps the parts
+ * a saved view is actually judged by (columns, sort, time range) and best-effort maps filters, while
+ * dropping V3-internal fields with no V4 equivalent.
+ */
+
+// The prefix V3 wrote its saved-view tags under. Kept in sync with `TRACE_SAVED_VIEW_TAG_PREFIX` in
+// `traces-v3/TracesV3SavedViews.tsx` (which stays frozen); duplicated here so the V4 tab can read
+// legacy tags without importing the V3 module.
+export const TRACE_V3_SAVED_VIEW_TAG_PREFIX = 'mlflow.traceViewState.';
+
+const V3_SORT_SEPARATOR = '::';
+
+export const getTraceV3SavedViewIdFromTagKey = (key: string): string | null => {
+  if (!key.startsWith(TRACE_V3_SAVED_VIEW_TAG_PREFIX)) {
+    return null;
+  }
+  // A key that is exactly the prefix (no id) yields an empty id, which would collide across tags;
+  // treat it as not a saved-view key (mirrors the V3 / V4 helpers).
+  const id = key.slice(TRACE_V3_SAVED_VIEW_TAG_PREFIX.length);
+  return id === '' ? null : id;
+};
+
+/**
+ * The frozen shape of a deserialized V3 saved-view state. Mirrors V3's `CapturedTraceViewState`
+ * (`traces-v3/TracesV3SavedViews.tsx`): `sort` is the monolithic `key::type::asc` wire string,
+ * columns are a comma-joined id list, and `filter` is repeatable. Every field is optional — a view
+ * may omit any of them — and unknown extra fields are ignored.
+ */
+interface V3SavedViewState {
+  single?: {
+    selectedColumns?: string;
+    sort?: string;
+    viewState?: string;
+    startTimeLabel?: string;
+    startTime?: string;
+    endTime?: string;
+  };
+  multi?: {
+    filter?: string[];
+  };
+}
+
+/**
+ * Split V3's monolithic `key::type::asc` sort string into V4's separate `sort` + `dir`. The middle
+ * `type` segment is dropped: V4 derives a column's sort type from its own column definition, so the
+ * stored type is redundant rather than lost. Returns an empty object for an absent or malformed
+ * value so a view with a broken sort still opens (just unsorted).
+ */
+const translateV3Sort = (sort: string | undefined): Pick<CapturedV4ViewState['single'], 'sort' | 'dir'> => {
+  if (!sort) {
+    return {};
+  }
+  const parts = sort.split(V3_SORT_SEPARATOR);
+  if (parts.length !== 3) {
+    return {};
+  }
+  const [key, , ascStr] = parts;
+  if (!key) {
+    return {};
+  }
+  return { sort: key, dir: ascStr === 'true' ? 'asc' : 'desc' };
+};
+
+/**
+ * Best-effort map V3's generic `filter[]` onto V4's `tag[]`. V4 tags are strictly `key=value`
+ * trace-metadata filters, whereas V3 filters were a looser vocabulary, so only entries already
+ * shaped `key=value` carry over; anything else is dropped rather than producing an invalid V4 tag.
+ * (In OSS with URL persistence off, V3 filters live in localStorage and usually aren't captured into
+ * a view at all, so this is rarely exercised.) Returns undefined when nothing maps.
+ */
+const translateV3Filters = (filters: string[] | undefined): string[] | undefined => {
+  if (!filters || filters.length === 0) {
+    return undefined;
+  }
+  const mapped = filters.filter((entry) => {
+    const eq = entry.indexOf('=');
+    // Require a non-empty key and value on either side of the first '='.
+    return eq > 0 && eq < entry.length - 1;
+  });
+  return mapped.length > 0 ? mapped : undefined;
+};
+
+/**
+ * Translate a deserialized legacy V3 saved-view state into V4's captured view state, so a V3-authored
+ * view can be applied by the V4 tab's normal navigation path. Maps columns (`selectedColumns` →
+ * `cols`), sort (`key::type::asc` → `sort`+`dir`), the time range (identical keys, passthrough), and
+ * best-effort filters (`filter[]` → `tag[]`). V3-internal fields (`viewState`) are dropped. The
+ * caller is responsible for having already inflated the envelope's `state` blob.
+ *
+ * The V4 captured state's `filters` (the popover filter model) is intentionally left absent: V3's
+ * `filter[]` are `key=value` trace-metadata filters that map onto V4's URL-backed `tag[]` above, not
+ * onto the in-memory popover model, which V3 had no equivalent of. An absent `filters` reads as an
+ * empty model, so a translated V3 view opens with no popover clauses and isn't spuriously dirty.
+ */
+export const translateV3ViewState = (state: V3SavedViewState): CapturedV4ViewState => {
+  const v3Single = state.single ?? {};
+  const single: CapturedV4ViewState['single'] = {};
+
+  if (v3Single.selectedColumns !== undefined) {
+    single.cols = v3Single.selectedColumns;
+  }
+  Object.assign(single, translateV3Sort(v3Single.sort));
+  // Time-range fields share the same keys and semantics between V3 and V4 — pass them through as-is.
+  if (v3Single.startTimeLabel !== undefined) {
+    single.startTimeLabel = v3Single.startTimeLabel;
+  }
+  if (v3Single.startTime !== undefined) {
+    single.startTime = v3Single.startTime;
+  }
+  if (v3Single.endTime !== undefined) {
+    single.endTime = v3Single.endTime;
+  }
+
+  const multi: CapturedV4ViewState['multi'] = {};
+  const tag = translateV3Filters(state.multi?.filter);
+  if (tag !== undefined) {
+    multi.tag = tag;
+  }
+
+  return { single, multi };
+};

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV3ViewCompat.ts
@@ -1,3 +1,9 @@
+import {
+  FilterOp,
+  isSortableTraceColumn,
+  type FilterClause,
+  type TraceFilterModel,
+} from '@databricks/web-shared/traces-table';
 import { type CapturedV4ViewState } from './tracesV4SavedViewState';
 
 /**
@@ -11,9 +17,16 @@ import { type CapturedV4ViewState } from './tracesV4SavedViewState';
  * view opens and can be deleted in place, and overwriting one migrates it forward — the edited state
  * is written under the V4 prefix (same id) and the old V3 tag is deleted (see `overwriteView`).
  *
- * The translation is intentionally lossy in the ways that don't matter to the user: it maps the parts
- * a saved view is actually judged by (columns, sort, time range) and best-effort maps filters, while
- * dropping V3-internal fields with no V4 equivalent.
+ * V3 and V4 speak different vocabularies for the three things a saved view is judged by — columns,
+ * sort, and filters — so the translation maps each across:
+ *   - columns: V3 ids (`request`, `response`, `request_time`, `execution_duration`, …) → V4 ids
+ *     (`input`, `output`, `start_time`, `duration`, …); ids with no V4 column are dropped.
+ *   - sort: V3's monolithic `key::type::asc` → V4's `sort`+`dir`, with the key mapped and dropped
+ *     entirely if it isn't a V4-sortable column.
+ *   - filters: V3's URL-shaped `column::operator::value::key` entries → V4's popover filter model
+ *     ({@link FilterClause}[]); columns/operators with no V4 equivalent are dropped.
+ * The mapping is intentionally lossy in the ways that don't matter: an unmappable column/sort/filter
+ * is dropped rather than carried as an invalid V4 value.
  */
 
 // The prefix V3 wrote its saved-view tags under. Kept in sync with `TRACE_SAVED_VIEW_TAG_PREFIX` in
@@ -21,7 +34,9 @@ import { type CapturedV4ViewState } from './tracesV4SavedViewState';
 // legacy tags without importing the V3 module.
 export const TRACE_V3_SAVED_VIEW_TAG_PREFIX = 'mlflow.traceViewState.';
 
-const V3_SORT_SEPARATOR = '::';
+// V3 joins both its `sort` string (`key::type::asc`) and each `filter` entry
+// (`column::operator::value::key`) on the same separator (see `useFilters.tsx` / `TracesV3SavedViews`).
+const V3_VALUE_SEPARATOR = '::';
 
 export const getTraceV3SavedViewTagKey = (id: string): string => `${TRACE_V3_SAVED_VIEW_TAG_PREFIX}${id}`;
 
@@ -38,8 +53,8 @@ export const getTraceV3SavedViewIdFromTagKey = (key: string): string | null => {
 /**
  * The frozen shape of a deserialized V3 saved-view state. Mirrors V3's `CapturedTraceViewState`
  * (`traces-v3/TracesV3SavedViews.tsx`): `sort` is the monolithic `key::type::asc` wire string,
- * columns are a comma-joined id list, and `filter` is repeatable. Every field is optional — a view
- * may omit any of them — and unknown extra fields are ignored.
+ * columns are a comma-joined id list, and `filter` is repeatable (each `column::operator::value::key`).
+ * Every field is optional — a view may omit any of them — and unknown extra fields are ignored.
  */
 export interface V3SavedViewState {
   single?: {
@@ -55,64 +70,153 @@ export interface V3SavedViewState {
   };
 }
 
+// V3 → V4 column-id map. V3 named a handful of columns differently (`request`/`response`/
+// `request_time`/`execution_duration`); the rest share the same id in both. Ids absent here (e.g.
+// V3's `logged_model`, `custom_metadata.*`, `span.*`) have no V4 column and are dropped.
+const V3_TO_V4_COLUMN_ID = new Map<string, string>([
+  ['request', 'input'],
+  ['response', 'output'],
+  ['request_time', 'start_time'],
+  ['execution_duration', 'duration'],
+  ['trace_id', 'trace_id'],
+  ['trace_name', 'trace_name'],
+  ['user', 'user'],
+  ['session', 'session'],
+  ['state', 'state'],
+  ['source', 'source'],
+  ['run_name', 'run_name'],
+  ['tokens', 'tokens'],
+  ['tags', 'tags'],
+]);
+
+// V3 filter `column` → V4 popover filter field id. Standard scalar columns map straight across;
+// V3's TAG / ASSESSMENT groups become V4's key-requiring `tag` / `assessment` fields (the V3 entry's
+// 4th segment carries the key). Columns with no V4 filter field (logged_model, prompt, git_*,
+// custom_metadata.*, expectation, issue.id, span.content) are dropped.
+const V3_TO_V4_FILTER_FIELD = new Map<string, string>([
+  ['execution_duration', 'duration'],
+  ['state', 'state'],
+  ['user', 'user'],
+  ['session', 'session'],
+  ['run_name', 'run_name'],
+  ['trace_name', 'trace_name'],
+  ['source', 'source'],
+  ['request', 'input'],
+  ['response', 'output'],
+  ['span.name', 'span_name'],
+  ['span.type', 'span_type'],
+  ['span.status', 'span_status'],
+  ['TAG', 'tag'],
+  ['ASSESSMENT', 'assessment'],
+]);
+
+// V4 popover fields that carry a free-text key alongside their value (mirrors `requiresKey` in
+// `filterModel.ts`): a translated clause for one of these must keep the V3 entry's key segment.
+const V4_KEY_REQUIRING_FIELDS = new Set<string>(['tag', 'metadata', 'assessment']);
+
+// The operator tokens V4 understands (the `FilterOp` enum values). V3 additionally had
+// `IS NULL` / `IS NOT NULL`, which V4 has no equivalent for — clauses using them are dropped.
+const V4_FILTER_OPS = new Set<string>(Object.values(FilterOp));
+
+// V3 → V4 sort-key map: only the two server-sortable V3 columns have a V4-sortable counterpart.
+const V3_TO_V4_SORT_KEY = new Map<string, string>([
+  ['execution_duration', 'duration'],
+  ['request_time', 'start_time'],
+]);
+
 /**
- * Split V3's monolithic `key::type::asc` sort string into V4's separate `sort` + `dir`. The middle
- * `type` segment is dropped: V4 derives a column's sort type from its own column definition, so the
- * stored type is redundant rather than lost. Returns an empty object for an absent or malformed
- * value so a view with a broken sort still opens (just unsorted).
+ * Map V3's comma-joined `selectedColumns` id list onto V4 column ids, dropping any id with no V4
+ * column. Returns the comma-joined V4 list, or undefined when nothing maps (so the caller leaves the
+ * user's columns untouched rather than hiding everything). The caller still re-validates against the
+ * live column set, so this only needs to translate the names it knows.
+ */
+const translateV3Columns = (selectedColumns: string | undefined): string | undefined => {
+  if (selectedColumns === undefined) {
+    return undefined;
+  }
+  const mapped = selectedColumns
+    .split(',')
+    .filter(Boolean)
+    .map((id) => V3_TO_V4_COLUMN_ID.get(id))
+    .filter((id): id is string => id !== undefined);
+  return mapped.length > 0 ? mapped.join(',') : undefined;
+};
+
+/**
+ * Split V3's monolithic `key::type::asc` sort string into V4's separate `sort` + `dir`, mapping the
+ * V3 sort key to its V4 column id. The middle `type` segment is dropped (V4 derives a column's sort
+ * type from its own definition). Returns an empty object for an absent / malformed value, or for a
+ * key that isn't a V4-sortable column, so the view opens (just unsorted) rather than carrying a sort
+ * V4 would silently reject.
  */
 const translateV3Sort = (sort: string | undefined): Pick<CapturedV4ViewState['single'], 'sort' | 'dir'> => {
   if (!sort) {
     return {};
   }
-  const parts = sort.split(V3_SORT_SEPARATOR);
+  const parts = sort.split(V3_VALUE_SEPARATOR);
   if (parts.length !== 3) {
     return {};
   }
-  const [key, , ascStr] = parts;
-  if (!key) {
+  const [v3Key, , ascStr] = parts;
+  const v4Key = V3_TO_V4_SORT_KEY.get(v3Key);
+  if (!v4Key || !isSortableTraceColumn(v4Key)) {
     return {};
   }
-  return { sort: key, dir: ascStr === 'true' ? 'asc' : 'desc' };
+  return { sort: v4Key, dir: ascStr === 'true' ? 'asc' : 'desc' };
 };
 
 /**
- * Best-effort map V3's generic `filter[]` onto V4's `tag[]`. V4 tags are strictly `key=value`
- * trace-metadata filters, whereas V3 filters were a looser vocabulary, so only entries already
- * shaped `key=value` carry over; anything else is dropped rather than producing an invalid V4 tag.
- * (In OSS with URL persistence off, V3 filters live in localStorage and usually aren't captured into
- * a view at all, so this is rarely exercised.) Returns undefined when nothing maps.
+ * Translate V3's URL-shaped `column::operator::value::key` filter entries into V4's popover filter
+ * model. Each entry is mapped by column → V4 field id and validated for a known operator; entries
+ * whose column has no V4 field, or whose operator V4 doesn't support (e.g. `IS NULL`), are dropped.
+ * A key-requiring field (tag / assessment) keeps the entry's key segment; others drop it. Returns
+ * undefined when nothing maps, so a filter-less view stays byte-identical to a native V4 one (and the
+ * downstream `isSupportedFilterClause` pass still prunes any clause a field's own operator set rejects).
  */
-const translateV3Filters = (filters: string[] | undefined): string[] | undefined => {
+const translateV3Filters = (filters: string[] | undefined): TraceFilterModel | undefined => {
   if (!filters || filters.length === 0) {
     return undefined;
   }
-  const mapped = filters.filter((entry) => {
-    const eq = entry.indexOf('=');
-    // Require a non-empty key and value on either side of the first '='.
-    return eq > 0 && eq < entry.length - 1;
-  });
-  return mapped.length > 0 ? mapped : undefined;
+  const clauses: FilterClause[] = [];
+  for (const entry of filters) {
+    const [column, operator, value, key] = entry.split(V3_VALUE_SEPARATOR);
+    if (!column || !operator) {
+      continue;
+    }
+    const field = V3_TO_V4_FILTER_FIELD.get(column);
+    if (!field || !V4_FILTER_OPS.has(operator)) {
+      continue;
+    }
+    const requiresKey = V4_KEY_REQUIRING_FIELDS.has(field);
+    // A key-requiring field with no key can't produce a valid clause; a value is always required.
+    if ((requiresKey && !key) || !value) {
+      continue;
+    }
+    clauses.push({
+      field,
+      operator: operator as FilterOp,
+      value,
+      ...(requiresKey ? { key } : {}),
+    });
+  }
+  return clauses.length > 0 ? clauses : undefined;
 };
 
 /**
  * Translate a deserialized legacy V3 saved-view state into V4's captured view state, so a V3-authored
  * view can be applied by the V4 tab's normal navigation path. Maps columns (`selectedColumns` →
- * `cols`), sort (`key::type::asc` → `sort`+`dir`), the time range (identical keys, passthrough), and
- * best-effort filters (`filter[]` → `tag[]`). V3-internal fields (`viewState`) are dropped. The
- * caller is responsible for having already inflated the envelope's `state` blob.
- *
- * The V4 captured state's `filters` (the popover filter model) is intentionally left absent: V3's
- * `filter[]` are `key=value` trace-metadata filters that map onto V4's URL-backed `tag[]` above, not
- * onto the in-memory popover model, which V3 had no equivalent of. An absent `filters` reads as an
- * empty model, so a translated V3 view opens with no popover clauses and isn't spuriously dirty.
+ * `cols`, V3→V4 ids), sort (`key::type::asc` → `sort`+`dir`, key mapped), the time range (identical
+ * keys, passthrough), and filters (`filter[]` → V4's popover `filters` model). V3-internal fields
+ * (`viewState`) are dropped. The caller is responsible for having already inflated the envelope's
+ * `state` blob.
  */
 export const translateV3ViewState = (state: V3SavedViewState): CapturedV4ViewState => {
   const v3Single = state.single ?? {};
   const single: CapturedV4ViewState['single'] = {};
 
-  if (v3Single.selectedColumns !== undefined) {
-    single.cols = v3Single.selectedColumns;
+  const cols = translateV3Columns(v3Single.selectedColumns);
+  if (cols !== undefined) {
+    single.cols = cols;
   }
   Object.assign(single, translateV3Sort(v3Single.sort));
   // Time-range fields share the same keys and semantics between V3 and V4 — pass them through as-is.
@@ -126,11 +230,10 @@ export const translateV3ViewState = (state: V3SavedViewState): CapturedV4ViewSta
     single.endTime = v3Single.endTime;
   }
 
-  const multi: CapturedV4ViewState['multi'] = {};
-  const tag = translateV3Filters(state.multi?.filter);
-  if (tag !== undefined) {
-    multi.tag = tag;
+  const result: CapturedV4ViewState = { single, multi: {} };
+  const filters = translateV3Filters(state.multi?.filter);
+  if (filters !== undefined) {
+    result.filters = filters;
   }
-
-  return { single, multi };
+  return result;
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from '@jest/globals';
+import { capturedV4StatesMatch, __test__ } from './tracesV4DirtyState';
+import { captureV4ViewState } from './tracesV4SavedViewState';
+import { FilterOp, type TraceColumnId, type TraceFilterModel } from '@databricks/web-shared/traces-table';
+
+const { canonicalViewQuery, columnSetsEqual } = __test__;
+
+const capture = (query: string, cols: TraceColumnId[] = [], filters: TraceFilterModel = []) =>
+  captureV4ViewState(new URLSearchParams(query), cols, filters);
+
+describe('capturedV4StatesMatch', () => {
+  test('identical captures match (clean)', () => {
+    const a = capture('q=x&sort=duration&dir=asc', ['start_time', 'input']);
+    const b = capture('q=x&sort=duration&dir=asc', ['start_time', 'input']);
+    expect(capturedV4StatesMatch(a, b)).toBe(true);
+  });
+
+  test('a different search query is dirty', () => {
+    const a = capture('q=changed', ['start_time']);
+    const b = capture('q=x', ['start_time']);
+    expect(capturedV4StatesMatch(a, b)).toBe(false);
+  });
+
+  test('columns are compared as a set — reordering is still clean', () => {
+    const a = capture('q=x', ['input', 'start_time']);
+    const b = capture('q=x', ['start_time', 'input']);
+    expect(capturedV4StatesMatch(a, b)).toBe(true);
+  });
+
+  test('a different column selection is dirty', () => {
+    const a = capture('q=x', ['start_time', 'input', 'duration']);
+    const b = capture('q=x', ['start_time', 'input']);
+    expect(capturedV4StatesMatch(a, b)).toBe(false);
+  });
+
+  test('tag filters must match (including order)', () => {
+    const a = capture('tag=env%3Dprod&tag=team%3Dml');
+    const b = capture('tag=env%3Dprod&tag=team%3Dml');
+    expect(capturedV4StatesMatch(a, b)).toBe(true);
+    const c = capture('tag=team%3Dml&tag=env%3Dprod');
+    expect(capturedV4StatesMatch(a, c)).toBe(false);
+  });
+
+  test('an absent filter model matches an empty one (legacy view stays clean)', () => {
+    const a = capture('q=x', ['start_time']); // no filters → undefined
+    const b = capture('q=x', ['start_time'], []); // empty filters → omitted too
+    expect(capturedV4StatesMatch(a, b)).toBe(true);
+  });
+
+  test('the popover filter model is part of the diff', () => {
+    const a = capture('q=x', ['start_time'], [{ field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' }]);
+    const b = capture('q=x', ['start_time'], []);
+    expect(capturedV4StatesMatch(a, b)).toBe(false);
+    const c = capture('q=x', ['start_time'], [{ field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' }]);
+    expect(capturedV4StatesMatch(a, c)).toBe(true);
+  });
+});
+
+describe('canonicalViewQuery', () => {
+  test('drops the recomputed absolute bounds for a relative time label', () => {
+    // Two captures of the same relative range differ only in their recomputed startTime/endTime;
+    // they must canonicalize equal so a passive re-render never reads as dirty.
+    const a = capture('startTimeLabel=LAST_7_DAYS&startTime=2026-01-01T00:00:00Z&endTime=2026-01-08T00:00:00Z');
+    const b = capture('startTimeLabel=LAST_7_DAYS&startTime=2026-02-01T00:00:00Z&endTime=2026-02-08T00:00:00Z');
+    expect(canonicalViewQuery(a)).toBe(canonicalViewQuery(b));
+  });
+
+  test('keeps the explicit bounds for a CUSTOM range', () => {
+    const a = capture('startTimeLabel=CUSTOM&startTime=2026-01-01T00:00:00Z&endTime=2026-01-08T00:00:00Z');
+    const b = capture('startTimeLabel=CUSTOM&startTime=2026-02-01T00:00:00Z&endTime=2026-02-08T00:00:00Z');
+    expect(canonicalViewQuery(a)).not.toBe(canonicalViewQuery(b));
+  });
+
+  test('normalizes the default label so an absent label matches the explicit default', () => {
+    // A stored view saved before the default label was written vs a fresh capture that includes it.
+    const withDefault = capture('q=x&startTimeLabel=LAST_7_DAYS');
+    const withoutLabel = capture('q=x');
+    expect(canonicalViewQuery(withDefault)).toBe(canonicalViewQuery(withoutLabel));
+  });
+
+  test('is order-independent across params', () => {
+    const a = capture('q=x&sort=duration&dir=asc');
+    const b = capture('sort=duration&dir=asc&q=x');
+    expect(canonicalViewQuery(a)).toBe(canonicalViewQuery(b));
+  });
+});
+
+describe('columnSetsEqual', () => {
+  test('true regardless of order, false on differing membership', () => {
+    expect(columnSetsEqual(['a', 'b'], ['b', 'a'])).toBe(true);
+    expect(columnSetsEqual(['a'], ['a', 'b'])).toBe(false);
+    expect(columnSetsEqual(['a', 'b'], ['a', 'c'])).toBe(false);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.test.ts
@@ -54,6 +54,13 @@ describe('capturedV4StatesMatch', () => {
     const c = capture('q=x', ['start_time'], [{ field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' }]);
     expect(capturedV4StatesMatch(a, c)).toBe(true);
   });
+
+  test('toggling session grouping is dirty', () => {
+    const grouped = capture('q=x&groupBy=session', ['start_time']);
+    const flat = capture('q=x', ['start_time']);
+    expect(capturedV4StatesMatch(grouped, flat)).toBe(false);
+    expect(capturedV4StatesMatch(grouped, capture('q=x&groupBy=session', ['start_time']))).toBe(true);
+  });
 });
 
 describe('canonicalViewQuery', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.ts
@@ -1,0 +1,83 @@
+import { isEqual } from 'lodash';
+
+import { type CapturedV4ViewState } from './tracesV4SavedViewState';
+import { DEFAULT_TRACES_V4_TIME_LABEL } from './timeRange';
+
+/**
+ * Dirty comparison for V4 saved views: does the live table state still match the view the user
+ * opened? Drives the Views button's dirty dot and the Overwrite / Reset actions.
+ *
+ * It compares exactly what a view captures — the whitelisted URL params ({@link CapturedV4ViewState}
+ * `single`/`multi`), the stored column set, and the popover filter model — and nothing else.
+ *
+ * The match is narrower than a raw field equality, for the same reasons managed's is:
+ *   - Relative time ranges recompute their absolute `startTime`/`endTime` on every render, so for a
+ *     non-CUSTOM label only the label is compared (the bounds are dropped). The default label is
+ *     explicit in fresh captures but absent in older stored views, so it is normalized in first.
+ *   - Column visibility is a selection, not an ordering, so the two lists are compared as sets.
+ *   - The popover filter model is deep-compared (`filters ?? []`) so absent (legacy) and empty read
+ *     as equal. The caller must normalize the stored baseline through the same `supportedFilters`
+ *     validation openView applies, so a clause referencing a since-removed field/operator (dropped
+ *     on restore) can't strand the view permanently dirty.
+ */
+
+const START_TIME_LABEL_KEY = 'startTimeLabel';
+
+// The `cols` param no longer rides in the URL query, but a stored view may still carry it inside
+// `single`; strip it from the query comparison and diff columns as a set instead (below).
+const COLS_KEY = 'cols';
+
+/**
+ * Canonicalize a captured view's `single`/`multi` params into a stable, comparable query string:
+ * drop the recomputed absolute bounds for relative time ranges, normalize the default label, and
+ * sort by key so param order never spuriously reads as dirty.
+ */
+const canonicalViewQuery = (state: CapturedV4ViewState): string => {
+  const params = new URLSearchParams();
+  Object.entries(state.single ?? {}).forEach(([key, value]) => {
+    if (typeof value === 'string' && key !== COLS_KEY) {
+      params.set(key, value);
+    }
+  });
+  Object.entries(state.multi ?? {}).forEach(([key, values]) => {
+    (values ?? []).forEach((value) => params.append(key, value));
+  });
+
+  const label = params.get(START_TIME_LABEL_KEY) ?? DEFAULT_TRACES_V4_TIME_LABEL;
+  if (label !== 'CUSTOM') {
+    params.delete('startTime');
+    params.delete('endTime');
+  }
+  params.set(START_TIME_LABEL_KEY, label);
+
+  // Sort by key; Array.sort is stable, so repeated keys (tag filters) keep their relative order.
+  const entries = [...params.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const canonical = new URLSearchParams();
+  for (const [key, value] of entries) {
+    canonical.append(key, value);
+  }
+  return canonical.toString();
+};
+
+/** Column visibility is a selection, not an ordering — compare the two id lists as sets. */
+const columnSetsEqual = (a: readonly string[], b: readonly string[]): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  const set = new Set(a);
+  return b.every((id) => set.has(id));
+};
+
+const colsOf = (state: CapturedV4ViewState): string[] => {
+  const raw = state.single?.[COLS_KEY];
+  return raw ? raw.split(',').filter(Boolean) : [];
+};
+
+/** True when the live captured state matches the stored view (i.e. not dirty). */
+export const capturedV4StatesMatch = (live: CapturedV4ViewState, stored: CapturedV4ViewState): boolean =>
+  canonicalViewQuery(live) === canonicalViewQuery(stored) &&
+  columnSetsEqual(colsOf(live), colsOf(stored)) &&
+  isEqual(live.filters ?? [], stored.filters ?? []);
+
+// Exported for unit-testing the pure comparisons in isolation.
+export const __test__ = { canonicalViewQuery, columnSetsEqual };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.test.ts
@@ -37,7 +37,9 @@ describe('tracesV4SavedViewState tag-key helpers', () => {
 describe('captureV4ViewState', () => {
   test('captures the whitelisted URL view params and drops the transient ones', () => {
     const state = captureV4ViewState(
-      params('q=refund&sort=duration&dir=asc&pageSize=50&page=3&traceId=abc123&startTimeLabel=LAST_7_DAYS'),
+      params(
+        'q=refund&sort=duration&dir=asc&pageSize=50&page=3&traceId=abc123&startTimeLabel=LAST_7_DAYS&groupBy=session',
+      ),
       ['start_time', 'input', 'duration'],
     );
     const query = buildV4ViewQuery(state, 'view-1');
@@ -48,6 +50,8 @@ describe('captureV4ViewState', () => {
     expect(out.get('dir')).toBe('asc');
     expect(out.get('pageSize')).toBe('50');
     expect(out.get('startTimeLabel')).toBe('LAST_7_DAYS');
+    // Session grouping is a URL-backed view param, so it round-trips like the rest.
+    expect(out.get('groupBy')).toBe('session');
     // Transient state is never part of a saved view.
     expect(out.get('page')).toBeNull();
     expect(out.get('traceId')).toBeNull();

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
-import { TRACE_COLUMN_IDS } from '@databricks/web-shared/traces-table';
+import { FilterOp, TRACE_COLUMN_IDS } from '@databricks/web-shared/traces-table';
 import {
   captureV4ViewState,
   buildV4ViewQuery,
-  decodePreviewColumns,
+  decodeViewColumns,
   getTraceV4SavedViewShareUrl,
   getTraceV4SavedViewTagKey,
   getTraceV4SavedViewIdFromTagKey,
@@ -59,11 +59,29 @@ describe('captureV4ViewState', () => {
     expect(out.getAll('tag')).toEqual(['env=prod', 'team=search']);
   });
 
-  test('captures the live visible columns as the cols param (not read from the URL)', () => {
-    // Columns live in localStorage, not the URL, so capture takes them from the live arg.
+  test('captures the live visible columns into the stored state (not the URL query)', () => {
+    // Columns live in localStorage, not the URL: they are stored in the envelope's `cols` key and
+    // restored into the column store on open, so they must NOT appear in the built query string.
     const state = captureV4ViewState(params('q=x'), ['start_time', 'input', 'duration']);
+    expect(state.single.cols).toBe('start_time,input,duration');
     const out = params(buildV4ViewQuery(state, 'view-1'));
-    expect(out.get('cols')).toBe('start_time,input,duration');
+    expect(out.get('cols')).toBeNull();
+  });
+
+  test('stores the live popover filter model, and omits an empty one', () => {
+    // Filters are React state (not URL-backed), so they're passed in and stored on the envelope; an
+    // empty model is omitted so a filter-less view stays byte-identical to a legacy (pre-filter) one.
+    const withFilters = captureV4ViewState(
+      params('q=x'),
+      ['start_time'],
+      [{ field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' }],
+    );
+    expect(withFilters.filters).toEqual([{ field: 'state', operator: FilterOp.EQUALS, value: 'ERROR' }]);
+    // Filters never leak into the rebuilt URL query.
+    expect(params(buildV4ViewQuery(withFilters, 'view-1')).has('filters')).toBe(false);
+
+    const noFilters = captureV4ViewState(params('q=x'), ['start_time'], []);
+    expect(noFilters.filters).toBeUndefined();
   });
 
   test('never captures an incoming share key or cols param from the URL (only the live columns)', () => {
@@ -72,8 +90,8 @@ describe('captureV4ViewState', () => {
       'start_time',
       'input',
     ]);
+    expect(state.single.cols).toBe('start_time,input'); // live columns win, not the URL's cols
     const out = params(buildV4ViewQuery(state, 'view-b'));
-    expect(out.get('cols')).toBe('start_time,input'); // live columns win, not the URL's cols
     expect(out.get(TRACE_V4_SHARE_URL_PARAM_KEY)).toBe('view-b'); // the new id, not the old one
   });
 });
@@ -89,7 +107,6 @@ describe('buildV4ViewQuery', () => {
 describe('urlHasCapturedV4ViewState', () => {
   test('true when the URL carries any serialized view state', () => {
     expect(urlHasCapturedV4ViewState(params('sort=duration'))).toBe(true);
-    expect(urlHasCapturedV4ViewState(params('cols=start_time'))).toBe(true);
     expect(urlHasCapturedV4ViewState(params('tag=env%3Dprod'))).toBe(true);
   });
 
@@ -101,9 +118,11 @@ describe('urlHasCapturedV4ViewState', () => {
   });
 });
 
-describe('decodePreviewColumns', () => {
-  test('resolves known column ids in the given order', () => {
-    expect(decodePreviewColumns('start_time,input,duration', TRACE_COLUMN_IDS)).toEqual([
+describe('decodeViewColumns', () => {
+  const withCols = (cols: string) => ({ single: { cols }, multi: {} });
+
+  test('resolves known column ids in the given (stored) order', () => {
+    expect(decodeViewColumns(withCols('start_time,input,duration'), TRACE_COLUMN_IDS)).toEqual([
       'start_time',
       'input',
       'duration',
@@ -111,13 +130,13 @@ describe('decodePreviewColumns', () => {
   });
 
   test('drops ids that no longer resolve (view saved against an older column set)', () => {
-    expect(decodePreviewColumns('start_time,bogus,input', TRACE_COLUMN_IDS)).toEqual(['start_time', 'input']);
+    expect(decodeViewColumns(withCols('start_time,bogus,input'), TRACE_COLUMN_IDS)).toEqual(['start_time', 'input']);
   });
 
-  test('returns undefined when nothing resolves or the value is empty', () => {
-    expect(decodePreviewColumns('bogus', TRACE_COLUMN_IDS)).toBeUndefined();
-    expect(decodePreviewColumns('', TRACE_COLUMN_IDS)).toBeUndefined();
-    expect(decodePreviewColumns(undefined, TRACE_COLUMN_IDS)).toBeUndefined();
+  test('returns undefined when nothing resolves or the value is empty/absent', () => {
+    expect(decodeViewColumns(withCols('bogus'), TRACE_COLUMN_IDS)).toBeUndefined();
+    expect(decodeViewColumns(withCols(''), TRACE_COLUMN_IDS)).toBeUndefined();
+    expect(decodeViewColumns({ single: {}, multi: {} }, TRACE_COLUMN_IDS)).toBeUndefined();
   });
 });
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.ts
@@ -1,17 +1,17 @@
-import { type TraceColumnId } from '@databricks/web-shared/traces-table';
+import { type TraceColumnId, type TraceFilterModel } from '@databricks/web-shared/traces-table';
 import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
 import { ExperimentPageTabName } from '@mlflow/mlflow/src/experiment-tracking/constants';
 
 /**
  * Pure serialization for V4 saved views.
  *
- * Unlike the V3 tab (whose columns/sort live in localStorage, forcing a live-state bridge + a
- * React-state preview overlay), the V4 tab is URL-first: search, sort, page size, tag filters and
- * the time range all already live in the URL. So a V4 "view" is essentially a snapshot of the URL
- * search string (minus the transient page/traceId/share-key params), plus the one piece of view
- * state that ISN'T in the URL — column visibility — carried as a `cols` param. Applying a view is
- * then just a navigation to the rebuilt query; the URL itself is the applied view, and the `cols`
- * param doubles as the preview overlay (present only while a shared view is applied).
+ * Most V4 view state is URL-first: search, sort, page size, tag filters and the time range all live
+ * in the URL, so a view is largely a snapshot of the URL search string (minus the transient
+ * page/traceId/share-key params). The one piece that ISN'T in the URL — column visibility — is
+ * stored in the envelope under the `cols` key and, on open, restored into the user's column store
+ * (localStorage) rather than the URL. Applying a view is a navigation to the rebuilt query plus that
+ * column restore; the live table then diverges from the stored view as the user edits ("dirty"),
+ * and Overwrite / Reset act on the active view.
  */
 
 // Distinct from the V3 prefix (`mlflow.traceViewState.`) and the runs prefix
@@ -20,8 +20,8 @@ import { ExperimentPageTabName } from '@mlflow/mlflow/src/experiment-tracking/co
 export const TRACE_V4_SAVED_VIEW_TAG_PREFIX = 'mlflow.tracesV4ViewState.';
 export const TRACE_V4_SHARE_URL_PARAM_KEY = 'traceViewShareKey';
 
-// The `cols` param carries column visibility (the only view state not otherwise in the URL) and, by
-// its presence, marks a live preview of a shared view.
+// The key under which column visibility is stored inside the envelope's captured state. It is NOT a
+// URL param: columns are restored into the user's column store on open, not carried in the query.
 export const TRACE_V4_COLS_PARAM_KEY = 'cols';
 
 const COLUMNS_SEPARATOR = ',';
@@ -34,6 +34,11 @@ const MULTI_VALUE_KEYS = ['tag'] as const;
 export interface CapturedV4ViewState {
   single: Partial<Record<(typeof SINGLE_VALUE_KEYS)[number] | typeof TRACE_V4_COLS_PARAM_KEY, string>>;
   multi: Partial<Record<(typeof MULTI_VALUE_KEYS)[number], string[]>>;
+  // The popover filter clauses (React state, not URL-backed), captured so a saved view restores the
+  // exact filter model the user had applied. Absent in older stored views; restored through a
+  // validation pass (see `isSupportedFilterClause`) so a clause referencing a since-removed
+  // field/operator is dropped rather than silently producing wrong results.
+  filters?: TraceFilterModel;
 }
 
 export const getTraceV4SavedViewTagKey = (id: string): string => `${TRACE_V4_SAVED_VIEW_TAG_PREFIX}${id}`;
@@ -57,18 +62,20 @@ export const getTraceV4SavedViewIdFromTagKey = (key: string): string | null => {
  */
 export const urlHasCapturedV4ViewState = (params: URLSearchParams): boolean =>
   SINGLE_VALUE_KEYS.some((key) => params.get(key) !== null) ||
-  MULTI_VALUE_KEYS.some((key) => params.getAll(key).length > 0) ||
-  params.get(TRACE_V4_COLS_PARAM_KEY) !== null;
+  MULTI_VALUE_KEYS.some((key) => params.getAll(key).length > 0);
 
 /**
- * Capture the current view: the whitelisted URL params plus the live visible columns (which live in
- * localStorage, not the URL, so they're passed in rather than read from `params`). The incoming
- * URL's own `cols` / share key are intentionally ignored so opening view A then saving view B never
- * leaks A's columns or id into B.
+ * Capture the current view: the whitelisted URL params, the live visible columns (which live in
+ * localStorage, not the URL, so they're passed in rather than read from `params`), and the live
+ * popover filter model (also React state, not URL-backed). The incoming URL's own `cols` / share
+ * key are intentionally ignored so opening view A then saving view B never leaks A's columns or id
+ * into B. An empty filter model is omitted so a filter-less view stays byte-identical to a legacy
+ * one (and never spuriously reads as dirty against `filters ?? []`).
  */
 export const captureV4ViewState = (
   params: URLSearchParams,
   visibleColumns: readonly TraceColumnId[],
+  filterModel: TraceFilterModel = [],
 ): CapturedV4ViewState => {
   const single: CapturedV4ViewState['single'] = {};
   SINGLE_VALUE_KEYS.forEach((key) => {
@@ -87,14 +94,22 @@ export const captureV4ViewState = (
       multi[key] = values;
     }
   });
-  return { single, multi };
+  const state: CapturedV4ViewState = { single, multi };
+  if (filterModel.length > 0) {
+    state.filters = filterModel;
+  }
+  return state;
 };
 
-/** Rebuild a URL query string from a captured view + the view's id (as the share key). */
+/**
+ * Rebuild a URL query string from a captured view + the view's id (as the share key). Columns are
+ * intentionally excluded — they live in the envelope's `cols` key and are restored into the user's
+ * column store on open, not carried in the URL (decode them with {@link decodeViewColumns}).
+ */
 export const buildV4ViewQuery = (state: CapturedV4ViewState, viewId: string): string => {
   const params = new URLSearchParams();
   Object.entries(state.single ?? {}).forEach(([key, value]) => {
-    if (typeof value === 'string') {
+    if (typeof value === 'string' && key !== TRACE_V4_COLS_PARAM_KEY) {
       params.set(key, value);
     }
   });
@@ -115,15 +130,16 @@ export const getTraceV4SavedViewShareUrl = (
 };
 
 /**
- * Decode the comma-joined `cols` value into known column ids in the given order. Ids that no longer
- * resolve to a known column are dropped (a view saved against an older column set still opens);
- * returns undefined when the value is absent or nothing resolves, so the caller falls back to the
- * user's own columns rather than hiding every column.
+ * Decode a view's stored column set (the envelope's comma-joined `cols` value) into known column ids
+ * in stored order. Ids that no longer resolve to a known column are dropped (a view saved against an
+ * older column set still opens); returns undefined when the value is absent or nothing resolves, so
+ * the caller can leave the user's columns untouched rather than hiding every column.
  */
-export const decodePreviewColumns = (
-  raw: string | undefined | null,
+export const decodeViewColumns = (
+  state: CapturedV4ViewState,
   allColumns: readonly TraceColumnId[],
 ): TraceColumnId[] | undefined => {
+  const raw = state.single?.[TRACE_V4_COLS_PARAM_KEY];
   if (!raw) {
     return undefined;
   }

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.ts
@@ -27,8 +27,18 @@ export const TRACE_V4_COLS_PARAM_KEY = 'cols';
 const COLUMNS_SEPARATOR = ',';
 
 // The URL view params that make up a V4 saved view. `tag` is repeatable (one param per filter).
-// Deliberately EXCLUDES the transient params `page`, `traceId`, and the share key itself.
-const SINGLE_VALUE_KEYS = ['q', 'pageSize', 'sort', 'dir', 'startTimeLabel', 'startTime', 'endTime'] as const;
+// `groupBy` carries the session-grouping toggle (`groupBy=session`). Deliberately EXCLUDES the
+// transient params `page`, `traceId`, and the share key itself.
+const SINGLE_VALUE_KEYS = [
+  'q',
+  'pageSize',
+  'sort',
+  'dir',
+  'startTimeLabel',
+  'startTime',
+  'endTime',
+  'groupBy',
+] as const;
 const MULTI_VALUE_KEYS = ['tag'] as const;
 
 export interface CapturedV4ViewState {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.test.ts
@@ -49,7 +49,35 @@ describe('savedViewEnvelope', () => {
       const envelopeJson = encodeSavedViewEnvelope('My view', compressedState, 1770000000000);
 
       const decoded = decodeSavedViewEnvelope(envelopeJson);
-      expect(decoded).toEqual({ name: 'My view', createdAt: 1770000000000, state: compressedState });
+      // updatedAt defaults to createdAt when not supplied.
+      expect(decoded).toEqual({
+        name: 'My view',
+        createdAt: 1770000000000,
+        updatedAt: 1770000000000,
+        state: compressedState,
+      });
+    });
+
+    it('preserves a distinct updatedAt when supplied (overwrite)', async () => {
+      const compressedState = await textCompressDeflate(JSON.stringify({}));
+      const envelopeJson = encodeSavedViewEnvelope('My view', compressedState, 100, 200);
+
+      expect(decodeSavedViewEnvelope(envelopeJson)).toEqual({
+        name: 'My view',
+        createdAt: 100,
+        updatedAt: 200,
+        state: compressedState,
+      });
+    });
+
+    it('defaults updatedAt to createdAt for a legacy tag written before overwrite existed', () => {
+      const legacy = JSON.stringify({ name: 'Old view', createdAt: 50, state: '{}' });
+      expect(decodeSavedViewEnvelope(legacy)).toEqual({
+        name: 'Old view',
+        createdAt: 50,
+        updatedAt: 50,
+        state: '{}',
+      });
     });
 
     it('throws on malformed JSON', () => {
@@ -72,7 +100,7 @@ describe('savedViewEnvelope', () => {
 
     it('supports an uncompressed (plain JSON) state field for forward-compat', async () => {
       const original = { selectedColumns: ['loss'] };
-      const envelope = { name: 'v', createdAt: 1, state: JSON.stringify(original) };
+      const envelope = { name: 'v', createdAt: 1, updatedAt: 1, state: JSON.stringify(original) };
 
       expect(await deserializePersistedState(envelope)).toEqual(original);
     });
@@ -94,15 +122,15 @@ describe('savedViewEnvelope', () => {
       const views = listSavedViews(tags);
 
       expect(views).toEqual([
-        { id: 'v1', name: 'First view', createdAt: 300 },
-        { id: 'v2', name: 'Second view', createdAt: 100 },
+        { id: 'v1', name: 'First view', createdAt: 300, updatedAt: 300 },
+        { id: 'v2', name: 'Second view', createdAt: 100, updatedAt: 100 },
       ]);
     });
 
     it('skips tags whose value fails to decode rather than throwing', async () => {
       const tags = [{ key: getSavedViewTagKey('bad'), value: 'not-json{' }, await buildTag('good', 'Good view', 5)];
 
-      expect(listSavedViews(tags)).toEqual([{ id: 'good', name: 'Good view', createdAt: 5 }]);
+      expect(listSavedViews(tags)).toEqual([{ id: 'good', name: 'Good view', createdAt: 5, updatedAt: 5 }]);
     });
 
     it('returns an empty array when there are no saved-view tags', () => {
@@ -118,7 +146,7 @@ describe('savedViewEnvelope', () => {
         await buildTag('good', 'Good view', 5),
       ];
 
-      expect(listSavedViews(tags)).toEqual([{ id: 'good', name: 'Good view', createdAt: 5 }]);
+      expect(listSavedViews(tags)).toEqual([{ id: 'good', name: 'Good view', createdAt: 5, updatedAt: 5 }]);
     });
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/savedViewEnvelope.ts
@@ -12,6 +12,9 @@ import { EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX } from '../../../constants'
 export interface SavedViewEnvelope {
   name: string;
   createdAt: number;
+  // When the view was last overwritten in place. Absent on views written before overwrite existed
+  // (and by callers that never overwrite, e.g. runs / V3); decode defaults it to `createdAt`.
+  updatedAt: number;
   // The compressed (or, for forward-compat, plain-JSON) serialized view state.
   state: string;
 }
@@ -23,6 +26,8 @@ export interface SavedViewSummary {
   id: string;
   name: string;
   createdAt: number;
+  // Present for callers that overwrite views (traces V4); the runs / V3 lists ignore it.
+  updatedAt?: number;
 }
 
 export const getSavedViewTagKey = (id: string): string => `${EXPERIMENT_PAGE_VIEW_STATE_SHARE_TAG_PREFIX}${id}`;
@@ -42,10 +47,17 @@ export const getSavedViewIdFromTagKey = (tagKey: string): string | null => {
  * (typically deflate-compressed) view-state blob; it is stored verbatim so the name/createdAt stay
  * readable without decompression.
  */
-export const encodeSavedViewEnvelope = (name: string, compressedState: string, createdAt: number): string =>
-  JSON.stringify({ name, createdAt, state: compressedState } satisfies SavedViewEnvelope);
+// `updatedAt` is optional so callers that never overwrite (runs / V3) can keep the 3-arg form; it
+// defaults to `createdAt` for a freshly-created view.
+export const encodeSavedViewEnvelope = (
+  name: string,
+  compressedState: string,
+  createdAt: number,
+  updatedAt: number = createdAt,
+): string => JSON.stringify({ name, createdAt, updatedAt, state: compressedState } satisfies SavedViewEnvelope);
 
-const isValidEnvelope = (value: unknown): value is SavedViewEnvelope =>
+// `updatedAt` is validated loosely (may be absent on legacy tags); decode fills it from `createdAt`.
+const isValidEnvelope = (value: unknown): value is Omit<SavedViewEnvelope, 'updatedAt'> & { updatedAt?: unknown } =>
   typeof value === 'object' &&
   value !== null &&
   typeof (value as SavedViewEnvelope).name === 'string' &&
@@ -55,7 +67,8 @@ const isValidEnvelope = (value: unknown): value is SavedViewEnvelope =>
 /**
  * Parse an experiment-tag value into a saved-view envelope. Throws if the value is not valid JSON
  * or is missing required fields; the `state` field is left compressed (deserialize lazily via
- * {@link deserializePersistedState}).
+ * {@link deserializePersistedState}). A missing/invalid `updatedAt` falls back to `createdAt`, so
+ * views written before overwrite existed decode cleanly.
  */
 export const decodeSavedViewEnvelope = (tagValue: string): SavedViewEnvelope => {
   const parsed = JSON.parse(tagValue);
@@ -64,7 +77,8 @@ export const decodeSavedViewEnvelope = (tagValue: string): SavedViewEnvelope => 
       'Invalid saved-view envelope: expected an object with a string `name`, number `createdAt`, and string `state`',
     );
   }
-  return { name: parsed.name, createdAt: parsed.createdAt, state: parsed.state };
+  const updatedAt = typeof parsed.updatedAt === 'number' ? parsed.updatedAt : parsed.createdAt;
+  return { name: parsed.name, createdAt: parsed.createdAt, updatedAt, state: parsed.state };
 };
 
 /**
@@ -99,8 +113,8 @@ export const listSavedViews = (tags: KeyValueEntity[]): SavedViewSummary[] =>
       return views;
     }
     try {
-      const { name, createdAt } = decodeSavedViewEnvelope(value);
-      views.push({ id, name, createdAt });
+      const { name, createdAt, updatedAt } = decodeSavedViewEnvelope(value);
+      views.push({ id, name, createdAt, updatedAt });
     } catch {
       // Skip a corrupt/legacy tag value rather than failing the entire list.
     }

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -651,10 +651,6 @@
     "defaultMessage": "No tags found.",
     "description": "Text for no tags found in editable form table in MLflow"
   },
-  "0jvNkS": {
-    "defaultMessage": "+ Save current view...",
-    "description": "Menu item that opens the modal to save the current view"
-  },
   "0ktvTS": {
     "defaultMessage": "Trace archival retention unit",
     "description": "Label for trace archival retention unit selector"
@@ -2046,6 +2042,10 @@
   "6vII7y": {
     "defaultMessage": "Cancel",
     "description": "A cancel label for the modal used for deleting logged models"
+  },
+  "6wOiP1": {
+    "defaultMessage": "This view is too large to save.",
+    "description": "Error toast shown when overwriting a saved traces view exceeds the experiment-tag size limit"
   },
   "6x1oqv": {
     "defaultMessage": "Safety",
@@ -3707,10 +3707,6 @@
     "defaultMessage": "Diff highlighting is not supported in Markdown view. Switch to Text view to see differences.",
     "description": "Warning message shown in prompt comparison view when markdown rendering is enabled"
   },
-  "DSBiYz": {
-    "defaultMessage": "Discard",
-    "description": "Experiment page > shared view banner > button that discards the shared view and restores the user's own view"
-  },
   "DSu+/R": {
     "defaultMessage": "Select reviewers",
     "description": "Review queue: reviewers dropdown label"
@@ -3814,6 +3810,10 @@
   "E/HEEL": {
     "defaultMessage": "Title",
     "description": "MCP compare title heading"
+  },
+  "E1nBWS": {
+    "defaultMessage": "Overwrite \"{name}\"",
+    "description": "Menu item that overwrites the active saved view with the current, edited state"
   },
   "E2V1sV": {
     "defaultMessage": "Light",
@@ -4475,6 +4475,10 @@
     "defaultMessage": "URL Variables",
     "description": "MCP server remote URL variables heading"
   },
+  "H6aarx": {
+    "defaultMessage": "Reset to saved",
+    "description": "Menu item that discards unsaved edits and re-applies the active saved view's stored state"
+  },
   "H7JwOl": {
     "defaultMessage": "Delete version",
     "description": "A label for a button to delete prompt version on the prompt details page"
@@ -4766,10 +4770,6 @@
   "IFJQom": {
     "defaultMessage": "{count, plural, one {# question} other {# questions}} selected",
     "description": "Create review queue: questions dropdown selected-count summary"
-  },
-  "IHcFdC": {
-    "defaultMessage": "This view is now your default.",
-    "description": "Traces page > shared view > confirmation toast after adopting a shared view as the own view"
   },
   "IHyeUr": {
     "defaultMessage": "Stage",
@@ -6411,6 +6411,10 @@
     "defaultMessage": "New run",
     "description": "Button used to pop up a modal to create a new run"
   },
+  "PEZbvU": {
+    "defaultMessage": "Overwrite view",
+    "description": "Menu item that overwrites the active saved view with the current state (no name available)"
+  },
   "PGbCZD": {
     "defaultMessage": "Production",
     "description": "Column title for production phase version in the registered model page"
@@ -6826,10 +6830,6 @@
   "QybNk9": {
     "defaultMessage": "Next unreviewed",
     "description": "Review focused view: jump to the next pending trace"
-  },
-  "QzRwbK": {
-    "defaultMessage": "Discard shared view",
-    "description": "Menu item that discards the currently-applied shared view and restores the user's own view"
   },
   "R+r9jY": {
     "defaultMessage": "Cancel issue detection?",
@@ -8003,6 +8003,10 @@
     "defaultMessage": "— model returns valid JSON.",
     "description": "Description of the JSON mode in the response_format info popover"
   },
+  "VrWPeb": {
+    "defaultMessage": "View \"{name}\" updated.",
+    "description": "Success toast shown after overwriting a saved traces view with the current state"
+  },
   "VrxfuC": {
     "defaultMessage": "Usage example",
     "description": "A title of the modal showing the usage example of the prompt"
@@ -8042,6 +8046,10 @@
   "W2PfF7": {
     "defaultMessage": "Stop sequences",
     "description": "Label for the stop-sequences input on the playground parameters panel"
+  },
+  "W5o4+R": {
+    "defaultMessage": "Exit shared view",
+    "description": "Experiment page > shared view banner > button that stops previewing the shared view and restores the user's own view"
   },
   "W60/kq": {
     "defaultMessage": "regression",
@@ -9227,6 +9235,10 @@
     "defaultMessage": "{count} {count, plural, one {minute} other {minutes}}",
     "description": "Formatted trace archival retention in minutes"
   },
+  "aiIzz9": {
+    "defaultMessage": "Save as new view",
+    "description": "Menu item that opens the modal to save the current view"
+  },
   "akmaST": {
     "defaultMessage": "Irrelevant",
     "description": "Evaluation results > retrieval relevancy assessment > negative value label. Displayed if evaluation result is considered as irrelevant to the query."
@@ -9983,10 +9995,6 @@
     "defaultMessage": "You cannot select rows when comparing runs",
     "description": "Tooltip message for the select button when comparing runs"
   },
-  "ds98nh": {
-    "defaultMessage": "You're viewing a shared view. Changes you make won't be saved unless you override your view.",
-    "description": "Traces page > shared view banner > message shown while a shared view is applied"
-  },
   "dsPent": {
     "defaultMessage": "Headers ({count})",
     "description": "MCP server remote headers heading with count"
@@ -10118,10 +10126,6 @@
   "eIdMWq": {
     "defaultMessage": "Reset example",
     "description": "Reset example button"
-  },
-  "eIk7yy": {
-    "defaultMessage": "You're viewing a shared view",
-    "description": "Heading above the override/discard actions in the saved views menu, shown while a shared view is applied"
   },
   "eLgTRT": {
     "defaultMessage": "Key",
@@ -11035,6 +11039,10 @@
     "defaultMessage": "Create",
     "description": "Confirm button text for create workspace modal"
   },
+  "hZ9EVM": {
+    "defaultMessage": "Saved views",
+    "description": "Header at the top of the saved views dropdown"
+  },
   "hZFbZl": {
     "defaultMessage": "Issue detection canceled",
     "description": "Issue detection progress > Step label when canceled"
@@ -11602,6 +11610,10 @@
   "jemjRR": {
     "defaultMessage": "Input",
     "description": "Header for the traces table input column"
+  },
+  "jgkxSk": {
+    "defaultMessage": "Exit shared view",
+    "description": "Menu item that stops previewing the currently-applied shared view and restores the user's own view"
   },
   "jhgu6C": {
     "defaultMessage": "A unique identifier for the session or conversation for grouping traces",
@@ -12562,10 +12574,6 @@
   "nYSJgH": {
     "defaultMessage": "Show all parent spans",
     "description": "Checkbox label for a setting that enables showing all parent spans in the trace explorer regardless of filter conditions."
-  },
-  "nZAOFL": {
-    "defaultMessage": "Override my view",
-    "description": "Traces page > shared view banner > button that adopts the shared view into the user's own view"
   },
   "naivho": {
     "defaultMessage": "of",


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24828

### What changes are proposed in this pull request?

Three changes to **Traces V4** saved views, on top of #24828:

1. **Match the managed dropdown (V4 only)** — the V4 Views menu adopts the managed Traces V4 dirty-mode model: an applied view that diverges shows a dirty dot plus `Overwrite "{name}"` / `Reset to saved`. This replaces V4's read-only preview overlay — **V4 no longer has a preview mode.**
2. **Capture the popover filter model (V4)** — a view now stores, restores, and diffs its filter clauses (validated against live fields on restore so a since-removed field/operator is dropped rather than stranding the view dirty).
3. **Migrate legacy V3 views into V4** — V3-authored views (`mlflow.traceViewState.` tags) appear in the V4 Views list, open via the existing `translateV3ViewState` shim, and can be deleted. Overwriting a V3 view migrates it forward: the edited state is written under the V4 prefix (same id) and the old V3 tag is deleted.

**Classic ML runs (and the legacy V3 traces tab) keep the existing preview / shared-view model** — they still use `Override` / `Exit shared view`, not the new dirty-mode actions. The shared `SavedViewsMenu` gains the dirty-mode branch (V4-only, opt-in via `dirtyViewActive`) and three cosmetic tweaks that also apply to runs: the dropdown aligns to `start`, a "Saved views" header, and the banner button relabelled `Discard` → `Exit shared view`.

### How is this PR tested?



- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Filters are saved

https://github.com/user-attachments/assets/2f4c057b-9eb1-481d-8fd1-db1410d8991e

Grouped by session is saved

https://github.com/user-attachments/assets/98d7e4f9-c9be-4cf9-9db1-0c4b25cd7952

Classic ML has no regression


https://github.com/user-attachments/assets/7b8db37a-c8fb-488a-8fea-7ff1da54d8f1



Sharing works

https://github.com/user-attachments/assets/2160c21b-9c00-4bee-a216-1f3b85e79939

Saved view Creation

https://github.com/user-attachments/assets/5dce323d-866b-4c87-8e3f-8557eb31917c


Saved view Deletion

https://github.com/user-attachments/assets/f208c5bb-7c02-4a65-99af-46e137c628d1


Saved view Override



https://github.com/user-attachments/assets/2f696df0-472e-4744-80f8-d872e7b3935b




### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release