### PR TITLE
Mount Traces V4 as the default traces experience

### DIFF
--- a/mlflow/server/js/src/common/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/common/utils/FeatureUtils.ts
@@ -34,6 +34,7 @@ export const shouldUseRegexpBasedAutoRunsSearchFilter = () => false;
 export const shouldUseRunRowsVisibilityMap = () => true;
 export const isUnstableNestedComponentsMigrated = () => true;
 export const shouldUsePredefinedErrorsInExperimentTracking = () => true;
+export const shouldUseTracesV4Tab = () => true;
 
 /**
  * Determines if logged models UI (part of model-centric IA shift) is enabled

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewTraces.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewTraces.tsx
@@ -1,6 +1,8 @@
 import { useDesignSystemTheme } from '@databricks/design-system';
 import { TracesV3View } from './traces-v3/TracesV3View';
+import { TracesV4Tab } from './traces-v4/TracesV4Tab';
 import { useGetExperimentQuery } from '../../../hooks/useExperimentQuery';
+import { shouldUseTracesV4Tab } from '../../../../common/utils/FeatureUtils';
 
 export const ExperimentViewTraces = ({ experimentIds }: { experimentIds: string[] }) => {
   const { theme } = useDesignSystemTheme();
@@ -24,6 +26,10 @@ const TracesComponent = ({ experimentIds }: { experimentIds: string[] }) => {
   const { loading: isLoadingExperiment } = useGetExperimentQuery({
     experimentId: experimentIds[0],
   });
+
+  if (shouldUseTracesV4Tab()) {
+    return <TracesV4Tab experimentId={experimentIds[0]} isLoadingExperiment={isLoadingExperiment} />;
+  }
 
   return <TracesV3View experimentIds={experimentIds} isLoadingExperiment={isLoadingExperiment} />;
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3View.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react';
 
 import { useDesignSystemTheme } from '@databricks/design-system';
 import { shouldEnableTracesTableStatePersistence } from '@databricks/web-shared/model-trace-explorer';
-import { useLocation } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import { TracesV3Logs } from './TracesV3Logs';
 import {
   MonitoringConfigProvider,
@@ -35,11 +34,6 @@ const TracesV3Content = ({
   // One useTraceSavedViews instance for both toolbar buttons: a single Apollo subscription and a
   // single `atCap` source, instead of each button opening its own subscription.
   const savedViews = useTraceSavedViews({ experimentId: experimentId || '' });
-  // The deprecated Sessions page links here with `?groupBy=session` to open the session-grouped view.
-  // TODO: Remove this V3 groupBy plumbing once the Traces tab mounts V4, which reads `?groupBy=session`
-  // natively via `useTracesV4UrlState`.
-  const { search } = useLocation();
-  const initialGroupBySession = new URLSearchParams(search).get('groupBy') === 'session';
   if (viewState === 'logs') {
     return (
       <TracesV3Logs
@@ -48,7 +42,6 @@ const TracesV3Content = ({
         endpointName={endpointName || ''}
         timeRange={timeRange}
         drawerWidth="80vw"
-        initialGroupBySession={initialGroupBySession}
         enableSavedViews
         toolbarCornerAddons={
           experimentId && <TracesV3SavedViewsButton experimentId={experimentId} savedViews={savedViews} />

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type InputRef, useDesignSystemTheme } from '@databricks/design-system';
 import { useIntl } from 'react-intl';
 import {
@@ -27,7 +27,8 @@ import { useDeleteTracesMutation } from '@mlflow/mlflow/src/experiment-tracking/
 import { AssistantAwareDrawer } from '@mlflow/mlflow/src/common/components/AssistantAwareDrawer';
 import { AssistantAwareActionBar } from '@mlflow/mlflow/src/common/components/AssistantAwareActionBar';
 import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
-import { useNavigate } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import { useNavigate, useSearchParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import { shouldEnableIssueDetection } from '@mlflow/mlflow/src/common/utils/FeatureUtils';
 import { SELECTED_TRACE_ID_QUERY_PARAM } from '@mlflow/mlflow/src/experiment-tracking/constants';
 // Reuse the generic (branding-free) "/" hotkey hook from datasets-v2.
 import { useSlashFocusSearch } from '@mlflow/mlflow/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/hooks/useSlashFocusSearch';
@@ -229,6 +230,25 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
   // selection, falling back to the most-recent page of traces when nothing is selected. Completion
   // toasts are handled globally by `IssueDetectionJobNotifications` (mounted in MlflowRouter).
   const [isIssueDetectionOpen, setIsIssueDetectionOpen] = useState(false);
+
+  // The overview and run pages deep-link here with `?detectIssues=true` to auto-open the modal.
+  // Wait for the first page so the modal seeds from real traces, then strip the param via `replace`
+  // so a refresh doesn't reopen it.
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    if (!shouldEnableIssueDetection() || searchParams.get('detectIssues') !== 'true' || page.isLoading) {
+      return;
+    }
+    setIsIssueDetectionOpen(true);
+    setSearchParams(
+      (params) => {
+        params.delete('detectIssues');
+        return params;
+      },
+      { replace: true },
+    );
+  }, [searchParams, setSearchParams, page.isLoading]);
+
   const selectedTraceIds = useMemo(() => Array.from(bulk.selected.keys()), [bulk.selected]);
   const availableTraceIds = useMemo(
     () => page.traces.map((trace) => trace.trace_id).filter((id): id is string => Boolean(id)),

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4UrlState.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4UrlState.test.tsx
@@ -136,6 +136,27 @@ describe('useTracesV4UrlState', () => {
     expect(param('traceId')).toBeNull();
   });
 
+  test('falls back to the legacy selectedEvaluationId param when traceId is absent', async () => {
+    const { result } = await mountHook('/p?selectedEvaluationId=tr-legacy');
+    expect(result.current.traceId).toBe('tr-legacy');
+  });
+
+  test('prefers traceId over selectedEvaluationId when both are present', async () => {
+    const { result } = await mountHook('/p?traceId=tr-new&selectedEvaluationId=tr-legacy');
+    expect(result.current.traceId).toBe('tr-new');
+  });
+
+  test('setTraceId normalizes the legacy selectedEvaluationId param away', async () => {
+    const { result } = await mountHook('/p?selectedEvaluationId=tr-legacy');
+    act(() => result.current.setTraceId('tr-new'));
+    expect(param('traceId')).toBe('tr-new');
+    expect(param('selectedEvaluationId')).toBeNull();
+
+    act(() => result.current.setTraceId(undefined));
+    expect(param('traceId')).toBeNull();
+    expect(param('selectedEvaluationId')).toBeNull();
+  });
+
   test('setPageIndex removes the param when set back to 1', async () => {
     const { result } = await mountHook('/p');
     act(() => result.current.setPageIndex(4));

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4UrlState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4UrlState.ts
@@ -19,6 +19,10 @@ const PAGE_SIZE_PARAM = 'pageSize';
 const SORT_PARAM = 'sort';
 const DIR_PARAM = 'dir';
 const TRACE_ID_PARAM = 'traceId';
+// v3 (and several still-live producers: the `/traces/:traceId` redirect, the issue-detection trace
+// picker, regression test-case links) open a trace by writing `?selectedEvaluationId=`. v4 reads
+// `traceId`, so honor the legacy param as a fallback and normalize it away on the next write.
+const LEGACY_TRACE_ID_PARAM = 'selectedEvaluationId';
 // Repeatable param (like v3's `filter`): each value is `encodeURIComponent(key)=encodeURIComponent(value)`.
 const TAG_PARAM = 'tag';
 // Present only when grouping is on; the single `session` value leaves room for other groupings later.
@@ -105,7 +109,7 @@ export const useTracesV4UrlState = (): TracesV4UrlState => {
   const pageSizeRaw = searchParams.get(PAGE_SIZE_PARAM);
   const sortRaw = searchParams.get(SORT_PARAM);
   const dirRaw = searchParams.get(DIR_PARAM);
-  const traceId = searchParams.get(TRACE_ID_PARAM) ?? undefined;
+  const traceId = searchParams.get(TRACE_ID_PARAM) ?? searchParams.get(LEGACY_TRACE_ID_PARAM) ?? undefined;
   const isGroupedBySession = searchParams.get(GROUP_BY_PARAM) === SESSION_GROUP_BY_VALUE;
   // getAll → the repeatable `tag` values. Memoize on the serialized params: `getAll().map().filter()`
   // returns a fresh array every render, and consumers use `tagFilters` as an effect dependency (e.g.
@@ -177,6 +181,8 @@ export const useTracesV4UrlState = (): TracesV4UrlState => {
   const setTraceId = useCallback(
     (next: string | undefined) => {
       setSearchParams((params) => {
+        // Always drop the legacy alias so it doesn't shadow future canonical writes or linger in the URL.
+        params.delete(LEGACY_TRACE_ID_PARAM);
         if (next) {
           params.set(TRACE_ID_PARAM, next);
         } else {


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24828

### What changes are proposed in this pull request?

Mounts `TracesV4Tab` as the active traces UI in `ExperimentViewTraces` behind `shouldUseTracesV4Tab` (returns `true`). `TracesV3View` is retained for the flag-off path.

Also removes the now-dead V3 `?groupBy=session` shim that was deferred in #25350: the `useLocation` import, `initialGroupBySession` variable, the TODO comment, and the prop passed to `TracesV3Logs`. V4 reads that query param natively via `useTracesV4UrlState`.

**Note:** V3→V4 saved-view migration is a known breaking change (tag prefixes and sort wire format differ; V3 views won't carry over). This must be called out at cutover.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The Traces tab now uses the V4 table (previously shipped unmounted in #24828), bringing columnar customization, saved views, and a redesigned trace drawer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release