### PR TITLE
fix: Make initial table creation idempotent to prevent migration failure (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,9 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    # Only create tables that don't already exist to avoid errors like "Table 'secrets' already exists"
+    # when upgrading from a prior version where the table was introduced without a proper Alembic migration.
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When upgrading MLflow from 3.7.0 to 3.8.x, running `mlflow db upgrade` can fail with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This happens because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` without `checkfirst=True`, which attempts to create all initial tables even if they already exist in the database (e.g., from a partial migration or an earlier failed upgrade). The new `secrets` table was added to the initial models, but the database already has it from a prior attempt, causing the migration to fail.

## Fix
Modify `_initialize_tables` to pass `checkfirst=True` to `create_all`, so that it only creates missing tables. This makes the initialization idempotent and prevents the duplicate table error while still creating all required tables on a fresh database. The subsequent `_upgrade_db` call will handle applying any remaining Alembic migrations.

Closes #19943