### PR TITLE
Use the shared `setup-python` action in `nailaopus.yml`

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -117,6 +117,16 @@ jobs:
             --repo "$REPO" \
             --add-label nailaopus-reviewed || true
 
+      - name: Checkout base repo
+        # Needed so `./.github/actions/setup-python` below resolves: GitHub only
+        # finds local actions under the workspace root. This is the base repo at
+        # the default branch, never PR head, so the composite action we execute
+        # is never PR-author-controlled. Must run before the checkouts below,
+        # which land in subdirectories that a root checkout would clean away.
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Checkout PR head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -150,10 +160,8 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
           persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-        with:
-          enable-cache: false
+      - name: Set up Python and uv
+        uses: ./.github/actions/setup-python
 
       - name: Install ripgrep
         run: |


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25417

### What changes are proposed in this pull request?

`nailaopus.yml` installed uv directly, so `astral-sh/setup-uv` was pinned in two places and had to be bumped in both (as #25417 just did). Route it through `./.github/actions/setup-python` instead, leaving a single pin in the repo.

Two consequences worth reviewing:

- Local actions only resolve under the workspace root, so this needs a root checkout. It is deliberately the base repo at the default branch, not PR head: running a composite action from PR head in a workflow that holds the App installation token would be a pwn-request. It also has to be ordered before the existing checkouts, since a root checkout cleans the workspace and would wipe the `mlflow/` and `internal/` trees.
- The workflow now inherits the shared action's env vars, notably `UV_EXCLUDE_NEWER=P7D`. That matches repo-wide supply-chain policy, but it does constrain what `uv run --directory internal/nailaopus` resolves. If the orchestrator has a lockfile this is a no-op; otherwise a dependency released in the last 7 days would no longer be picked. Flagging since `mlflow/internal` isn't visible here.

Stacked on #25417 to keep the diff clean; retarget to `master` once that merges.

### How is this PR tested?

- [x] Manual tests

`pre-commit run --files .github/workflows/nailaopus.yml` passes, including `check-github-workflows`, `check-actions` and `conftest` (policy.rego). The workflow itself only runs on a `/review-v2` comment, so it cannot be exercised by CI on this PR.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release