### PR TITLE
fix: Add future annotations to telemetry schema for Python 3.6 compatibility (closes #5474)

### DIFF
--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import platform
 import sys


### PR DESCRIPTION
## What

As reported in #5474, using MLflow 1.22.0 on Python 3.6.10 with SageMaker deployment leads to a `TypeError` when importing or using the telemetry schema module. The error occurs because the code uses PEP 585 type hints like `dict[str, Any]`, which are not supported at runtime in Python 3.6. This causes a failure in type checking for string objects and prevents the model from serving requests.

## Fix

Add `from __future__ import annotations` at the top of `mlflow/telemetry/schemas.py`. This makes all type annotations lazy (strings) and compatible with Python 3.6, while preserving the modern syntax for newer Python versions.

Closes #5474