### PR TITLE
Use the shared `setup-python` action in `nailaopus.yml`

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -28,7 +28,9 @@ runs:
       run: |
         python_version="$PYTHON_VERSION_INPUT"
         if [ -z "$python_version" ]; then
-          python_version=$(cat .python-version)
+          # Relative to the action, so callers that check out into a
+          # subdirectory still resolve it.
+          python_version=$(cat "$GITHUB_ACTION_PATH/../../../.python-version")
         fi
         if [[ "$PIN_MICRO_VERSION" == "true" ]]; then
           if [[ "$python_version" == "3.10" ]]; then

--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -150,10 +150,9 @@ jobs:
           token: ${{ steps.app_token.outputs.token }}
           persist-credentials: false
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-        with:
-          enable-cache: false
+      # PR head code. Safe only because the job gate limits this workflow to
+      # maintainer-authored PRs.
+      - uses: ./mlflow/.github/actions/setup-python
 
       - name: Install ripgrep
         run: |


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25417, #25419. Supersedes #25418.

### What changes are proposed in this pull request?

`nailaopus.yml` installed uv directly, so `astral-sh/setup-uv` was pinned in two places and had to be bumped in both (#25417). Route it through the shared composite action instead, leaving a single pin.

- `setup-python`: resolve the `.python-version` fallback from `$GITHUB_ACTION_PATH` instead of the working directory, so the action stops assuming the caller checked out at the workspace root. A no-op for existing callers, which all do.
- `nailaopus.yml`: swap the `astral-sh/setup-uv` step for `uses: ./mlflow/.github/actions/setup-python`.

That path is PR head, i.e. author-controlled code. It is safe only because the job gate limits this workflow to maintainer-authored PRs. #25418 added a root checkout to avoid touching PR head, which that gate makes unnecessary.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

The `setup-python` change is covered by CI here, since nearly every job uses it.

The `nailaopus.yml` change is not: `issue_comment` workflows run from the default branch, so CI cannot reach it. Verified on a throwaway push-triggered branch mirroring the checkout layout, where the action resolved through the subdirectory prefix and installed Python and uv. Branch deleted.

One thing to check before merging: the workflow now inherits `UV_EXCLUDE_NEWER=P7D`, which constrains what `uv run --directory internal/nailaopus` resolves. A no-op if the orchestrator has a lockfile, but `mlflow/internal` isn't visible here.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
