### PR TITLE
Tag `review.yml` gateway requests for cost attribution

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -232,9 +232,9 @@ jobs:
           # Lands in `system.ai_gateway.usage.request_tags`, so gateway spend can
           # be split by caller. `task` names the automation doing the spending,
           # not this workflow file, and is a literal so a rename cannot silently
-          # repoint it. `repo` is an expression because there the current name is
-          # the identity we want, and it keeps `task` unique across repositories.
-          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"repo":"${{ github.repository }}","task":"pr-review"}'
+          # repoint it. `repository` is an expression because there the current
+          # name is the identity we want, and it keeps `task` unique across repos.
+          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"repository":"${{ github.repository }}","task":"pr-review"}'
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -229,11 +229,6 @@ jobs:
           # The gateway's beta allowlist rejects several of the CLI's
           # experimental betas with HTTP 400.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
-          # Lands in `system.ai_gateway.usage.request_tags`, so gateway spend can
-          # be split by caller. `task` names the automation doing the spending,
-          # not this workflow file, and is a literal so a rename cannot silently
-          # repoint it. `repository` is an expression because there the current
-          # name is the identity we want, and it keeps `task` unique across repos.
           ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"repository":"${{ github.repository }}","task":"pr-review"}'
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -230,11 +230,11 @@ jobs:
           # experimental betas with HTTP 400.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           # Lands in `system.ai_gateway.usage.request_tags`, so gateway spend can
-          # be split by caller. `workflow` is a literal rather than
-          # `github.workflow`, which a rename would silently repoint; `repo` is
-          # the expression because there the current name is the identity we
-          # want, and it keeps `workflow` from colliding across repositories.
-          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"repo":"${{ github.repository }}","workflow":"pr-review"}'
+          # be split by caller. `task` names the automation doing the spending,
+          # not this workflow file, and is a literal so a rename cannot silently
+          # repoint it. `repo` is an expression because there the current name is
+          # the identity we want, and it keeps `task` unique across repositories.
+          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"repo":"${{ github.repository }}","task":"pr-review"}'
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -232,7 +232,7 @@ jobs:
           # Lands in `system.ai_gateway.usage.request_tags`, so gateway spend can
           # be split by workflow. A literal rather than `github.workflow`, which
           # a rename would silently repoint.
-          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"workflow":"pr-review","event":"${{ github.event_name }}"}'
+          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"workflow":"pr-review"}'
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -230,9 +230,11 @@ jobs:
           # experimental betas with HTTP 400.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           # Lands in `system.ai_gateway.usage.request_tags`, so gateway spend can
-          # be split by workflow. A literal rather than `github.workflow`, which
-          # a rename would silently repoint.
-          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"workflow":"pr-review"}'
+          # be split by caller. `workflow` is a literal rather than
+          # `github.workflow`, which a rename would silently repoint; `repo` is
+          # the expression because there the current name is the identity we
+          # want, and it keeps `workflow` from colliding across repositories.
+          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"repo":"${{ github.repository }}","workflow":"pr-review"}'
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -229,6 +229,10 @@ jobs:
           # The gateway's beta allowlist rejects several of the CLI's
           # experimental betas with HTTP 400.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          # Lands in `system.ai_gateway.usage.request_tags`, so gateway spend can
+          # be split by workflow. A literal rather than `github.workflow`, which
+          # a rename would silently repoint.
+          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"workflow":"pr-review","event":"${{ github.event_name }}"}'
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -196,7 +196,7 @@ jobs:
 
       # Only the short-lived bearer reaches the Claude step; the client secret
       # stays in this step.
-      - name: Mint gateway token
+      - name: Configure gateway
         id: gateway
         env:
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_GATEWAY_HOST }}
@@ -218,6 +218,8 @@ jobs:
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
           # `%/` so a trailing slash on the secret can't produce a `//` path.
           echo "base-url=${DATABRICKS_HOST%/}/ai-gateway/anthropic" >> "$GITHUB_OUTPUT"
+          TAGS=$(jq -cn --arg repository "$GITHUB_REPOSITORY" '{$repository, task: "pr-review"}')
+          echo "custom-headers=Databricks-Ai-Gateway-Request-Tags: $TAGS" >> "$GITHUB_OUTPUT"
 
       - name: Review
         id: review
@@ -226,7 +228,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
           ANTHROPIC_BASE_URL: ${{ steps.gateway.outputs.base-url }}
           ANTHROPIC_AUTH_TOKEN: ${{ steps.gateway.outputs.token }}
-          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"repository":"${{ github.repository }}","task":"pr-review"}'
+          ANTHROPIC_CUSTOM_HEADERS: ${{ steps.gateway.outputs.custom-headers }}
           # The gateway's beta allowlist rejects several of the CLI's
           # experimental betas with HTTP 400.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -226,10 +226,10 @@ jobs:
           GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
           ANTHROPIC_BASE_URL: ${{ steps.gateway.outputs.base-url }}
           ANTHROPIC_AUTH_TOKEN: ${{ steps.gateway.outputs.token }}
+          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"repository":"${{ github.repository }}","task":"pr-review"}'
           # The gateway's beta allowlist rejects several of the CLI's
           # experimental betas with HTTP 400.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
-          ANTHROPIC_CUSTOM_HEADERS: 'Databricks-Ai-Gateway-Request-Tags: {"repository":"${{ github.repository }}","task":"pr-review"}'
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #25409

### What changes are proposed in this pull request?

Gateway spend from `review.yml` is indistinguishable from every other caller sharing the service principal. This tags its requests so usage can be split:

```
Databricks-Ai-Gateway-Request-Tags: {"repository":"mlflow/mlflow","task":"pr-review"}
```

The tags land in `system.ai_gateway.usage.request_tags`, so a second consumer (issue triage, say) shows up as its own line. `task` rather than `workflow`, since the value names the skill while the workflow is named `review`; a literal, so a rename can't silently repoint attribution.

For Databricks-hosted models these rows carry token counts rather than dollars, so this buys attribution by volume, not a per-task invoice.

### How is this PR tested?

- [x] Manual tests

Ran a prompt against the real gateway with the header set and it was accepted. The `pull_request` trigger also runs `/pr-review` end to end here with Post gated off.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)






