### PR TITLE
Bump `astral-sh/setup-uv` to v10.0.1 to retry transient manifest fetches

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -58,7 +58,7 @@ runs:
     - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ steps.get-python-version.outputs.version }}
-    - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+    - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         version: "0.11.14"
         # Caching disabled to avoid cache-poisoning exposure across CI workflows.

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -151,7 +151,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: false
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25416

### What changes are proposed in this pull request?

Bump `astral-sh/setup-uv` from v9.0.0 to v10.0.1 at both call sites (`.github/actions/setup-python/action.yml`, `.github/workflows/nailaopus.yml`).

v9.0.0 fetches the uv version manifest exactly once, so a single network blip fails the job before any code runs. Observed on #25416, where the `r` job died during Python setup on a TypeScript-only diff:

```
Fetching manifest data from https://raw.githubusercontent.com/astral-sh/versions/main/v1/uv.ndjson ...
##[error]fetch failed
```

[v10.0.1](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.1) ("Tolerate transient manifest timeouts", astral-sh/setup-uv#1016) wraps that fetch in a retry: up to 3 attempts with backoff, catching any thrown network error. It does not retry HTTP error statuses, but the failure above is a thrown `fetch failed`, so it is covered.

v10.0.0's breaking change only affects `enable-cache: auto`, and we set `enable-cache: false`, so the major bump is a no-op here.

### How is this PR tested?

- [x] Existing unit/integration tests

CI exercises the bumped action on every job in this PR.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
