### PR TITLE
Fix NaiLaOpus ripgrep compatibility

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -143,7 +143,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: 5e5f9229e16b97822ea3349b31285370be36b4d1
+          ref: d6cabfbe48d238198a891120a57d998d8c4b3146
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Relates to the detected MLflow experiment issue:
https://dev.localhost:23090/ml/experiments/512285459693541/issues?o=2181382062016330&selectedIssueId=ef60c0f1015848d0a9c2b2ff5f3f9459%3Aissue-1&conf_enable=databricks.fe.mlflow.enableExperimentIssuesTab&conf_enable=databricks.fe.mlflow.enableExperimentIssuesScheduling

### What changes are proposed in this pull request?

Advance the pinned NaiLaOpus revision to include its ripgrep compatibility fix. The updated Grep wrapper uses ripgrep's `--color=never` syntax and preserves filenames, preventing repeated `unrecognized flag --no-color` failures during code reviews.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Validation performed against the pinned internal revision:

- `uv run pytest nailaopus/tests/test_tools.py -q` — 26 passed.
- The focused regression test reproduces the exact `--no-color` error on the old pin and passes on the new pin.
- A full uncached NaiLaOpus replay against affected PR 25394 completed successfully with 72 spans: one `run_review` root, both agent phases, 33 Anthropic model calls, and 10 successful Grep tool calls.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
