### PR TITLE
Capture assessment-column visibility in Traces V4 saved views

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
@@ -88,6 +88,8 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
     resetColumns,
     setFilterModel: controller.setFilterModel,
     assessmentNames: assessments.candidateNames,
+    assessmentVisibility: assessments.visibilityByName,
+    setAssessmentVisibility: assessments.setVisibility,
   });
 
   const handleHideColumn = useCallback(

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
@@ -45,8 +45,9 @@ const makeV4ViewTag = async (
   query = 'q=x',
   cols: TraceColumnId[] = ['start_time'],
   filters: TraceFilterModel = [],
+  assessments: Record<string, boolean> = {},
 ) => {
-  const state = captureV4ViewState(new URLSearchParams(query), cols, filters);
+  const state = captureV4ViewState(new URLSearchParams(query), cols, filters, assessments);
   const compressed = await textCompressDeflate(JSON.stringify(state));
   return { key: `mlflow.tracesV4ViewState.${id}`, value: encodeSavedViewEnvelope(name, compressed, createdAt) };
 };
@@ -342,12 +343,15 @@ describe('useTracesV4SavedViews dirty / overwrite / reset', () => {
   // Report BOTH the hook API and the live URL search each render, so assertions read the in-memory
   // router's state (TestRouter never touches window.location.hash) after a param rewrite.
   const setFilterModel = jest.fn();
+  const setAssessmentVisibility = jest.fn();
   const DirtyProbe = ({
     onRender,
     filterModel = [],
+    assessmentVisibility = {},
   }: {
     onRender: (s: any, search: string) => void;
     filterModel?: TraceFilterModel;
+    assessmentVisibility?: Record<string, boolean>;
   }) => {
     const savedViews = useTracesV4SavedViews({
       experimentId: 'exp-1',
@@ -356,6 +360,8 @@ describe('useTracesV4SavedViews dirty / overwrite / reset', () => {
       setColumns,
       resetColumns: jest.fn(),
       setFilterModel,
+      assessmentVisibility,
+      setAssessmentVisibility,
     });
     const [params] = useSearchParams();
     onRender(savedViews, params.toString());
@@ -366,12 +372,13 @@ describe('useTracesV4SavedViews dirty / overwrite / reset', () => {
     entry: string,
     onRender: (s: any, search: string) => void,
     filterModel: TraceFilterModel = [],
+    assessmentVisibility: Record<string, boolean> = {},
   ) =>
     render(
       <IntlProvider locale="en">
         <DesignSystemProvider>
           <MockedReduxStoreProvider>
-            <DirtyProbe onRender={onRender} filterModel={filterModel} />
+            <DirtyProbe onRender={onRender} filterModel={filterModel} assessmentVisibility={assessmentVisibility} />
           </MockedReduxStoreProvider>
         </DesignSystemProvider>
       </IntlProvider>,
@@ -528,6 +535,27 @@ describe('useTracesV4SavedViews dirty / overwrite / reset', () => {
     });
     expect(setFilterModel).toHaveBeenLastCalledWith([]);
     await waitFor(() => expect(state.dirtyStatus).toBe('clean'));
+  });
+
+  test('opening a view restores its stored assessment-column visibility', async () => {
+    // v1 stored with one assessment hidden; opening it must push the full map into the live store.
+    mockExperiment([
+      await makeV4ViewTag('v1', 'Known', 1000, 'q=x', ['start_time'], [], { correctness: true, relevance: false }),
+    ]);
+    let state: any;
+    renderProbeAt('/', (s) => (state = s));
+    await act(async () => {
+      await state.openView('v1');
+    });
+    expect(setAssessmentVisibility).toHaveBeenCalledWith({ correctness: true, relevance: false });
+  });
+
+  test('an assessment-visibility divergence from the stored view reads as dirty', async () => {
+    // v1 stored with correctness visible; the probe's live map hides it → dirty.
+    mockExperiment([await makeV4ViewTag('v1', 'Known', 1000, 'q=x', ['start_time'], [], { correctness: true })]);
+    let state: any;
+    renderProbeAt(`/?q=x&${TRACE_V4_SHARE_URL_PARAM_KEY}=v1`, (s) => (state = s), [], { correctness: false });
+    await waitFor(() => expect(state.dirtyStatus).toBe('dirty'));
   });
 });
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
@@ -103,6 +103,13 @@ interface UseTracesV4SavedViewsParams {
   setFilterModel: (next: TraceFilterModel) => void;
   /** Candidate assessment names, so restored assessment-filter clauses validate against live fields. */
   assessmentNames?: string[];
+  /**
+   * Live assessment-column visibility by name (localStorage-backed, not URL) — captured into a view on
+   * save and diffed for dirty. Defaults to an empty map so a page with no assessments captures nothing.
+   */
+  assessmentVisibility?: Record<string, boolean>;
+  /** Restores a view's assessment visibility (overwrites the override map); used by open / reset. */
+  setAssessmentVisibility?: (visibility: Record<string, boolean> | undefined) => void;
 }
 
 /**
@@ -119,6 +126,8 @@ export const useTracesV4SavedViews = ({
   resetColumns,
   setFilterModel,
   assessmentNames = [],
+  assessmentVisibility = {},
+  setAssessmentVisibility,
 }: UseTracesV4SavedViewsParams) => {
   const dispatch = useDispatch<ThunkDispatch>();
   const intl = useIntl();
@@ -211,8 +220,9 @@ export const useTracesV4SavedViews = ({
         );
         return null;
       }
-      // Capture the current URL view params + the live columns and filter model (neither in the URL).
-      const state = captureV4ViewState(searchParams, visibleColumns, filterModel);
+      // Capture the current URL view params + the live columns, filter model and assessment-column
+      // visibility (none of the latter three ride in the URL).
+      const state = captureV4ViewState(searchParams, visibleColumns, filterModel, assessmentVisibility);
       const compressedState = await textCompressDeflate(JSON.stringify(state));
       const id = getUUID();
       const envelope = encodeSavedViewEnvelope(name.trim(), compressedState, Date.now());
@@ -230,7 +240,18 @@ export const useTracesV4SavedViews = ({
       await refetch();
       return { id, state };
     },
-    [dispatch, experimentId, refetch, searchParams, visibleColumns, filterModel, views, atCap, intl],
+    [
+      dispatch,
+      experimentId,
+      refetch,
+      searchParams,
+      visibleColumns,
+      filterModel,
+      assessmentVisibility,
+      views,
+      atCap,
+      intl,
+    ],
   );
 
   const deleteView = useCallback(
@@ -305,8 +326,11 @@ export const useTracesV4SavedViews = ({
         setColumns(columns);
       }
       setFilterModel(supportedFilters(state.filters));
+      // Restore assessment-column visibility (localStorage, not URL). An older view without the field
+      // clears overrides rather than leaving the previous view's visibility applied on top.
+      setAssessmentVisibility?.(state.assessmentColumns);
     },
-    [setSearchParams, setColumns, setFilterModel, supportedFilters],
+    [setSearchParams, setColumns, setFilterModel, supportedFilters, setAssessmentVisibility],
   );
 
   // Return to the default state: drop every view param, clear the non-URL surfaces (columns +
@@ -367,7 +391,7 @@ export const useTracesV4SavedViews = ({
       if (!existing) {
         return;
       }
-      const state = captureV4ViewState(searchParams, visibleColumns, filterModel);
+      const state = captureV4ViewState(searchParams, visibleColumns, filterModel, assessmentVisibility);
       const compressedState = await textCompressDeflate(JSON.stringify(state));
       const envelope = encodeSavedViewEnvelope(existing.name, compressedState, existing.createdAt, Date.now());
       if (envelope.length > MAX_TAG_VALUE_LENGTH) {
@@ -399,7 +423,7 @@ export const useTracesV4SavedViews = ({
         3,
       );
     },
-    [views, searchParams, visibleColumns, filterModel, dispatch, experimentId, refetch, intl],
+    [views, searchParams, visibleColumns, filterModel, assessmentVisibility, dispatch, experimentId, refetch, intl],
   );
 
   // Discard live edits: re-apply the active view's stored state (which also restores its columns).
@@ -435,12 +459,13 @@ export const useTracesV4SavedViews = ({
           setColumns(columns);
         }
         setFilterModel(supportedFilters(state.filters));
+        setAssessmentVisibility?.(state.assessmentColumns);
       }
     });
     return () => {
       cancelled = true;
     };
-  }, [activeViewId, decodeViewState, setColumns, setFilterModel, supportedFilters]);
+  }, [activeViewId, decodeViewState, setColumns, setFilterModel, supportedFilters, setAssessmentVisibility]);
 
   // Dirty = the live table (URL view params + columns) diverges from the active view's stored state.
   // Treated as clean until the stored state is loaded AND columns are hydrated, so it never flashes
@@ -449,7 +474,7 @@ export const useTracesV4SavedViews = ({
     if (!activeViewId || !activeStoredState || hydratedViewIdRef.current !== activeViewId) {
       return 'clean';
     }
-    const live = captureV4ViewState(searchParams, visibleColumns, filterModel);
+    const live = captureV4ViewState(searchParams, visibleColumns, filterModel, assessmentVisibility);
     // Normalize the stored baseline's filters the same way openView restores them (drop unsupported
     // clauses); diffing raw stored filters would mark a view with a since-removed field dirty forever.
     const normalizedStored: CapturedV4ViewState = {
@@ -457,7 +482,15 @@ export const useTracesV4SavedViews = ({
       filters: supportedFilters(activeStoredState.filters),
     };
     return capturedV4StatesMatch(live, normalizedStored) ? 'clean' : 'dirty';
-  }, [activeViewId, activeStoredState, searchParams, visibleColumns, filterModel, supportedFilters]);
+  }, [
+    activeViewId,
+    activeStoredState,
+    searchParams,
+    visibleColumns,
+    filterModel,
+    assessmentVisibility,
+    supportedFilters,
+  ]);
 
   // Opening a saved-view link in a tab whose experiment was loaded before the view was saved reads a
   // stale Apollo tag cache (a client-side nav doesn't refetch). The view still applies (its state

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4AssessmentColumns.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4AssessmentColumns.ts
@@ -112,12 +112,23 @@ export const useTracesV4AssessmentColumns = (
 
   const reset = useCallback(() => setOverrides({}), [setOverrides]);
 
-  // Union candidate names with the override keys: candidates alone miss a hidden name that has since
-  // dropped off the page (no traces carry it), which must still be recorded as hidden in a saved view.
+  // Effective visibility for the page's candidate assessments, plus any off-page name that is
+  // explicitly hidden. A hidden name that has dropped off the page (no traces carry it) must still be
+  // recorded so a saved view keeps hiding it; but an off-page name that's visible is left out — absent
+  // already means default-visible, and carrying it would let the stored map accumulate stale `true`
+  // entries across save/restore cycles.
   const visibilityByName = useMemo(() => {
     const visible = new Set(visibleNames);
-    const names = new Set([...candidateNames, ...Object.keys(overrides)]);
-    return Object.fromEntries([...names].map((name) => [name, overrides[name] ?? visible.has(name)]));
+    const result: Record<string, boolean> = {};
+    for (const name of candidateNames) {
+      result[name] = overrides[name] ?? visible.has(name);
+    }
+    for (const [name, isVisible] of Object.entries(overrides)) {
+      if (!(name in result) && isVisible === false) {
+        result[name] = false;
+      }
+    }
+    return result;
   }, [candidateNames, visibleNames, overrides]);
 
   const setVisibility = useCallback(

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4AssessmentColumns.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4AssessmentColumns.ts
@@ -30,10 +30,17 @@ export interface TracesV4AssessmentColumns {
   selectorOptions: GenericColumnOption[];
   /** Namespaced ids of the currently-visible assessment columns. */
   visibleIds: string[];
+  /** Effective visibility by assessment name; captured into a saved view (see the `useMemo` below). */
+  visibilityByName: Record<string, boolean>;
   /** Toggle an assessment column's visibility by its namespaced id. */
   toggle: (id: string) => void;
   /** Show or hide every candidate assessment column at once (the "all assessments" toggle). */
   setAllVisible: (visible: boolean) => void;
+  /**
+   * Restore a saved view's assessment visibility (overwrites the override map). `undefined` clears
+   * overrides (returns every column to its default), matching an older view that captured nothing.
+   */
+  setVisibility: (visibility: Record<string, boolean> | undefined) => void;
   /** Clear all assessment overrides (return every column to its default visibility). */
   reset: () => void;
 }
@@ -105,5 +112,28 @@ export const useTracesV4AssessmentColumns = (
 
   const reset = useCallback(() => setOverrides({}), [setOverrides]);
 
-  return { columnDefs, candidateNames, selectorOptions, visibleIds, toggle, setAllVisible, reset };
+  // Union candidate names with the override keys: candidates alone miss a hidden name that has since
+  // dropped off the page (no traces carry it), which must still be recorded as hidden in a saved view.
+  const visibilityByName = useMemo(() => {
+    const visible = new Set(visibleNames);
+    const names = new Set([...candidateNames, ...Object.keys(overrides)]);
+    return Object.fromEntries([...names].map((name) => [name, overrides[name] ?? visible.has(name)]));
+  }, [candidateNames, visibleNames, overrides]);
+
+  const setVisibility = useCallback(
+    (visibility: Record<string, boolean> | undefined) => setOverrides(visibility ?? {}),
+    [setOverrides],
+  );
+
+  return {
+    columnDefs,
+    candidateNames,
+    selectorOptions,
+    visibleIds,
+    visibilityByName,
+    toggle,
+    setAllVisible,
+    setVisibility,
+    reset,
+  };
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.test.ts
@@ -3,10 +3,14 @@ import { capturedV4StatesMatch, __test__ } from './tracesV4DirtyState';
 import { captureV4ViewState } from './tracesV4SavedViewState';
 import { FilterOp, type TraceColumnId, type TraceFilterModel } from '@databricks/web-shared/traces-table';
 
-const { canonicalViewQuery, columnSetsEqual } = __test__;
+const { canonicalViewQuery, columnSetsEqual, assessmentVisibilityEqual } = __test__;
 
-const capture = (query: string, cols: TraceColumnId[] = [], filters: TraceFilterModel = []) =>
-  captureV4ViewState(new URLSearchParams(query), cols, filters);
+const capture = (
+  query: string,
+  cols: TraceColumnId[] = [],
+  filters: TraceFilterModel = [],
+  assessments: Record<string, boolean> = {},
+) => captureV4ViewState(new URLSearchParams(query), cols, filters, assessments);
 
 describe('capturedV4StatesMatch', () => {
   test('identical captures match (clean)', () => {
@@ -61,6 +65,12 @@ describe('capturedV4StatesMatch', () => {
     expect(capturedV4StatesMatch(grouped, flat)).toBe(false);
     expect(capturedV4StatesMatch(grouped, capture('q=x&groupBy=session', ['start_time']))).toBe(true);
   });
+
+  test('hiding an assessment column is dirty', () => {
+    const a = capture('q=x', ['start_time'], [], { correctness: true });
+    const b = capture('q=x', ['start_time'], [], { correctness: false });
+    expect(capturedV4StatesMatch(a, b)).toBe(false);
+  });
 });
 
 describe('canonicalViewQuery', () => {
@@ -97,5 +107,14 @@ describe('columnSetsEqual', () => {
     expect(columnSetsEqual(['a', 'b'], ['b', 'a'])).toBe(true);
     expect(columnSetsEqual(['a'], ['a', 'b'])).toBe(false);
     expect(columnSetsEqual(['a', 'b'], ['a', 'c'])).toBe(false);
+  });
+});
+
+describe('assessmentVisibilityEqual', () => {
+  test('compares effective visibility — an absent name is default-visible', () => {
+    expect(assessmentVisibilityEqual({ a: true }, {})).toBe(true);
+    expect(assessmentVisibilityEqual({ a: true, b: true }, { a: true })).toBe(true);
+    expect(assessmentVisibilityEqual({ a: false }, {})).toBe(false);
+    expect(assessmentVisibilityEqual({ a: false }, { a: true })).toBe(false);
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.ts
@@ -73,11 +73,29 @@ const colsOf = (state: CapturedV4ViewState): string[] => {
   return raw ? raw.split(',').filter(Boolean) : [];
 };
 
+/**
+ * Compare EFFECTIVE assessment visibility, not the key sets. Visibility is page-derived, so captures
+ * on different pages carry different names; an absent name means default-visible, so an extra
+ * default-visible entry isn't a change — only a real hide/show reads as dirty. (Two captures across
+ * pages with different assessments may still diverge, but the dirty dot is advisory and both
+ * Overwrite / Reset recover.)
+ */
+const assessmentVisibilityEqual = (a: Record<string, boolean> = {}, b: Record<string, boolean> = {}): boolean => {
+  const names = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const name of names) {
+    if ((a[name] ?? true) !== (b[name] ?? true)) {
+      return false;
+    }
+  }
+  return true;
+};
+
 /** True when the live captured state matches the stored view (i.e. not dirty). */
 export const capturedV4StatesMatch = (live: CapturedV4ViewState, stored: CapturedV4ViewState): boolean =>
   canonicalViewQuery(live) === canonicalViewQuery(stored) &&
   columnSetsEqual(colsOf(live), colsOf(stored)) &&
+  assessmentVisibilityEqual(live.assessmentColumns, stored.assessmentColumns) &&
   isEqual(live.filters ?? [], stored.filters ?? []);
 
 // Exported for unit-testing the pure comparisons in isolation.
-export const __test__ = { canonicalViewQuery, columnSetsEqual };
+export const __test__ = { canonicalViewQuery, columnSetsEqual, assessmentVisibilityEqual };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.test.ts
@@ -88,6 +88,19 @@ describe('captureV4ViewState', () => {
     expect(noFilters.filters).toBeUndefined();
   });
 
+  test('captures assessment-column visibility, omitting an empty map', () => {
+    // An empty map is omitted so a view saved with no assessments stays byte-identical to a legacy one.
+    const withAssessments = captureV4ViewState(params('q=x'), ['start_time'], [], {
+      correctness: true,
+      relevance: false,
+    });
+    expect(withAssessments.assessmentColumns).toEqual({ correctness: true, relevance: false });
+    expect(params(buildV4ViewQuery(withAssessments, 'view-1')).has('assessmentColumns')).toBe(false);
+
+    const noAssessments = captureV4ViewState(params('q=x'), ['start_time'], [], {});
+    expect(noAssessments.assessmentColumns).toBeUndefined();
+  });
+
   test('never captures an incoming share key or cols param from the URL (only the live columns)', () => {
     // Opening view A then saving must not leak A's share key / cols into view B.
     const state = captureV4ViewState(params(`q=x&cols=tokens,cost&${TRACE_V4_SHARE_URL_PARAM_KEY}=other-view`), [

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.ts
@@ -49,6 +49,10 @@ export interface CapturedV4ViewState {
   // validation pass (see `isSupportedFilterClause`) so a clause referencing a since-removed
   // field/operator is dropped rather than silently producing wrong results.
   filters?: TraceFilterModel;
+  // Assessment-column visibility by assessment name (localStorage-backed, not URL). A full map, not a
+  // visible-id list, so a hidden column is recorded too — restoring a bare id list would lose explicit
+  // hides. Absent in older stored views (treated as "capture nothing", i.e. clear overrides on restore).
+  assessmentColumns?: Record<string, boolean>;
 }
 
 export const getTraceV4SavedViewTagKey = (id: string): string => `${TRACE_V4_SAVED_VIEW_TAG_PREFIX}${id}`;
@@ -86,6 +90,7 @@ export const captureV4ViewState = (
   params: URLSearchParams,
   visibleColumns: readonly TraceColumnId[],
   filterModel: TraceFilterModel = [],
+  assessmentColumns: Record<string, boolean> = {},
 ): CapturedV4ViewState => {
   const single: CapturedV4ViewState['single'] = {};
   SINGLE_VALUE_KEYS.forEach((key) => {
@@ -107,6 +112,11 @@ export const captureV4ViewState = (
   const state: CapturedV4ViewState = { single, multi };
   if (filterModel.length > 0) {
     state.filters = filterModel;
+  }
+  // Omit an empty map so a view saved on a page with no assessments stays byte-identical to a legacy
+  // one (and never spuriously reads as dirty against `assessmentColumns ?? {}`).
+  if (Object.keys(assessmentColumns).length > 0) {
+    state.assessmentColumns = assessmentColumns;
   }
   return state;
 };


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25407

### Background: this is a port-fidelity fix, not a new feature

Traces V4 originated in the Databricks monorepo, where saved views have always captured **four** surfaces: URL params, standard columns, the filter model, and assessment-column visibility (`CapturedTraceViewState.assessmentColumns`). OSS Traces V4 is a staged port of that code (#24827 → #24828 → the saved-views restyle in #25407). When #25407 ported saved views, it carried over columns and filters but left assessment visibility behind — so this closes a gap between OSS and managed rather than adding behavior managed lacks.

The likely reason it slipped: in OSS, assessment visibility lives in a *separate* localStorage store (`useTracesV4AssessmentColumns`), decoupled from the main column store, so it wasn't in the obvious capture path the way columns and filters were. Managed already solves exactly this — its saved-views controller explicitly threads `visibilityByName`/`setVisibility` through capture/apply/dirty *because* it's a separate store — so this PR mirrors that existing managed implementation 1:1.

### What changes are proposed in this pull request?

Traces V4 saved views persist URL params, standard-column visibility and the popover filter model — but they dropped **assessment-column visibility**. A view saved with an assessment column hidden reopened with that column shown, because assessment visibility lives in its own localStorage store (`useTracesV4AssessmentColumns`) that was never threaded into the view capture/restore path. Managed (Databricks) V4 saved views already capture this; this PR ports that behavior into OSS so the two stay at parity.

Assessment visibility is now the fourth non-URL surface a view captures (alongside columns and the filter model):

- **`useTracesV4AssessmentColumns`** — exposes `visibilityByName` (the full effective map: candidate names ∪ overridden names, so a name that has been hidden but has since dropped off the page is still recorded) and a `setVisibility` restorer that overwrites the override map.
- **`CapturedV4ViewState`** — gains an optional `assessmentColumns: Record<string, boolean>`. `captureV4ViewState` stores it, omitting an empty map so a view saved on a page with no assessments stays byte-identical to a legacy one (and never spuriously reads as dirty).
- **`tracesV4DirtyState`** — `assessmentVisibilityEqual` compares *effective* visibility (an absent name means default-visible), so only a real hide/show reads as dirty, not a page carrying a different assessment set.
- **`TracesV4SavedViews`** — threads visibility through save, overwrite, apply (menu open), the cold-load share-link effect, and the dirty diff. "Default view" reset already clears assessment overrides via the existing `resetColumns` path, so no extra wiring is needed there.

A full map (not a visible-id list) is stored so an explicit hide is recorded rather than lost on restore.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New unit coverage: capture stores/omits the map (`tracesV4SavedViewState.test.ts`); `assessmentVisibilityEqual` + a hide-is-dirty case (`tracesV4DirtyState.test.ts`); restore-on-open and dirty-on-divergence (`TracesV4SavedViews.test.tsx`). 70 tests pass, `tsc --noEmit` clean.

Manual (Playwright, seeded traces with `correctness` + `relevance` feedback): hid `relevance` → saved a view → confirmed the backend tag stores `assessmentColumns: {correctness: true, relevance: false}` → re-showing `relevance` surfaced Overwrite/Reset (dirty) → Reset restored hidden → **cold-load**: cleared localStorage and hard-reloaded the bare share link, `relevance` stayed hidden and localStorage repopulated from the tag → Default view reset returned both columns to visible.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Traces V4 saved views now capture and restore assessment-column visibility, so a view saved with an assessment column hidden reopens with it hidden.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
