### PR TITLE
Document the shared setup actions in the GitHub Actions rules

### DIFF
--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -60,6 +60,32 @@ use `gh` CLI instead of `actions/github-script`. It avoids the need for
     gh pr comment ...
 ```
 
+## Prefer the Shared Setup Actions
+
+Set up toolchains through the composite actions in `.github/actions/` rather than
+calling the upstream actions directly. Each one centralizes the pinned version and
+the env defaults every job expects, so an upstream bump stays a one-line change
+instead of a repo-wide sweep.
+
+| Toolchain       | Action                           |
+| --------------- | -------------------------------- |
+| Python and `uv` | `./.github/actions/setup-python` |
+| Node            | `./.github/actions/setup-node`   |
+| Java            | `./.github/actions/setup-java`   |
+
+```yaml
+# Bad: a second copy of the pin to keep in sync, and no uv or env defaults
+- uses: actions/setup-python@...
+
+# Good
+- uses: ./.github/actions/setup-python
+```
+
+Local action paths resolve relative to `$GITHUB_WORKSPACE`, so a workflow that
+checks the repo out into a subdirectory needs that prefix
+(`./mlflow/.github/actions/setup-python`). Never point it at a PR head checkout:
+that runs author-controlled code with whatever secrets the workflow holds.
+
 ## Use `sparse-checkout` When Only a Subset of Files Is Needed
 
 When a workflow only needs a small subset of the repo (e.g., a single script under `.github/`), pass `sparse-checkout` to `actions/checkout` instead of cloning the whole tree. A full checkout of this repo takes around 10 seconds on average; a sparse checkout finishes in a fraction of that.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25417

### What changes are proposed in this pull request?

Add a "Prefer the Shared Setup Actions" entry to `.claude/rules/github-actions.md`, pointing at `./.github/actions/setup-python`, `setup-node` and `setup-java` instead of the upstream actions.

This codifies what the repo already does: 28 workflows use the shared `setup-python`, 14 use `setup-node`, 11 use `setup-java`, and nothing calls `actions/setup-python` or `actions/setup-node` directly. It was just never written down, so a new workflow can add a second copy of a pin without anything flagging it. #25417 is the cost of that: a one-line upstream bump had to touch two files.

The entry also records the constraint that makes this not always possible: GitHub only resolves local actions under the workspace root, so a workflow that checks out solely into subdirectories has to keep calling the upstream action directly. That is the case for `nailaopus.yml`, the one current exception.

### How is this PR tested?

- [x] Manual tests

Documentation only, no behavior change. `pre-commit run --files .claude/rules/github-actions.md` passes.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release