### PR TITLE
feat(typescript): add logExpectation and logAssessment for trace assessments

### DIFF
--- a/libs/typescript/README.md
+++ b/libs/typescript/README.md
@@ -165,6 +165,64 @@ console.log(info.assessments);
 
 Databricks Unity Catalog V4 assessment posting is not included in this first slice.
 
+Log a ground-truth expectation on a persisted trace (Python `mlflow.log_expectation` parity):
+
+```typescript
+import { AssessmentSourceType, MlflowClient, createAuthProvider } from '@mlflow/core';
+
+const trackingUri = 'http://localhost:5000';
+const client = new MlflowClient({
+  trackingUri,
+  authProvider: createAuthProvider({ trackingUri }),
+});
+
+await client.logExpectation({
+  traceId: '<trace-id>',
+  name: 'expected_answer',
+  value: 'Paris',
+  source: { sourceType: AssessmentSourceType.HUMAN, sourceId: 'annotator@example.com' },
+  rationale: 'Verified against authoritative source.',
+});
+
+// The expectation value can be any JSON-serializable type:
+await client.logExpectation({
+  traceId: '<trace-id>',
+  name: 'expected_message',
+  value: {
+    role: 'assistant',
+    content: 'The answer is 42.',
+    tool_calls: [{ id: '1234', type: 'function' }],
+  },
+});
+
+const info = await client.getTraceInfo('<trace-id>');
+console.log(info.assessments); // contains typed Expectation instances
+```
+
+Use `logAssessment` as a generic dispatcher when holding a `Feedback` or `Expectation`
+instance (Python `mlflow.log_assessment` parity):
+
+```typescript
+import { Expectation, Feedback, MlflowClient, createAuthProvider } from '@mlflow/core';
+
+const client = new MlflowClient({
+  trackingUri: 'http://localhost:5000',
+  authProvider: createAuthProvider({ trackingUri: 'http://localhost:5000' }),
+});
+
+// Dispatches to logExpectation internally
+await client.logAssessment({
+  traceId: '<trace-id>',
+  assessment: new Expectation({ name: 'expected_answer', value: 'Paris' }),
+});
+
+// Dispatches to logFeedback internally
+await client.logAssessment({
+  traceId: '<trace-id>',
+  assessment: new Feedback({ name: 'correctness', value: 0.9 }),
+});
+```
+
 Tag spans with a severity level so users (or you) can filter by **Minimum log level** in the trace UI:
 
 ```typescript

--- a/libs/typescript/core/src/clients/client.ts
+++ b/libs/typescript/core/src/clients/client.ts
@@ -17,10 +17,14 @@ import {
   AssessmentSourceType,
   assertFeedbackPayload,
   assertMetadataStringMap,
+  Expectation,
   Feedback,
+  isFeedback,
+  isExpectation,
   standardizeSourceType,
   type AssessmentError,
   type AssessmentSource,
+  type ExpectationValueType,
   type FeedbackValueType,
 } from '../core/entities/assessment';
 import { makeRawRequest, makeRequest, MlflowHttpError } from './utils';
@@ -379,6 +383,116 @@ export class MlflowClient {
       payload,
     );
     return Feedback.fromJson(response.assessment);
+  }
+
+  /**
+   * Log a ground-truth expectation on a persisted trace via the V3 assessments API.
+   * Corresponds to Python `mlflow.log_expectation`.
+   *
+   * Unlike `logFeedback`, expectations always require a `value` and do not accept
+   * an `error` field — they represent known-correct labels, not scored quality signals.
+   *
+   * Databricks Unity Catalog V4 assessment posting is not included in this method.
+   *
+   * @example
+   * ```typescript
+   * await client.logExpectation({
+   *   traceId: '<trace-id>',
+   *   name: 'expected_answer',
+   *   value: 'Paris',
+   *   source: { sourceType: AssessmentSourceType.HUMAN, sourceId: 'annotator@example.com' },
+   *   rationale: 'Verified against authoritative source.',
+   * });
+   * ```
+   */
+  async logExpectation(params: {
+    traceId: string;
+    name?: string;
+    value: ExpectationValueType;
+    source?: AssessmentSource;
+    rationale?: string;
+    metadata?: Record<string, string>;
+    spanId?: string;
+  }): Promise<Expectation> {
+    const metadata = assertMetadataStringMap(params.metadata);
+    const source = params.source
+      ? {
+          sourceType: standardizeSourceType(params.source.sourceType),
+          sourceId: params.source.sourceId || 'default',
+        }
+      : { sourceType: AssessmentSourceType.HUMAN, sourceId: 'default' };
+
+    const expectation = new Expectation({
+      name: params.name,
+      value: params.value,
+      source,
+      rationale: params.rationale,
+      metadata,
+      spanId: params.spanId,
+      traceId: params.traceId,
+    });
+
+    const url = CreateAssessment.getEndpoint(this.hostUrl, params.traceId);
+    const payload: CreateAssessment.Request = { assessment: expectation.toJson() };
+    const response = await makeRequest<CreateAssessment.Response>(
+      'POST',
+      url,
+      this.headersProvider,
+      payload,
+    );
+    return Expectation.fromJson(response.assessment);
+  }
+
+  /**
+   * Log any assessment (Feedback or Expectation) on a persisted trace.
+   * Thin dispatcher for Python `mlflow.log_assessment` parity.
+   *
+   * - Pass a `Feedback` instance   → internally calls `logFeedback`
+   * - Pass an `Expectation` instance → internally calls `logExpectation`
+   *
+   * @example
+   * ```typescript
+   * import { Expectation, Feedback } from '@mlflow/core';
+   *
+   * await client.logAssessment({
+   *   traceId: '<trace-id>',
+   *   assessment: new Expectation({ name: 'expected_answer', value: 'Paris' }),
+   * });
+   * ```
+   */
+  async logAssessment(params: {
+    traceId: string;
+    assessment: Feedback | Expectation;
+  }): Promise<Feedback | Expectation> {
+    const { traceId, assessment } = params;
+
+    if (isFeedback(assessment)) {
+      return this.logFeedback({
+        traceId,
+        name: assessment.name,
+        value: assessment.value,
+        error: assessment.error,
+        source: assessment.source,
+        rationale: assessment.rationale,
+        metadata: assessment.metadata,
+        spanId: assessment.spanId,
+      });
+    }
+
+    if (isExpectation(assessment)) {
+      return this.logExpectation({
+        traceId,
+        name: assessment.name,
+        value: assessment.value,
+        source: assessment.source,
+        rationale: assessment.rationale,
+        metadata: assessment.metadata,
+        spanId: assessment.spanId,
+      });
+    }
+
+    // TypeScript exhaustiveness guard — should never reach here at runtime
+    throw new Error('logAssessment: assessment must be a Feedback or Expectation instance.');
   }
 
   // === EXPERIMENT METHODS  ===

--- a/libs/typescript/core/src/core/entities/assessment.ts
+++ b/libs/typescript/core/src/core/entities/assessment.ts
@@ -21,6 +21,9 @@ export type FeedbackValueType =
   | FeedbackPrimitive[]
   | { [key: string]: FeedbackPrimitive | FeedbackValueType };
 
+/** Expectation values use the same primitive types as Feedback (Python parity). */
+export type ExpectationValueType = FeedbackValueType;
+
 /** Matches Python `mlflow.entities.assessment_error` truncation. */
 export const STACK_TRACE_TRUNCATION_PREFIX = '[Stack trace is truncated]\n...\n';
 export const STACK_TRACE_TRUNCATION_LENGTH = 10000;
@@ -52,6 +55,10 @@ export interface SerializedFeedbackValue {
   error?: SerializedAssessmentError;
 }
 
+export interface SerializedExpectationValue {
+  value?: unknown;
+}
+
 export interface SerializedAssessment {
   assessment_id?: string;
   assessment_name: string;
@@ -61,7 +68,7 @@ export interface SerializedAssessment {
   create_time?: string;
   last_update_time?: string;
   feedback?: SerializedFeedbackValue;
-  expectation?: unknown;
+  expectation?: SerializedExpectationValue;
   issue?: unknown;
   rationale?: string;
   error?: SerializedAssessmentError;
@@ -201,10 +208,136 @@ export class Feedback {
   }
 }
 
-export type Assessment = Feedback | SerializedAssessment;
+export type Assessment = Feedback | Expectation | SerializedAssessment;
 
 export function isFeedback(assessment: Assessment): assessment is Feedback {
   return assessment instanceof Feedback;
+}
+
+export function isExpectation(assessment: Assessment): assessment is Expectation {
+  return assessment instanceof Expectation;
+}
+
+// ─── Expectation ──────────────────────────────────────────────────────────────
+
+/**
+ * Represents a ground-truth label attached to a trace.
+ * Corresponds to Python `mlflow.entities.Expectation`.
+ *
+ * Wire format places the value under the `expectation` key:
+ *   { "expectation": { "value": <any JSON-serializable value> } }
+ *
+ * Unlike Feedback, Expectation always requires a `value` (no `error` field).
+ */
+export class Expectation {
+  name: string;
+  source: AssessmentSource;
+  value: ExpectationValueType;
+  traceId?: string;
+  spanId?: string;
+  rationale?: string;
+  metadata?: Record<string, string>;
+  assessmentId?: string;
+  createTime?: string;
+  lastUpdateTime?: string;
+  overrides?: string;
+  valid?: boolean;
+
+  constructor(params: {
+    name?: string;
+    source?: AssessmentSource;
+    value: ExpectationValueType;
+    traceId?: string;
+    spanId?: string;
+    rationale?: string;
+    metadata?: Record<string, string>;
+    assessmentId?: string;
+    createTime?: string;
+    lastUpdateTime?: string;
+    overrides?: string;
+    valid?: boolean;
+  }) {
+    this.name = params.name ?? 'expectation';
+    // Expectations default to HUMAN source — ground-truth annotations are human-authored
+    this.source = params.source
+      ? {
+          sourceType: standardizeSourceType(params.source.sourceType),
+          sourceId: params.source.sourceId || 'default',
+        }
+      : { sourceType: AssessmentSourceType.HUMAN, sourceId: 'default' };
+    this.value = params.value;
+    this.traceId = params.traceId;
+    this.spanId = params.spanId;
+    this.rationale = params.rationale;
+    this.metadata = params.metadata;
+    this.assessmentId = params.assessmentId;
+    this.createTime = params.createTime;
+    this.lastUpdateTime = params.lastUpdateTime;
+    this.overrides = params.overrides;
+    this.valid = params.valid;
+  }
+
+  toJson(): SerializedAssessment {
+    const json: SerializedAssessment = {
+      assessment_name: this.name,
+      source: {
+        source_type: this.source.sourceType,
+        source_id: this.source.sourceId,
+      },
+      expectation: { value: this.value },
+    };
+    if (this.assessmentId != null) {
+      json.assessment_id = this.assessmentId;
+    }
+    if (this.traceId != null) {
+      json.trace_id = this.traceId;
+    }
+    if (this.spanId != null) {
+      json.span_id = this.spanId;
+    }
+    if (this.createTime != null) {
+      json.create_time = this.createTime;
+    }
+    if (this.lastUpdateTime != null) {
+      json.last_update_time = this.lastUpdateTime;
+    }
+    if (this.rationale != null) {
+      json.rationale = this.rationale;
+    }
+    if (this.metadata != null) {
+      json.metadata = this.metadata;
+    }
+    if (this.overrides != null) {
+      json.overrides = this.overrides;
+    }
+    if (this.valid != null) {
+      json.valid = this.valid;
+    }
+    return json;
+  }
+
+  static fromJson(json: SerializedAssessment): Expectation {
+    const expectationValue = json.expectation as SerializedExpectationValue | undefined;
+    return new Expectation({
+      name: json.assessment_name,
+      source: json.source
+        ? {
+            sourceType: standardizeSourceType(json.source.source_type),
+            sourceId: json.source.source_id || 'default',
+          }
+        : undefined,
+      value: expectationValue?.value as ExpectationValueType,
+      traceId: json.trace_id,
+      spanId: json.span_id,
+      rationale: json.rationale,
+      metadata: json.metadata,
+      assessmentId: json.assessment_id,
+      createTime: json.create_time,
+      lastUpdateTime: json.last_update_time,
+      overrides: json.overrides,
+      valid: json.valid,
+    });
+  }
 }
 
 /** Truncate stack traces the same way as Python `AssessmentError.to_proto`. */
@@ -234,11 +367,14 @@ export function assessmentFromJson(json: SerializedAssessment): Assessment {
   if (json.feedback) {
     return Feedback.fromJson(json);
   }
+  if (json.expectation) {
+    return Expectation.fromJson(json);
+  }
   return json;
 }
 
 export function assessmentToJson(assessment: Assessment): SerializedAssessment {
-  if (assessment instanceof Feedback) {
+  if (assessment instanceof Feedback || assessment instanceof Expectation) {
     return assessment.toJson();
   }
   return assessment;

--- a/libs/typescript/core/src/core/entities/trace_info.ts
+++ b/libs/typescript/core/src/core/entities/trace_info.ts
@@ -10,6 +10,7 @@ import {
   assessmentFromJson,
   assessmentToJson,
   isFeedback,
+  isExpectation,
   type Assessment,
   type SerializedAssessment,
 } from './assessment';
@@ -188,10 +189,10 @@ export class TraceInfo {
 }
 
 function normalizeAssessment(assessment: Assessment | SerializedAssessment): Assessment {
-  if (isFeedback(assessment)) {
+  if (isFeedback(assessment) || isExpectation(assessment)) {
     return assessment;
   }
-  return assessmentFromJson(assessment);
+  return assessmentFromJson(assessment as SerializedAssessment);
 }
 
 export interface SerializedTraceInfo {

--- a/libs/typescript/core/src/index.ts
+++ b/libs/typescript/core/src/index.ts
@@ -36,9 +36,11 @@ export type { Trace } from './core/entities/trace';
 export type { TraceInfo, TokenUsage } from './core/entities/trace_info';
 export {
   AssessmentSourceType,
+  Expectation,
   Feedback,
   assessmentFromJson,
   assessmentToJson,
+  isExpectation,
   isFeedback,
 } from './core/entities/assessment';
 export type {
@@ -46,8 +48,10 @@ export type {
   AssessmentError,
   AssessmentSource,
   AssessmentSourceTypeName,
+  ExpectationValueType,
   FeedbackValueType,
   SerializedAssessment,
+  SerializedExpectationValue,
 } from './core/entities/assessment';
 export type { TraceData } from './core/entities/trace_data';
 export type { TraceLocation, UnityCatalogLocation } from './core/entities/trace_location';

--- a/libs/typescript/core/tests/clients/client.test.ts
+++ b/libs/typescript/core/tests/clients/client.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import * as mlflow from '../../src';
 import { MlflowClient, type SearchTracesOptions } from '../../src/clients/client';
 import type { ArtifactsClient } from '../../src/clients/artifacts';
-import { Feedback } from '../../src/core/entities/assessment';
+import { Expectation, Feedback } from '../../src/core/entities/assessment';
 import { Trace } from '../../src/core/entities/trace';
 import { TraceData } from '../../src/core/entities/trace_data';
 import { TraceInfo } from '../../src/core/entities/trace_info';
@@ -184,6 +184,139 @@ describe('MlflowClient', () => {
           source: { sourceType: 'ROBOT' as 'HUMAN', sourceId: 'bot' },
         }),
       ).rejects.toThrow(/Invalid assessment source type/);
+    });
+  });
+
+  describe('logExpectation', () => {
+    const experimentLocation = () => ({
+      type: TraceLocationType.MLFLOW_EXPERIMENT,
+      mlflowExperiment: { experimentId: experimentId },
+    });
+
+    it('logs an expectation and reads it back from getTraceInfo', async () => {
+      const traceId = randomUUID();
+      await client.createTrace(
+        new TraceInfo({
+          traceId,
+          traceLocation: experimentLocation(),
+          state: TraceState.OK,
+          requestTime: 1000,
+        }),
+      );
+
+      const created = await client.logExpectation({
+        traceId,
+        name: 'expected_answer',
+        value: 'Paris',
+        source: { sourceType: 'HUMAN', sourceId: 'annotator@example.com' },
+        rationale: 'Verified against atlas',
+        metadata: { dataset: 'geography-v1' },
+      });
+
+      expect(created).toBeInstanceOf(Expectation);
+      expect(created.name).toBe('expected_answer');
+      expect(created.value).toBe('Paris');
+      expect(created.assessmentId).toBeDefined();
+
+      const retrieved = await client.getTraceInfo(traceId);
+      expect(retrieved.assessments.length).toBeGreaterThanOrEqual(1);
+
+      const expectation = retrieved.assessments.find(
+        (a) => a instanceof Expectation && a.name === 'expected_answer',
+      ) as Expectation | undefined;
+
+      expect(expectation).toBeDefined();
+      expect(expectation?.value).toBe('Paris');
+      expect(expectation?.source.sourceType).toBe('HUMAN');
+    });
+
+    it('logs an expectation with a complex object value', async () => {
+      const traceId = randomUUID();
+      await client.createTrace(
+        new TraceInfo({
+          traceId,
+          traceLocation: experimentLocation(),
+          state: TraceState.OK,
+          requestTime: 1000,
+        }),
+      );
+
+      const complexValue = { role: 'assistant', content: 'The answer is 42.' };
+      const created = await client.logExpectation({
+        traceId,
+        name: 'expected_message',
+        value: complexValue,
+      });
+
+      expect(created).toBeInstanceOf(Expectation);
+      expect(created.value).toEqual(complexValue);
+    });
+
+    it('rejects an invalid source type', async () => {
+      await expect(
+        client.logExpectation({
+          traceId: randomUUID(),
+          name: 'bad-source',
+          value: 'hello',
+          source: { sourceType: 'ROBOT' as 'HUMAN', sourceId: 'bot' },
+        }),
+      ).rejects.toThrow(/Invalid assessment source type/);
+    });
+  });
+
+  describe('logAssessment', () => {
+    const experimentLocation = () => ({
+      type: TraceLocationType.MLFLOW_EXPERIMENT,
+      mlflowExperiment: { experimentId: experimentId },
+    });
+
+    async function makeTrace() {
+      const traceId = randomUUID();
+      await client.createTrace(
+        new TraceInfo({
+          traceId,
+          traceLocation: experimentLocation(),
+          state: TraceState.OK,
+          requestTime: 1000,
+        }),
+      );
+      return traceId;
+    }
+
+    it('dispatches a Feedback instance to logFeedback', async () => {
+      const traceId = await makeTrace();
+      const feedback = new Feedback({ name: 'correctness', value: true });
+
+      const result = await client.logAssessment({ traceId, assessment: feedback });
+
+      expect(result).toBeInstanceOf(Feedback);
+      expect((result as Feedback).value).toBe(true);
+    });
+
+    it('dispatches an Expectation instance to logExpectation', async () => {
+      const traceId = await makeTrace();
+      const expectation = new Expectation({ name: 'expected_answer', value: 'Paris' });
+
+      const result = await client.logAssessment({ traceId, assessment: expectation });
+
+      expect(result).toBeInstanceOf(Expectation);
+      expect((result as Expectation).value).toBe('Paris');
+    });
+
+    it('preserves source, rationale and metadata when dispatching via logAssessment', async () => {
+      const traceId = await makeTrace();
+      const expectation = new Expectation({
+        name: 'expected_answer',
+        value: 42,
+        source: { sourceType: 'HUMAN', sourceId: 'alice' },
+        rationale: 'ground truth',
+        metadata: { suite: 'typescript' },
+      });
+
+      const result = await client.logAssessment({ traceId, assessment: expectation });
+
+      expect((result as Expectation).source.sourceId).toBe('alice');
+      expect((result as Expectation).rationale).toBe('ground truth');
     });
   });
 

--- a/libs/typescript/core/tests/core/entities/assessment.test.ts
+++ b/libs/typescript/core/tests/core/entities/assessment.test.ts
@@ -1,5 +1,6 @@
 import {
   AssessmentSourceType,
+  Expectation,
   Feedback,
   STACK_TRACE_TRUNCATION_LENGTH,
   STACK_TRACE_TRUNCATION_PREFIX,
@@ -65,14 +66,14 @@ describe('assessment entities', () => {
     expect(() => assertFeedbackPayload({ error: 'failed' })).not.toThrow();
   });
 
-  it('leaves expectation assessments opaque so TraceInfo does not drop them', () => {
+  it('parses expectation assessments to Expectation instances', () => {
     const raw = {
       assessment_name: 'expected_response',
       expectation: { value: 'Paris' },
     };
     const parsed = assessmentFromJson(raw);
-    expect(parsed).toEqual(raw);
-    expect(assessmentToJson(parsed)).toEqual(raw);
+    expect(parsed).toBeInstanceOf(Expectation);
+    expect((parsed as Expectation).value).toBe('Paris');
   });
 
   it('exports isFeedback for public Assessment narrowing', () => {

--- a/libs/typescript/core/tests/core/entities/expectation.test.ts
+++ b/libs/typescript/core/tests/core/entities/expectation.test.ts
@@ -1,0 +1,147 @@
+﻿import {
+  AssessmentSourceType,
+  Expectation,
+  assessmentFromJson,
+  assessmentToJson,
+  isExpectation,
+  isFeedback,
+} from '../../../src/core/entities/assessment';
+
+describe('Expectation entity', () => {
+  it('serializes expectation to proto JSON snake_case with expectation key', () => {
+    const expectation = new Expectation({
+      name: 'expected_answer',
+      value: 'Paris',
+      source: { sourceType: AssessmentSourceType.HUMAN, sourceId: 'annotator@example.com' },
+      rationale: 'Verified against atlas',
+      metadata: { dataset: 'geography-v1' },
+      traceId: 'tr-1',
+    });
+
+    expect(expectation.toJson()).toEqual({
+      assessment_name: 'expected_answer',
+      source: { source_type: 'HUMAN', source_id: 'annotator@example.com' },
+      trace_id: 'tr-1',
+      rationale: 'Verified against atlas',
+      metadata: { dataset: 'geography-v1' },
+      expectation: { value: 'Paris' },
+    });
+  });
+
+  it('serializes complex expectation values (objects, arrays)', () => {
+    const complexValue = {
+      role: 'assistant',
+      content: 'The answer is 42.',
+      score: 0.95,
+    };
+
+    const expectation = new Expectation({ name: 'expected_message', value: complexValue });
+    const json = expectation.toJson();
+
+    expect(json.expectation).toEqual({ value: complexValue });
+    expect(json.feedback).toBeUndefined();
+  });
+
+  it('round-trips fromJson to toJson', () => {
+    const parsed = Expectation.fromJson({
+      assessment_id: 'a-1',
+      assessment_name: 'expected_answer',
+      trace_id: 'tr-2',
+      source: { source_type: 'HUMAN', source_id: 'alice' },
+      expectation: { value: 42 },
+      rationale: 'ground truth',
+      valid: true,
+    });
+
+    expect(parsed).toBeInstanceOf(Expectation);
+    expect(parsed.value).toBe(42);
+    expect(parsed.assessmentId).toBe('a-1');
+    expect(parsed.rationale).toBe('ground truth');
+    expect(parsed.valid).toBe(true);
+
+    const json = parsed.toJson();
+    expect(json.expectation).toEqual({ value: 42 });
+    expect(json.feedback).toBeUndefined();
+  });
+
+  it('defaults to HUMAN source type (Python parity for ground-truth annotations)', () => {
+    const expectation = new Expectation({ name: 'expected_answer', value: 'Paris' });
+    expect(expectation.source.sourceType).toBe(AssessmentSourceType.HUMAN);
+    expect(expectation.source.sourceId).toBe('default');
+  });
+
+  it('isExpectation returns true for Expectation, false for Feedback and opaque objects', () => {
+    const exp = new Expectation({ name: 'expected_answer', value: 'Paris' });
+    const opaque = { assessment_name: 'feedback_item', feedback: { value: true } };
+
+    expect(isExpectation(exp)).toBe(true);
+    expect(isFeedback(exp)).toBe(false);
+    expect(isExpectation(opaque)).toBe(false);
+  });
+
+  it('assessmentFromJson dispatches expectation key to Expectation instance', () => {
+    const raw = {
+      assessment_name: 'expected_response',
+      expectation: { value: 'Paris' },
+    };
+
+    const parsed = assessmentFromJson(raw);
+    expect(parsed).toBeInstanceOf(Expectation);
+    expect((parsed as Expectation).value).toBe('Paris');
+  });
+
+  it('assessmentFromJson keeps unknown payloads opaque', () => {
+    const raw = {
+      assessment_name: 'some_issue',
+      issue: { issue_id: 'ISS-001' },
+    };
+
+    const parsed = assessmentFromJson(raw);
+    expect(parsed).toEqual(raw);
+    expect(assessmentToJson(parsed)).toEqual(raw);
+  });
+
+  it('assessmentToJson round-trips an Expectation via toJson', () => {
+    const exp = new Expectation({
+      name: 'expected_answer',
+      value: true,
+      source: { sourceType: 'CODE', sourceId: 'eval-script' },
+    });
+
+    const json = assessmentToJson(exp);
+    expect(json.expectation).toEqual({ value: true });
+    expect(json.feedback).toBeUndefined();
+  });
+
+  it('preserves absent optional fields (no spurious keys in output)', () => {
+    const expectation = new Expectation({ name: 'minimal', value: 'hello' });
+    const json = expectation.toJson();
+
+    expect(json.assessment_id).toBeUndefined();
+    expect(json.trace_id).toBeUndefined();
+    expect(json.span_id).toBeUndefined();
+    expect(json.rationale).toBeUndefined();
+    expect(json.metadata).toBeUndefined();
+    expect(json.feedback).toBeUndefined();
+  });
+
+  it('maps deprecated AI_JUDGE to LLM_JUDGE in source', () => {
+    const exp = new Expectation({
+      name: 'expected_answer',
+      value: 'Paris',
+      source: { sourceType: 'AI_JUDGE' as 'LLM_JUDGE', sourceId: 'judge' },
+    });
+    expect(exp.source.sourceType).toBe(AssessmentSourceType.LLM_JUDGE);
+  });
+
+  it('rejects invalid source types', () => {
+    expect(
+      () =>
+        new Expectation({
+          name: 'test',
+          value: 'x',
+          source: { sourceType: 'ROBOT' as 'HUMAN', sourceId: 'bot' },
+        }),
+    ).toThrow(/Invalid assessment source type/);
+  });
+});


### PR DESCRIPTION
### Related Issues/PRs

Closes #25411
Follow-up to #25169

### What changes are proposed in this pull request?

Implements Phase A from #25411 for `@mlflow/core`:

- **`Expectation` Entity**: Typed `Expectation` class (`libs/typescript/core/src/core/entities/assessment.ts`) with `toJson`/`fromJson` round-trips for the `expectation: { value: ... }` wire format (proto JSON snake_case). Defaults `source` to `HUMAN` (matching Python `Expectation`).
- **Type Guards & Deserialization**: Added `isExpectation` guard and updated `assessmentFromJson` & `TraceInfo.normalizeAssessment` to parse `expectation` payloads into typed `Expectation` instances.
- **Client Methods**: Added `MlflowClient.logExpectation(...)` (OSS V3) and generic `MlflowClient.logAssessment(...)` (dispatches `Feedback` vs `Expectation`) to mirror Python `mlflow.log_expectation` and `mlflow.log_assessment`.
- **Public Exports**: Exported `Expectation`, `isExpectation`, `ExpectationValueType`, and `SerializedExpectationValue` from `@mlflow/core`.
- **Documentation**: Updated `libs/typescript/README.md` with usage examples.

### How is this PR tested?

Focused unit tests & verification under `libs/typescript`:
- `npm run build:core` (clean compilation, zero errors)
- `npm run format:check` (clean formatting, 100% Prettier compliant)
- `npx jest tests/core/entities/` (10 test suites, 82 unit tests passed including new `expectation.test.ts`)
- New tests in `expectation.test.ts` and `client.test.ts` covering proto JSON serialization, `Expectation` entity round-tripping, `isExpectation` guard, `logExpectation` success path, and `logAssessment` dispatcher.

### Does this PR require documentation update?

Yes, updated `libs/typescript/README.md` with `logExpectation` and `logAssessment` examples.

### Release Notes

#### Is this a user-facing change?

Yes. Adds TypeScript `@mlflow/core` support for logging ground-truth expectations (`logExpectation`) and generic assessment dispatching (`logAssessment`), aligning with Python `mlflow.log_expectation` and `mlflow.log_assessment` for OSS tracking servers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components: `area/tracing`, `area/evaluation`, `area/build`, `area/docs`

#### How should the PR be classified in the release notes?

`rn/feature`
