### PR TITLE
Add configurable custom trace columns (tags + metadata) to Traces V4

### DIFF
--- a/mlflow/server/js/scripts/componentId-registry.js
+++ b/mlflow/server/js/scripts/componentId-registry.js
@@ -2159,6 +2159,7 @@ module.exports = {
   "mlflow.traces-v4.column-selector.item.cost": "",
   "mlflow.traces-v4.column-selector.item.duration": "",
   "mlflow.traces-v4.column-selector.item.input": "",
+  "mlflow.traces-v4.column-selector.item.metadata": "",
   "mlflow.traces-v4.column-selector.item.output": "",
   "mlflow.traces-v4.column-selector.item.run_name": "",
   "mlflow.traces-v4.column-selector.item.session": "",

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { type InputRef, useDesignSystemTheme } from '@databricks/design-system';
-import { useIntl } from 'react-intl';
+import { type InputRef, ColumnSplitIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { useIntl, FormattedMessage } from 'react-intl';
 import {
   createTraceV4LongIdentifier,
   ModelTraceExplorerContextProvider,
@@ -33,6 +33,7 @@ import { SELECTED_TRACE_ID_QUERY_PARAM } from '@mlflow/mlflow/src/experiment-tra
 // Reuse the generic (branding-free) "/" hotkey hook from datasets-v2.
 import { useSlashFocusSearch } from '@mlflow/mlflow/src/experiment-tracking/pages/experiment-evaluation-datasets-v2/hooks/useSlashFocusSearch';
 import { isAssessmentColumnId } from '../utils/assessmentColumns';
+import { isCustomTraceColumnId } from '../utils/customColumns';
 import { useTracesV4Controller } from '../hooks/useTracesV4Controller';
 import { useTracesV4Density } from '../hooks/useTracesV4Density';
 import { useTracesV4Notifications } from '../hooks/useTracesV4Notifications';
@@ -44,6 +45,7 @@ import { makeTracesV4ErrorDescription } from './TracesV4States';
 import { TracesV4EmptyState } from './TracesV4EmptyState';
 import { IssueDetectionModal } from '../../traces-v3/IssueDetectionModal';
 import { TracesV4SavedViewsButton, useTracesV4SavedViews } from './TracesV4SavedViews';
+import { type TraceColumnHeaderAction } from '@databricks/web-shared/traces-table';
 
 interface TracesV4PageContentProps {
   experimentId: string;
@@ -74,15 +76,27 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
   useSlashFocusSearch(searchInputRef);
 
   const controller = useTracesV4Controller({ experimentId });
-  const { url, page, columns, assessments, columnSizing, traceCount, bulk, searchInput, filterModel, flags } =
-    controller;
+  const {
+    url,
+    page,
+    columns,
+    assessments,
+    columnSizing,
+    traceCount,
+    customColumns,
+    bulk,
+    searchInput,
+    filterModel,
+    flags,
+  } = controller;
   const { density, setDensity } = useTracesV4Density(experimentId);
 
-  // One "Reset to defaults" in the column selector clears both standard and assessment overrides.
+  // One "Reset to defaults" in the column selector clears standard, assessment, and custom overrides.
   const resetColumns = useCallback(() => {
     columns.resetToDefaults();
     assessments.reset();
-  }, [columns, assessments]);
+    customColumns.reset();
+  }, [columns, assessments, customColumns]);
 
   // Saved views (dirty model): the hook reads/writes view tags, restores a view's columns into the
   // user's own column store on open, and reports whether the live table has diverged from the active
@@ -98,18 +112,47 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
     assessmentNames: assessments.candidateNames,
     assessmentVisibility: assessments.visibilityByName,
     setAssessmentVisibility: assessments.setVisibility,
+    customVisibility: customColumns.visibilityById,
+    setCustomVisibility: customColumns.setVisibility,
   });
 
   const handleHideColumn = useCallback(
     (columnId: string) => {
-      if (isAssessmentColumnId(columnId)) {
+      if (isCustomTraceColumnId(columnId)) {
+        customColumns.toggle(columnId);
+      } else if (isAssessmentColumnId(columnId)) {
         assessments.toggle(columnId);
       } else if (isStandardColumnId(columnId)) {
         columns.toggleColumn(columnId);
       }
     },
-    [assessments, columns],
+    [customColumns, assessments, columns],
   );
+
+  const columnHeaderActions = useMemo<Readonly<Partial<Record<string, TraceColumnHeaderAction>>>>(() => {
+    const actions: Partial<Record<string, TraceColumnHeaderAction>> = {};
+    if (customColumns.tags.selectorOptions.length > 0) {
+      actions['tags'] = {
+        label: intl.formatMessage({
+          defaultMessage: 'Expand tag columns',
+          description: 'Column header action for expanding tag columns',
+        }),
+        icon: <ColumnSplitIcon />,
+        onClick: () => customColumns.tags.setAllVisible(true),
+      };
+    }
+    if (customColumns.metadata.selectorOptions.length > 0) {
+      actions['metadata'] = {
+        label: intl.formatMessage({
+          defaultMessage: 'Expand metadata columns',
+          description: 'Column header action for expanding metadata columns',
+        }),
+        icon: <ColumnSplitIcon />,
+        onClick: () => customColumns.metadata.setAllVisible(true),
+      };
+    }
+    return actions;
+  }, [customColumns.tags, customColumns.metadata, intl]);
 
   const actions = useTracesV4TraceActions(experimentId, page.traces, page.refetch);
 
@@ -275,6 +318,7 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
     onToggleColumn: columns.toggleColumn,
     onResetColumns: resetColumns,
     assessmentColumns: assessments,
+    customColumns,
     sort: url.sort,
     dir: url.dir,
     onSort: url.setSort,
@@ -340,7 +384,8 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
             // Table
             traces={page.traces}
             visibleColumns={columns.visibleColumns}
-            extraColumns={assessments.columnDefs}
+            extraColumns={[...customColumns.columnDefs, ...assessments.columnDefs]}
+            columnHeaderActions={columnHeaderActions}
             initialColumnSizing={columnSizing.columnSizing}
             onColumnSizingSettled={columnSizing.setColumnSizing}
             isLoading={page.isFetching}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
@@ -161,6 +161,14 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
   // gets its expected input regardless of which page a trace was selected on.
   const selectedTraceInfos = useMemo(() => Array.from(bulk.selected.values()), [bulk.selected]);
 
+  // Combine custom (tag/metadata) and assessment column defs into one stable array — the table's
+  // `extraColumns` prop expects a stable reference, so building it inline would rebuild the columns
+  // every render.
+  const extraColumns = useMemo(
+    () => [...customColumns.columnDefs, ...assessments.columnDefs],
+    [customColumns.columnDefs, assessments.columnDefs],
+  );
+
   const deleteTracesMutation = useDeleteTracesMutation();
   const [deleteOpen, setDeleteOpen] = useState(false);
   // Snapshot ids when the modal opens so a refetch/clear mid-prompt can't zero the count or
@@ -384,7 +392,7 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
             // Table
             traces={page.traces}
             visibleColumns={columns.visibleColumns}
-            extraColumns={[...customColumns.columnDefs, ...assessments.columnDefs]}
+            extraColumns={extraColumns}
             columnHeaderActions={columnHeaderActions}
             initialColumnSizing={columnSizing.columnSizing}
             onColumnSizingSettled={columnSizing.setColumnSizing}

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.test.tsx
@@ -46,8 +46,9 @@ const makeV4ViewTag = async (
   cols: TraceColumnId[] = ['start_time'],
   filters: TraceFilterModel = [],
   assessments: Record<string, boolean> = {},
+  custom: Record<string, boolean> = {},
 ) => {
-  const state = captureV4ViewState(new URLSearchParams(query), cols, filters, assessments);
+  const state = captureV4ViewState(new URLSearchParams(query), cols, filters, assessments, custom);
   const compressed = await textCompressDeflate(JSON.stringify(state));
   return { key: `mlflow.tracesV4ViewState.${id}`, value: encodeSavedViewEnvelope(name, compressed, createdAt) };
 };
@@ -78,6 +79,7 @@ const { history } = setupTestRouter();
 
 // Shared across the button harness so tests can assert column restore on open / reset.
 const buttonSetColumns = jest.fn();
+const buttonSetCustomVisibility = jest.fn();
 const SavedViewsButtonHarness = ({ experimentId }: { experimentId: string }) => {
   const savedViews = useTracesV4SavedViews({
     experimentId,
@@ -86,6 +88,8 @@ const SavedViewsButtonHarness = ({ experimentId }: { experimentId: string }) => 
     setColumns: buttonSetColumns,
     resetColumns: jest.fn(),
     setFilterModel: jest.fn(),
+    customVisibility: {},
+    setCustomVisibility: buttonSetCustomVisibility,
   });
   return <TracesV4SavedViewsButton experimentId={experimentId} savedViews={savedViews} />;
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4SavedViews.tsx
@@ -110,6 +110,13 @@ interface UseTracesV4SavedViewsParams {
   assessmentVisibility?: Record<string, boolean>;
   /** Restores a view's assessment visibility (overwrites the override map); used by open / reset. */
   setAssessmentVisibility?: (visibility: Record<string, boolean> | undefined) => void;
+  /**
+   * Live custom-column visibility by id (localStorage-backed, not URL) — captured into a view on
+   * save and diffed for dirty. Defaults to an empty map so a page with no custom columns captures nothing.
+   */
+  customVisibility?: Record<string, boolean>;
+  /** Restores a view's custom-column visibility (overwrites the override map); used by open / reset. */
+  setCustomVisibility?: (visibility: Record<string, boolean> | undefined) => void;
 }
 
 /**
@@ -128,6 +135,8 @@ export const useTracesV4SavedViews = ({
   assessmentNames = [],
   assessmentVisibility = {},
   setAssessmentVisibility,
+  customVisibility = {},
+  setCustomVisibility,
 }: UseTracesV4SavedViewsParams) => {
   const dispatch = useDispatch<ThunkDispatch>();
   const intl = useIntl();
@@ -220,9 +229,15 @@ export const useTracesV4SavedViews = ({
         );
         return null;
       }
-      // Capture the current URL view params + the live columns, filter model and assessment-column
+      // Capture the current URL view params + the live columns, filter model and assessment/custom-column
       // visibility (none of the latter three ride in the URL).
-      const state = captureV4ViewState(searchParams, visibleColumns, filterModel, assessmentVisibility);
+      const state = captureV4ViewState(
+        searchParams,
+        visibleColumns,
+        filterModel,
+        assessmentVisibility,
+        customVisibility,
+      );
       const compressedState = await textCompressDeflate(JSON.stringify(state));
       const id = getUUID();
       const envelope = encodeSavedViewEnvelope(name.trim(), compressedState, Date.now());
@@ -248,6 +263,7 @@ export const useTracesV4SavedViews = ({
       visibleColumns,
       filterModel,
       assessmentVisibility,
+      customVisibility,
       views,
       atCap,
       intl,
@@ -329,8 +345,11 @@ export const useTracesV4SavedViews = ({
       // Restore assessment-column visibility (localStorage, not URL). An older view without the field
       // clears overrides rather than leaving the previous view's visibility applied on top.
       setAssessmentVisibility?.(state.assessmentColumns);
+      // Restore custom-column visibility (localStorage, not URL). An older view without the field
+      // clears overrides rather than leaving the previous view's visibility applied on top.
+      setCustomVisibility?.(state.customColumns);
     },
-    [setSearchParams, setColumns, setFilterModel, supportedFilters, setAssessmentVisibility],
+    [setSearchParams, setColumns, setFilterModel, supportedFilters, setAssessmentVisibility, setCustomVisibility],
   );
 
   // Return to the default state: drop every view param, clear the non-URL surfaces (columns +
@@ -391,7 +410,13 @@ export const useTracesV4SavedViews = ({
       if (!existing) {
         return;
       }
-      const state = captureV4ViewState(searchParams, visibleColumns, filterModel, assessmentVisibility);
+      const state = captureV4ViewState(
+        searchParams,
+        visibleColumns,
+        filterModel,
+        assessmentVisibility,
+        customVisibility,
+      );
       const compressedState = await textCompressDeflate(JSON.stringify(state));
       const envelope = encodeSavedViewEnvelope(existing.name, compressedState, existing.createdAt, Date.now());
       if (envelope.length > MAX_TAG_VALUE_LENGTH) {
@@ -423,7 +448,18 @@ export const useTracesV4SavedViews = ({
         3,
       );
     },
-    [views, searchParams, visibleColumns, filterModel, assessmentVisibility, dispatch, experimentId, refetch, intl],
+    [
+      views,
+      searchParams,
+      visibleColumns,
+      filterModel,
+      assessmentVisibility,
+      customVisibility,
+      dispatch,
+      experimentId,
+      refetch,
+      intl,
+    ],
   );
 
   // Discard live edits: re-apply the active view's stored state (which also restores its columns).
@@ -460,12 +496,21 @@ export const useTracesV4SavedViews = ({
         }
         setFilterModel(supportedFilters(state.filters));
         setAssessmentVisibility?.(state.assessmentColumns);
+        setCustomVisibility?.(state.customColumns);
       }
     });
     return () => {
       cancelled = true;
     };
-  }, [activeViewId, decodeViewState, setColumns, setFilterModel, supportedFilters, setAssessmentVisibility]);
+  }, [
+    activeViewId,
+    decodeViewState,
+    setColumns,
+    setFilterModel,
+    supportedFilters,
+    setAssessmentVisibility,
+    setCustomVisibility,
+  ]);
 
   // Dirty = the live table (URL view params + columns) diverges from the active view's stored state.
   // Treated as clean until the stored state is loaded AND columns are hydrated, so it never flashes
@@ -474,7 +519,7 @@ export const useTracesV4SavedViews = ({
     if (!activeViewId || !activeStoredState || hydratedViewIdRef.current !== activeViewId) {
       return 'clean';
     }
-    const live = captureV4ViewState(searchParams, visibleColumns, filterModel, assessmentVisibility);
+    const live = captureV4ViewState(searchParams, visibleColumns, filterModel, assessmentVisibility, customVisibility);
     // Normalize the stored baseline's filters the same way openView restores them (drop unsupported
     // clauses); diffing raw stored filters would mark a view with a since-removed field dirty forever.
     const normalizedStored: CapturedV4ViewState = {
@@ -489,6 +534,7 @@ export const useTracesV4SavedViews = ({
     visibleColumns,
     filterModel,
     assessmentVisibility,
+    customVisibility,
     supportedFilters,
   ]);
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4Toolbar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4Toolbar.tsx
@@ -11,6 +11,7 @@ import {
 } from '@databricks/web-shared/traces-table';
 import { shouldEnableIssueDetection } from '@mlflow/mlflow/src/common/utils/FeatureUtils';
 import { type TracesV4AssessmentColumns } from '../hooks/useTracesV4AssessmentColumns';
+import { type TracesV4CustomColumns } from '../hooks/useTracesV4CustomColumns';
 import { type TracesV4Density } from '../hooks/useTracesV4Density';
 import { TracesV4DateSelector, TracesV4RefreshButton } from './TracesV4DateSelector';
 import { TracesV4DisplayButton, type TracesV4ColumnGroup } from './TracesV4DisplayButton';
@@ -29,6 +30,8 @@ export interface TracesV4ToolbarParams {
   onResetColumns: () => void;
   /** Assessment column selection (dynamic, per-page) rendered as a group in the column selector. */
   assessmentColumns: TracesV4AssessmentColumns;
+  /** Custom (tag + metadata) column selection (dynamic, per-page). */
+  customColumns: TracesV4CustomColumns;
   /** Active sort column + direction, and its setter — surfaced in the Display popover's Sort submenu. */
   sort: TraceColumnId;
   dir: SortDirection;
@@ -73,6 +76,9 @@ const COLUMN_LABELS: Record<TraceColumnId, React.ReactNode> = {
   tokens: <FormattedMessage defaultMessage="Tokens" description="Column selector label for the tokens column" />,
   cost: <FormattedMessage defaultMessage="Cost" description="Column selector label for the cost column" />,
   tags: <FormattedMessage defaultMessage="Tags" description="Column selector label for the tags column" />,
+  metadata: (
+    <FormattedMessage defaultMessage="Metadata" description="Column selector label for the aggregate metadata column" />
+  ),
 };
 
 // Static per-column componentIds (the lint rule requires static ids). Canonical render order.
@@ -103,6 +109,7 @@ const COLUMN_OPTIONS: ColumnSelectorOption[] = [
   { id: 'tokens', label: COLUMN_LABELS.tokens, componentId: 'mlflow.traces-v4.column-selector.item.tokens' },
   { id: 'cost', label: COLUMN_LABELS.cost, componentId: 'mlflow.traces-v4.column-selector.item.cost' },
   { id: 'tags', label: COLUMN_LABELS.tags, componentId: 'mlflow.traces-v4.column-selector.item.tags' },
+  { id: 'metadata', label: COLUMN_LABELS.metadata, componentId: 'mlflow.traces-v4.column-selector.item.metadata' },
 ];
 
 export interface TracesV4ToolbarSlots {
@@ -126,6 +133,7 @@ export const useTracesV4ToolbarSlots = ({
   onToggleColumn,
   onResetColumns,
   assessmentColumns,
+  customColumns,
   sort,
   dir,
   onSort,
@@ -153,25 +161,52 @@ export const useTracesV4ToolbarSlots = ({
     ? COLUMN_OPTIONS.map((option) => (option.id === 'session' ? { ...option, disabled: true } : option))
     : COLUMN_OPTIONS;
 
-  // Assessment columns are dynamic (per-page), so they render as a labeled group under the standard
-  // columns in the Display → Columns submenu. Omitted entirely when the page has no assessments.
-  const columnGroups: TracesV4ColumnGroup[] | undefined =
-    assessmentColumns.selectorOptions.length > 0
-      ? [
-          {
-            label: (
-              <FormattedMessage
-                defaultMessage="Assessments"
-                description="Section label for assessment columns in the traces table column selector"
-              />
-            ),
-            options: assessmentColumns.selectorOptions,
-            visibleIds: assessmentColumns.visibleIds,
-            onToggle: assessmentColumns.toggle,
-            onToggleAll: assessmentColumns.setAllVisible,
-          },
-        ]
-      : undefined;
+  // Custom and assessment columns are dynamic (per-page), so they render as labeled groups under
+  // the standard columns in the Display → Columns submenu. Each group is included only when the
+  // page has relevant candidates.
+  const columnGroups: TracesV4ColumnGroup[] = [];
+  if (customColumns.tags.selectorOptions.length > 0) {
+    columnGroups.push({
+      label: (
+        <FormattedMessage
+          defaultMessage="Tags"
+          description="Section label for tag columns in the traces table column selector"
+        />
+      ),
+      options: customColumns.tags.selectorOptions,
+      visibleIds: customColumns.tags.visibleIds,
+      onToggle: customColumns.tags.toggle,
+      onToggleAll: customColumns.tags.setAllVisible,
+    });
+  }
+  if (customColumns.metadata.selectorOptions.length > 0) {
+    columnGroups.push({
+      label: (
+        <FormattedMessage
+          defaultMessage="Metadata"
+          description="Section label for metadata columns in the traces table column selector"
+        />
+      ),
+      options: customColumns.metadata.selectorOptions,
+      visibleIds: customColumns.metadata.visibleIds,
+      onToggle: customColumns.metadata.toggle,
+      onToggleAll: customColumns.metadata.setAllVisible,
+    });
+  }
+  if (assessmentColumns.selectorOptions.length > 0) {
+    columnGroups.push({
+      label: (
+        <FormattedMessage
+          defaultMessage="Assessments"
+          description="Section label for assessment columns in the traces table column selector"
+        />
+      ),
+      options: assessmentColumns.selectorOptions,
+      visibleIds: assessmentColumns.visibleIds,
+      onToggle: assessmentColumns.toggle,
+      onToggleAll: assessmentColumns.setAllVisible,
+    });
+  }
 
   // Note: the Databricks build disables Delete for UC-backed traces (with a "delete from the Delta
   // table instead" tooltip). OSS traces are always deletable via the standard path, so that gate is

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4Columns.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4Columns.ts
@@ -5,6 +5,7 @@ import {
   type TraceColumnVisibility,
 } from '@databricks/web-shared/traces-table';
 import { TRACE_COLUMN_STORAGE_KEY_PREFIX } from '../utils/constants';
+import { isCustomTraceColumnId } from '../utils/customColumns';
 
 // Bump when the stored schema changes so stale entries reset. v2 → override map (was a flat visible
 // list); v3 → new default-visibility set; v4 → Tokens now shown by default. New opt-in columns
@@ -18,6 +19,7 @@ const OPT_IN_COLUMNS: ReadonlySet<TraceColumnId> = new Set([
   'source',
   'run_name',
   'cost',
+  'metadata',
 ]);
 
 export interface UseTracesV4ColumnsParams {
@@ -49,5 +51,6 @@ export const useTracesV4Columns = (
     storageKey: `${TRACE_COLUMN_STORAGE_KEY_PREFIX}.${experimentId}`,
     version: COLUMN_STORAGE_VERSION,
     getDefaultVisible,
+    isDynamicColumnId: isCustomTraceColumnId,
   });
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4Controller.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4Controller.ts
@@ -15,12 +15,14 @@ import {
 import { useMonitoringConfig } from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringConfig';
 // Reuse the generic (branding-free) datasets-v2 helpers.
 import { useDebouncedSearchInput } from './useDebouncedSearchInput';
+import type { TracesV4CustomColumns } from './useTracesV4CustomColumns';
 import { useTracesV4UrlState } from './useTracesV4UrlState';
 import { useTracesV4TimeRange } from './useTracesV4TimeRange';
 import { useTracesV4Columns } from './useTracesV4Columns';
 import { useTracesV4AssessmentColumns } from './useTracesV4AssessmentColumns';
 import { useTracesV4ColumnSizing } from './useTracesV4ColumnSizing';
 import { useTracesV4TraceCount } from './useTracesV4TraceCount';
+import { useTracesV4CustomColumns } from './useTracesV4CustomColumns';
 import { buildFilter, buildOrderBy } from '../utils/buildTracesV4SearchParams';
 import { compileFilterModel, compileTagFilters } from '../utils/filterModel';
 import { SEARCH_DEBOUNCE_MS } from '../utils/constants';
@@ -42,6 +44,7 @@ export interface UseTracesV4ControllerResult {
   columnSizing: ReturnType<typeof useTracesV4ColumnSizing>;
   /** "{n} of {total}" footer count — current page rows out of the experiment total. */
   traceCount: ReturnType<typeof useTracesV4TraceCount>;
+  customColumns: TracesV4CustomColumns;
   bulk: ReturnType<typeof useBulkTraceSelection>;
   searchInput: ReturnType<typeof useDebouncedSearchInput>;
   filterModel: TraceFilterModel;
@@ -178,6 +181,11 @@ export const useTracesV4Controller = ({ experimentId }: UseTracesV4ControllerPar
   const assessments = useTracesV4AssessmentColumns(experimentId, page.traces);
   const columnSizing = useTracesV4ColumnSizing(experimentId);
   const traceCount = useTracesV4TraceCount(experimentId, page.traces.length, timeRange);
+  const customColumns = useTracesV4CustomColumns(
+    page.traces,
+    columns.dynamicVisibilityById,
+    columns.setDynamicVisibility,
+  );
 
   const bulk = useBulkTraceSelection(page.traces);
 
@@ -211,6 +219,7 @@ export const useTracesV4Controller = ({ experimentId }: UseTracesV4ControllerPar
     assessments,
     columnSizing,
     traceCount,
+    customColumns,
     bulk,
     searchInput,
     filterModel,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4CustomColumns.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4CustomColumns.test.tsx
@@ -2,11 +2,14 @@ import { describe, expect, it } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react';
 import type { ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
 import { useState } from 'react';
+import { IntlProvider } from 'react-intl';
 
 import { useTracesV4CustomColumns } from './useTracesV4CustomColumns';
 
 const trace = (over: Partial<ModelTraceInfoV3>): ModelTraceInfoV3 =>
   ({ tags: {}, trace_metadata: {}, ...over }) as ModelTraceInfoV3;
+
+const wrapper = ({ children }: { children: React.ReactNode }) => <IntlProvider locale="en">{children}</IntlProvider>;
 
 const useCustomColumns = (traces: ModelTraceInfoV3[]) => {
   const [visibility, setVisibility] = useState<Record<string, boolean>>({});
@@ -15,16 +18,18 @@ const useCustomColumns = (traces: ModelTraceInfoV3[]) => {
 
 describe('useTracesV4CustomColumns', () => {
   it('offers user tags and metadata in separate opt-in groups', () => {
-    const { result } = renderHook(() =>
-      useCustomColumns([
-        trace({
-          tags: { environment: 'prod', 'mlflow.internal': 'hidden' },
-          trace_metadata: {
-            region: 'us-west',
-            'mlflow.trace.tokenUsage': '{}',
-          },
-        }),
-      ]),
+    const { result } = renderHook(
+      () =>
+        useCustomColumns([
+          trace({
+            tags: { environment: 'prod', 'mlflow.internal': 'hidden' },
+            trace_metadata: {
+              region: 'us-west',
+              'mlflow.trace.tokenUsage': '{}',
+            },
+          }),
+        ]),
+      { wrapper },
     );
 
     expect(result.current.tags.selectorOptions.map((opt) => opt.id)).toEqual(['tag:environment']);
@@ -39,7 +44,7 @@ describe('useTracesV4CustomColumns', () => {
         trace_metadata: { region: 'us-west' },
       }),
     ];
-    const { result } = renderHook(() => useCustomColumns(traces));
+    const { result } = renderHook(() => useCustomColumns(traces), { wrapper });
 
     act(() => {
       result.current.tags.toggle('tag:environment');
@@ -54,6 +59,7 @@ describe('useTracesV4CustomColumns', () => {
   it('keeps an opted-in field available when it is absent from a later page', () => {
     const { result, rerender } = renderHook(({ traces }: { traces: ModelTraceInfoV3[] }) => useCustomColumns(traces), {
       initialProps: { traces: [trace({ tags: { environment: 'prod' } })] },
+      wrapper,
     });
     act(() => result.current.tags.toggle('tag:environment'));
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4CustomColumns.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4CustomColumns.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react';
+import type { ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
+import { useState } from 'react';
+
+import { useTracesV4CustomColumns } from './useTracesV4CustomColumns';
+
+const trace = (over: Partial<ModelTraceInfoV3>): ModelTraceInfoV3 =>
+  ({ tags: {}, trace_metadata: {}, ...over }) as ModelTraceInfoV3;
+
+const useCustomColumns = (traces: ModelTraceInfoV3[]) => {
+  const [visibility, setVisibility] = useState<Record<string, boolean>>({});
+  return useTracesV4CustomColumns(traces, visibility, setVisibility);
+};
+
+describe('useTracesV4CustomColumns', () => {
+  it('offers user tags and metadata in separate opt-in groups', () => {
+    const { result } = renderHook(() =>
+      useCustomColumns([
+        trace({
+          tags: { environment: 'prod', 'mlflow.internal': 'hidden' },
+          trace_metadata: {
+            region: 'us-west',
+            'mlflow.trace.tokenUsage': '{}',
+          },
+        }),
+      ]),
+    );
+
+    expect(result.current.tags.selectorOptions.map((opt) => opt.id)).toEqual(['tag:environment']);
+    expect(result.current.metadata.selectorOptions.map((opt) => opt.id)).toEqual(['custom_metadata:region']);
+    expect(result.current.columnDefs).toEqual([]);
+  });
+
+  it('renders an opted-in tag and metadata field as table columns', () => {
+    const traces = [
+      trace({
+        tags: { environment: 'prod' },
+        trace_metadata: { region: 'us-west' },
+      }),
+    ];
+    const { result } = renderHook(() => useCustomColumns(traces));
+
+    act(() => {
+      result.current.tags.toggle('tag:environment');
+      result.current.metadata.toggle('custom_metadata:region');
+    });
+
+    expect(result.current.columnDefs.map((col) => col.id)).toEqual(['tag:environment', 'custom_metadata:region']);
+    expect(result.current.tags.visibleIds).toEqual(['tag:environment']);
+    expect(result.current.metadata.visibleIds).toEqual(['custom_metadata:region']);
+  });
+
+  it('keeps an opted-in field available when it is absent from a later page', () => {
+    const { result, rerender } = renderHook(({ traces }: { traces: ModelTraceInfoV3[] }) => useCustomColumns(traces), {
+      initialProps: { traces: [trace({ tags: { environment: 'prod' } })] },
+    });
+    act(() => result.current.tags.toggle('tag:environment'));
+
+    rerender({ traces: [trace({})] });
+
+    expect(result.current.tags.selectorOptions.map((opt) => opt.id)).toEqual(['tag:environment']);
+    expect(result.current.tags.visibleIds).toEqual(['tag:environment']);
+    expect(result.current.columnDefs.map((col) => col.id)).toEqual(['tag:environment']);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4CustomColumns.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4CustomColumns.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
+import { useIntl } from 'react-intl';
 import { CodeIcon, TagIcon } from '@databricks/design-system';
 import { type ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
 import {
@@ -95,6 +96,7 @@ export const useTracesV4CustomColumns = (
   visibility: Record<string, boolean>,
   setVisibility: Dispatch<SetStateAction<Record<string, boolean>>>,
 ): TracesV4CustomColumns => {
+  const intl = useIntl();
   const discovered = useMemo(() => discoverCandidates(traces), [traces]);
   const candidates = useMemo(() => {
     const byId = new Map(discovered.map((candidate) => [candidate.id, candidate]));
@@ -119,7 +121,24 @@ export const useTracesV4CustomColumns = (
           id: candidate.id,
           ...COLUMN_SIZE,
           maxSize: getTextColumnMaxSize([candidate.key, ...values], COLUMN_SIZE.size),
-          labelText: candidate.key,
+          // Qualify the menu's accessible label with the field kind so a tag and a metadata field
+          // that share a key (e.g. `environment`) don't produce identical labels for screen readers.
+          labelText:
+            candidate.kind === 'tag'
+              ? intl.formatMessage(
+                  {
+                    defaultMessage: 'Tag: {name}',
+                    description: 'Accessible label qualifier for a custom trace tag column header',
+                  },
+                  { name: candidate.key },
+                )
+              : intl.formatMessage(
+                  {
+                    defaultMessage: 'Metadata: {name}',
+                    description: 'Accessible label qualifier for a custom trace metadata column header',
+                  },
+                  { name: candidate.key },
+                ),
           header: () => <CustomColumnHeader kind={candidate.kind} name={candidate.key} />,
           cell: ({ row }: { row: { original: ModelTraceInfoV3 } }) =>
             valueFor(row.original, candidate)?.toString() ?? '',
@@ -129,7 +148,7 @@ export const useTracesV4CustomColumns = (
             ),
         };
       }),
-    [visibleCandidates, traces],
+    [visibleCandidates, traces, intl],
   );
 
   const toggle = useCallback(

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4CustomColumns.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/hooks/useTracesV4CustomColumns.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
+import { CodeIcon, TagIcon } from '@databricks/design-system';
+import { type ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
+import {
+  getTextColumnMaxSize,
+  type GenericColumnOption,
+  type TraceTableColumn,
+} from '@databricks/web-shared/traces-table';
+import { isCustomTraceColumnId, METADATA_COLUMN_PREFIX, TAG_COLUMN_PREFIX } from '../utils/customColumns';
+
+export { isCustomTraceColumnId } from '../utils/customColumns';
+
+const INTERNAL_KEY_PREFIX = 'mlflow.';
+const ITEM_COMPONENT_ID = 'mlflow.traces-v4.column-selector.custom-item';
+const COLUMN_SIZE = { size: 180, minSize: 100 } as const;
+
+const CustomColumnHeader = ({ kind, name }: { kind: CustomColumnKind; name: string }) => (
+  <span css={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+    {kind === 'tag' ? (
+      <TagIcon data-testid="trace-tag-column-icon" css={{ fontSize: 16 }} />
+    ) : (
+      <CodeIcon data-testid="trace-metadata-column-icon" css={{ fontSize: 16 }} />
+    )}
+    {name}
+  </span>
+);
+
+type CustomColumnKind = 'tag' | 'metadata';
+
+interface CustomColumnCandidate {
+  id: string;
+  key: string;
+  kind: CustomColumnKind;
+}
+
+const columnId = (kind: CustomColumnKind, key: string) =>
+  `${kind === 'tag' ? TAG_COLUMN_PREFIX : METADATA_COLUMN_PREFIX}${key}`;
+
+const valueFor = (trace: ModelTraceInfoV3, candidate: CustomColumnCandidate) =>
+  candidate.kind === 'tag' ? trace.tags?.[candidate.key] : trace.trace_metadata?.[candidate.key];
+
+const candidateFromId = (id: string): CustomColumnCandidate | undefined => {
+  if (id.startsWith(TAG_COLUMN_PREFIX)) {
+    return { id, key: id.slice(TAG_COLUMN_PREFIX.length), kind: 'tag' };
+  }
+  if (id.startsWith(METADATA_COLUMN_PREFIX)) {
+    return {
+      id,
+      key: id.slice(METADATA_COLUMN_PREFIX.length),
+      kind: 'metadata',
+    };
+  }
+  return undefined;
+};
+
+const discoverCandidates = (traces: ModelTraceInfoV3[]): CustomColumnCandidate[] => {
+  const candidates = new Map<string, CustomColumnCandidate>();
+  for (const trace of traces) {
+    for (const key of Object.keys(trace.tags ?? {})) {
+      if (key && !key.startsWith(INTERNAL_KEY_PREFIX)) {
+        const id = columnId('tag', key);
+        candidates.set(id, { id, key, kind: 'tag' });
+      }
+    }
+    for (const key of Object.keys(trace.trace_metadata ?? {})) {
+      if (key && !key.startsWith(INTERNAL_KEY_PREFIX)) {
+        const id = columnId('metadata', key);
+        candidates.set(id, { id, key, kind: 'metadata' });
+      }
+    }
+  }
+  return [...candidates.values()].sort((left, right) => left.key.localeCompare(right.key));
+};
+
+export interface TracesV4CustomColumnGroup {
+  selectorOptions: GenericColumnOption[];
+  visibleIds: string[];
+  toggle: (id: string) => void;
+  setAllVisible: (visible: boolean) => void;
+}
+
+export interface TracesV4CustomColumns {
+  columnDefs: TraceTableColumn[];
+  tags: TracesV4CustomColumnGroup;
+  metadata: TracesV4CustomColumnGroup;
+  visibilityById: Record<string, boolean>;
+  setVisibility: (visibility: Record<string, boolean> | undefined) => void;
+  toggle: (id: string) => void;
+  reset: () => void;
+}
+
+/** Discovers user-authored tags and metadata on the current page and exposes them as opt-in columns. */
+export const useTracesV4CustomColumns = (
+  traces: ModelTraceInfoV3[],
+  visibility: Record<string, boolean>,
+  setVisibility: Dispatch<SetStateAction<Record<string, boolean>>>,
+): TracesV4CustomColumns => {
+  const discovered = useMemo(() => discoverCandidates(traces), [traces]);
+  const candidates = useMemo(() => {
+    const byId = new Map(discovered.map((candidate) => [candidate.id, candidate]));
+    for (const id of Object.keys(visibility)) {
+      const candidate = candidateFromId(id);
+      if (visibility[id] === true && candidate && !candidate.key.startsWith(INTERNAL_KEY_PREFIX) && !byId.has(id)) {
+        byId.set(id, candidate);
+      }
+    }
+    return [...byId.values()].sort((left, right) => left.key.localeCompare(right.key));
+  }, [discovered, visibility]);
+
+  const visibleCandidates = useMemo(
+    () => candidates.filter(({ id }) => visibility[id] === true),
+    [candidates, visibility],
+  );
+  const columnDefs = useMemo<TraceTableColumn[]>(
+    () =>
+      visibleCandidates.map((candidate) => {
+        const values = traces.map((trace) => valueFor(trace, candidate)?.toString() ?? '');
+        return {
+          id: candidate.id,
+          ...COLUMN_SIZE,
+          maxSize: getTextColumnMaxSize([candidate.key, ...values], COLUMN_SIZE.size),
+          labelText: candidate.key,
+          header: () => <CustomColumnHeader kind={candidate.kind} name={candidate.key} />,
+          cell: ({ row }: { row: { original: ModelTraceInfoV3 } }) =>
+            valueFor(row.original, candidate)?.toString() ?? '',
+          renderSessionCell: (sessionTraces: ModelTraceInfoV3[]) =>
+            [...new Set(sessionTraces.map((trace) => valueFor(trace, candidate)?.toString()).filter(Boolean))].join(
+              ', ',
+            ),
+        };
+      }),
+    [visibleCandidates, traces],
+  );
+
+  const toggle = useCallback(
+    (id: string) => setVisibility((current) => ({ ...current, [id]: current[id] !== true })),
+    [setVisibility],
+  );
+  const makeGroup = useCallback(
+    (kind: CustomColumnKind): TracesV4CustomColumnGroup => {
+      const groupCandidates = candidates.filter((candidate) => candidate.kind === kind);
+      return {
+        selectorOptions: groupCandidates.map(({ id, key }) => ({ id, label: key, componentId: ITEM_COMPONENT_ID })),
+        visibleIds: groupCandidates.filter(({ id }) => visibility[id] === true).map(({ id }) => id),
+        toggle,
+        setAllVisible: (visible) =>
+          setVisibility((current) => ({
+            ...current,
+            ...Object.fromEntries(groupCandidates.map(({ id }) => [id, visible])),
+          })),
+      };
+    },
+    [candidates, visibility, toggle, setVisibility],
+  );
+  const reset = useCallback(() => setVisibility({}), [setVisibility]);
+  const restoreVisibility = useCallback(
+    (next: Record<string, boolean> | undefined) =>
+      setVisibility(
+        Object.fromEntries(
+          Object.entries(next ?? {}).filter(
+            ([id]) => isCustomTraceColumnId(id) && !candidateFromId(id)?.key.startsWith(INTERNAL_KEY_PREFIX),
+          ),
+        ),
+      ),
+    [setVisibility],
+  );
+
+  return {
+    columnDefs,
+    tags: makeGroup('tag'),
+    metadata: makeGroup('metadata'),
+    visibilityById: visibility,
+    setVisibility: restoreVisibility,
+    toggle,
+    reset,
+  };
+};

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/buildAssessmentColumnDefs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/buildAssessmentColumnDefs.test.tsx
@@ -1,8 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
+import { render as rtlRender } from '@testing-library/react';
 import { buildAssessmentColumnDefs } from './buildAssessmentColumnDefs';
 
 describe('buildAssessmentColumnDefs', () => {
-  test('builds column defs for assessment columns with correct ids and headers', () => {
+  test('builds column defs for assessment columns with correct ids and labelText', () => {
     const columns = [
       { name: 'relevance', type: 'categorical' as const },
       { name: 'score', type: 'numeric' as const },
@@ -12,9 +13,20 @@ describe('buildAssessmentColumnDefs', () => {
     expect(defs).toHaveLength(2);
     expect(defs[0].id).toBe('assessment:relevance');
     expect(defs[1].id).toBe('assessment:score');
-    // header is a render fn returning the assessment name; invoke through a callable cast.
-    expect((defs[0].header as () => string)()).toBe('relevance');
-    expect((defs[1].header as () => string)()).toBe('score');
+    // labelText is set for a11y on the column menu trigger.
+    expect(defs[0].labelText).toBe('relevance');
+    expect(defs[1].labelText).toBe('score');
+  });
+
+  test('renders assessment column header with gavel icon', () => {
+    const columns = [{ name: 'relevance', type: 'categorical' as const }];
+    const defs = buildAssessmentColumnDefs(columns);
+
+    const headerElement = defs[0].header as () => JSX.Element;
+    const { container } = rtlRender(headerElement());
+
+    expect(container.querySelector('[data-testid="trace-assessment-column-icon"]')).toBeInTheDocument();
+    expect(container.textContent).toContain('relevance');
   });
 
   test('assigns correct column sizes', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/buildAssessmentColumnDefs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/buildAssessmentColumnDefs.tsx
@@ -1,3 +1,4 @@
+import { GavelIcon } from '@databricks/design-system';
 import type { TraceTableColumn } from '@databricks/web-shared/traces-table';
 import { TraceAssessmentCell } from '../components/TraceAssessmentCell';
 import { assessmentColumnId } from './assessmentColumns';
@@ -15,6 +16,12 @@ export const buildAssessmentColumnDefs = (assessmentColumns: AssessmentColumn[])
   assessmentColumns.map(({ name, type }) => ({
     id: assessmentColumnId(name),
     ...ASSESSMENT_COLUMN_SIZE,
-    header: () => name,
+    header: () => (
+      <span css={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+        <GavelIcon data-testid="trace-assessment-column-icon" css={{ fontSize: 16 }} />
+        {name}
+      </span>
+    ),
+    labelText: name,
     cell: (ctx) => <TraceAssessmentCell trace={ctx.row.original} assessmentName={name} columnType={type} />,
   }));

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/customColumns.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/customColumns.ts
@@ -1,0 +1,5 @@
+export const TAG_COLUMN_PREFIX = 'tag:';
+export const METADATA_COLUMN_PREFIX = 'custom_metadata:';
+
+export const isCustomTraceColumnId = (id: string) =>
+  id.startsWith(TAG_COLUMN_PREFIX) || id.startsWith(METADATA_COLUMN_PREFIX);

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.test.ts
@@ -3,14 +3,15 @@ import { capturedV4StatesMatch, __test__ } from './tracesV4DirtyState';
 import { captureV4ViewState } from './tracesV4SavedViewState';
 import { FilterOp, type TraceColumnId, type TraceFilterModel } from '@databricks/web-shared/traces-table';
 
-const { canonicalViewQuery, columnSetsEqual, assessmentVisibilityEqual } = __test__;
+const { canonicalViewQuery, columnSetsEqual, assessmentVisibilityEqual, customVisibilityEqual } = __test__;
 
 const capture = (
   query: string,
   cols: TraceColumnId[] = [],
   filters: TraceFilterModel = [],
   assessments: Record<string, boolean> = {},
-) => captureV4ViewState(new URLSearchParams(query), cols, filters, assessments);
+  custom: Record<string, boolean> = {},
+) => captureV4ViewState(new URLSearchParams(query), cols, filters, assessments, custom);
 
 describe('capturedV4StatesMatch', () => {
   test('identical captures match (clean)', () => {
@@ -71,6 +72,18 @@ describe('capturedV4StatesMatch', () => {
     const b = capture('q=x', ['start_time'], [], { correctness: false });
     expect(capturedV4StatesMatch(a, b)).toBe(false);
   });
+
+  test('showing a custom column is dirty', () => {
+    const a = capture('q=x', ['start_time'], [], {}, { 'tag:environment': true });
+    const b = capture('q=x', ['start_time'], [], {}, { 'tag:environment': false });
+    expect(capturedV4StatesMatch(a, b)).toBe(false);
+  });
+
+  test('an absent custom column entry is treated as hidden (opt-in default)', () => {
+    const a = capture('q=x', ['start_time'], [], {}, {});
+    const b = capture('q=x', ['start_time'], [], {}, { 'tag:environment': false });
+    expect(capturedV4StatesMatch(a, b)).toBe(true);
+  });
 });
 
 describe('canonicalViewQuery', () => {
@@ -116,5 +129,14 @@ describe('assessmentVisibilityEqual', () => {
     expect(assessmentVisibilityEqual({ a: true, b: true }, { a: true })).toBe(true);
     expect(assessmentVisibilityEqual({ a: false }, {})).toBe(false);
     expect(assessmentVisibilityEqual({ a: false }, { a: true })).toBe(false);
+  });
+});
+
+describe('customVisibilityEqual', () => {
+  test('compares effective visibility — an absent id is default-hidden (opt-in)', () => {
+    expect(customVisibilityEqual({ a: false }, {})).toBe(true);
+    expect(customVisibilityEqual({ a: false, b: false }, { a: false })).toBe(true);
+    expect(customVisibilityEqual({ a: true }, {})).toBe(false);
+    expect(customVisibilityEqual({ a: true }, { a: false })).toBe(false);
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4DirtyState.ts
@@ -90,12 +90,28 @@ const assessmentVisibilityEqual = (a: Record<string, boolean> = {}, b: Record<st
   return true;
 };
 
+/**
+ * Compare EFFECTIVE custom column visibility. Unlike assessments (opt-out / default-visible), custom
+ * columns are opt-in / default-hidden, so an absent id means hidden. Only a real show/hide reads
+ * as dirty — an extra default-hidden entry isn't a change.
+ */
+const customVisibilityEqual = (a: Record<string, boolean> = {}, b: Record<string, boolean> = {}): boolean => {
+  const ids = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const id of ids) {
+    if ((a[id] ?? false) !== (b[id] ?? false)) {
+      return false;
+    }
+  }
+  return true;
+};
+
 /** True when the live captured state matches the stored view (i.e. not dirty). */
 export const capturedV4StatesMatch = (live: CapturedV4ViewState, stored: CapturedV4ViewState): boolean =>
   canonicalViewQuery(live) === canonicalViewQuery(stored) &&
   columnSetsEqual(colsOf(live), colsOf(stored)) &&
   assessmentVisibilityEqual(live.assessmentColumns, stored.assessmentColumns) &&
+  customVisibilityEqual(live.customColumns, stored.customColumns) &&
   isEqual(live.filters ?? [], stored.filters ?? []);
 
 // Exported for unit-testing the pure comparisons in isolation.
-export const __test__ = { canonicalViewQuery, columnSetsEqual, assessmentVisibilityEqual };
+export const __test__ = { canonicalViewQuery, columnSetsEqual, assessmentVisibilityEqual, customVisibilityEqual };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.test.ts
@@ -101,6 +101,25 @@ describe('captureV4ViewState', () => {
     expect(noAssessments.assessmentColumns).toBeUndefined();
   });
 
+  test('captures custom-column visibility, omitting an empty map', () => {
+    // An empty map is omitted so a view saved with no custom columns stays byte-identical to a legacy one.
+    const withCustom = captureV4ViewState(
+      params('q=x'),
+      ['start_time'],
+      [],
+      {},
+      {
+        'tag:environment': true,
+        'custom_metadata:region': false,
+      },
+    );
+    expect(withCustom.customColumns).toEqual({ 'tag:environment': true, 'custom_metadata:region': false });
+    expect(params(buildV4ViewQuery(withCustom, 'view-1')).has('customColumns')).toBe(false);
+
+    const noCustom = captureV4ViewState(params('q=x'), ['start_time'], [], {}, {});
+    expect(noCustom.customColumns).toBeUndefined();
+  });
+
   test('never captures an incoming share key or cols param from the URL (only the live columns)', () => {
     // Opening view A then saving must not leak A's share key / cols into view B.
     const state = captureV4ViewState(params(`q=x&cols=tokens,cost&${TRACE_V4_SHARE_URL_PARAM_KEY}=other-view`), [

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/utils/tracesV4SavedViewState.ts
@@ -53,6 +53,8 @@ export interface CapturedV4ViewState {
   // visible-id list, so a hidden column is recorded too — restoring a bare id list would lose explicit
   // hides. Absent in older stored views (treated as "capture nothing", i.e. clear overrides on restore).
   assessmentColumns?: Record<string, boolean>;
+  /** Custom tag/metadata column visibility. Optional for backward compatibility with older views. */
+  customColumns?: Record<string, boolean>;
 }
 
 export const getTraceV4SavedViewTagKey = (id: string): string => `${TRACE_V4_SAVED_VIEW_TAG_PREFIX}${id}`;
@@ -91,6 +93,7 @@ export const captureV4ViewState = (
   visibleColumns: readonly TraceColumnId[],
   filterModel: TraceFilterModel = [],
   assessmentColumns: Record<string, boolean> = {},
+  customColumns: Record<string, boolean> = {},
 ): CapturedV4ViewState => {
   const single: CapturedV4ViewState['single'] = {};
   SINGLE_VALUE_KEYS.forEach((key) => {
@@ -117,6 +120,11 @@ export const captureV4ViewState = (
   // one (and never spuriously reads as dirty against `assessmentColumns ?? {}`).
   if (Object.keys(assessmentColumns).length > 0) {
     state.assessmentColumns = assessmentColumns;
+  }
+  // Omit an empty map so a view saved on a page with no custom columns stays byte-identical to a legacy
+  // one (and never spuriously reads as dirty against `customColumns ?? {}`).
+  if (Object.keys(customColumns).length > 0) {
+    state.customColumns = customColumns;
   }
   return state;
 };

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2163,6 +2163,10 @@
     "defaultMessage": "Off",
     "description": "Runs charts > line chart > ignore outliers > off setting label"
   },
+  "78/HiZ": {
+    "defaultMessage": "Expand tag columns",
+    "description": "Column header action for expanding tag columns"
+  },
   "79dD5F": {
     "defaultMessage": "There was an error submitting your note.",
     "description": "Error message text when saving an editable note in MLflow"
@@ -2467,6 +2471,10 @@
     "defaultMessage": "Type a key",
     "description": "Key-value tag editor modal > Tag dropdown > Tag input placeholder"
   },
+  "8CgyA/": {
+    "defaultMessage": "Tags",
+    "description": "Section label for tag columns in the traces table column selector"
+  },
   "8DoNdT": {
     "defaultMessage": "Save",
     "description": "Save button text for edit endpoint name modal"
@@ -2534,6 +2542,10 @@
   "8XrJnT": {
     "defaultMessage": "Delete section",
     "description": "Experiment page > compare runs > chart section > delete section label"
+  },
+  "8Y+yRh": {
+    "defaultMessage": "Expand metadata columns",
+    "description": "Column header action for expanding metadata columns"
   },
   "8YmId5": {
     "defaultMessage": "Y axis",
@@ -6127,6 +6139,10 @@
     "defaultMessage": "{fieldName} are identical",
     "description": "Default text in data table where items are identical in the model comparison page"
   },
+  "NJPvPG": {
+    "defaultMessage": "Metadata: {name}",
+    "description": "Accessible label qualifier for a custom trace metadata column header"
+  },
   "NKj5Xb": {
     "defaultMessage": "Create evaluation datasets in order to iteratively evaluate and improve your app. Run evaluations to check that your fixes are working, and compare quality between app / prompt versions. {learnMoreLink}",
     "description": "Description of the empty state for the evaluation runs page"
@@ -6983,6 +6999,10 @@
     "defaultMessage": "Name",
     "description": "Header for the name column in the experiments table"
   },
+  "Qhtkvn": {
+    "defaultMessage": "Tag: {name}",
+    "description": "Accessible label qualifier for a custom trace tag column header"
+  },
   "Qi6Etm": {
     "defaultMessage": "Hide all runs",
     "description": "Menu option for revealing all hidden runs in the experiment view runs compare mode"
@@ -7586,6 +7606,10 @@
   "TFWXO/": {
     "defaultMessage": "Hide raw server.json",
     "description": "Toggle to hide raw server.json"
+  },
+  "TKo/CQ": {
+    "defaultMessage": "Metadata",
+    "description": "Column selector label for the aggregate metadata column"
   },
   "TKtJIK": {
     "defaultMessage": "Page not found",
@@ -10683,6 +10707,10 @@
     "defaultMessage": "Columns",
     "description": "Run page > artifact view > logged table view > columns selector label"
   },
+  "fMsHva": {
+    "defaultMessage": "Metadata",
+    "description": "Header for the traces table metadata column"
+  },
   "fMxD0i": {
     "defaultMessage": "Admin",
     "description": "Tag content marking an admin role (single-tenant)"
@@ -12490,6 +12518,10 @@
   "lyNyOH": {
     "defaultMessage": "Default queue",
     "description": "Add to review queue: the experiment default queue option"
+  },
+  "lzW28v": {
+    "defaultMessage": "Metadata",
+    "description": "Section label for metadata columns in the traces table column selector"
   },
   "m1Nb7W": {
     "defaultMessage": "Save",

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TraceCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TraceCell.tsx
@@ -236,6 +236,8 @@ interface TraceCellProps {
 interface TraceTagsCellProps extends TraceCellProps {
   /** Toggle a filter when a tag pill is clicked. Absent → pills render as plain (non-clickable) tags. */
   onFilterByTag?: (key: string, value: string) => void;
+  /** Override the key/value entries rendered by the shared pill layout. */
+  entries?: Array<[string, string]>;
 }
 
 /** Trace id — monospace text that links when a destination is provided, with the full id in a tooltip. */
@@ -739,10 +741,18 @@ const TagPill = ({
  * siblings, and each clickable pill `stopPropagation`s so a filter click never also opens the drawer.
  */
 export const TraceTagsCell: React.MemoExoticComponent<(props: TraceTagsCellProps) => JSX.Element> = memo(
-  function TraceTagsCell({ trace, onSelect, accessibleLabel, onFilterByTag }: TraceTagsCellProps) {
+  function TraceTagsCell({
+    trace,
+    onSelect,
+    accessibleLabel,
+    onFilterByTag,
+    entries: entriesOverride,
+  }: TraceTagsCellProps) {
     const { theme } = useDesignSystemTheme();
     const intl = useIntl();
-    const entries = Object.entries(trace.tags ?? {}).filter(([key]) => !key.startsWith(MLFLOW_INTERNAL_TAG_PREFIX));
+    const entries =
+      entriesOverride ??
+      Object.entries(trace.tags ?? {}).filter(([key]) => !key.startsWith(MLFLOW_INTERNAL_TAG_PREFIX));
     const containerRef = useRef<HTMLSpanElement>(null);
     const pillRefs = useRef<Array<HTMLSpanElement | null>>([]);
     const overflowRefs = useRef<Array<HTMLSpanElement | null>>([]);
@@ -858,4 +868,14 @@ export const TraceTagsCell: React.MemoExoticComponent<(props: TraceTagsCellProps
       </span>
     );
   },
+);
+
+/** User-authored metadata rendered with the same compact pill layout as aggregate tags. */
+export const TraceMetadataCell = ({ trace, onSelect, accessibleLabel }: TraceCellProps): JSX.Element => (
+  <TraceTagsCell
+    trace={trace}
+    onSelect={onSelect}
+    accessibleLabel={accessibleLabel}
+    entries={Object.entries(trace.trace_metadata ?? {}).filter(([key]) => !key.startsWith(MLFLOW_INTERNAL_TAG_PREFIX))}
+  />
 );

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TraceColumnHeader.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TraceColumnHeader.tsx
@@ -12,7 +12,7 @@ import {
   VisibleOffIcon,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from '@databricks/i18n';
-import type { SortDirection } from './types';
+import type { SortDirection, TraceColumnHeaderAction } from './types';
 
 // Static componentId prefix — the `@databricks/no-dynamic-property-value` rule needs static literals.
 const COMPONENT_ID = 'web-shared.traces-table.header-menu';
@@ -27,6 +27,7 @@ interface TraceColumnHeaderMenuProps {
   onSortDescending: () => void;
   /** Omit → no Hide item (and, on a non-sortable column, no menu at all). */
   onHide?: () => void;
+  action?: TraceColumnHeaderAction;
   triggerLabel: string;
 }
 
@@ -37,6 +38,7 @@ export const TraceColumnHeaderMenu = ({
   onSortAscending,
   onSortDescending,
   onHide,
+  action,
   triggerLabel,
 }: TraceColumnHeaderMenuProps): JSX.Element => {
   const { theme } = useDesignSystemTheme();
@@ -81,9 +83,16 @@ export const TraceColumnHeaderMenu = ({
                 </DropdownMenu.HintColumn>
               )}
             </DropdownMenu.Item>
-            {onHide && <DropdownMenu.Separator />}
           </>
         )}
+        {sortable && action && <DropdownMenu.Separator />}
+        {action && (
+          <DropdownMenu.Item componentId={`${COMPONENT_ID}.action`} onClick={action.onClick}>
+            <DropdownMenu.IconWrapper>{action.icon}</DropdownMenu.IconWrapper>
+            {action.label}
+          </DropdownMenu.Item>
+        )}
+        {onHide && (sortable || action) && <DropdownMenu.Separator />}
         {onHide && (
           <DropdownMenu.Item componentId={`${COMPONENT_ID}.hide-column`} onClick={onHide}>
             <VisibleOffIcon css={iconCss} />
@@ -108,6 +117,7 @@ export interface TraceColumnHeaderProps {
   onSortAscending: () => void;
   onSortDescending: () => void;
   onHide?: () => void;
+  action?: TraceColumnHeaderAction;
 }
 
 /**
@@ -123,6 +133,7 @@ export const TraceColumnHeader = ({
   onSortAscending,
   onSortDescending,
   onHide,
+  action,
 }: TraceColumnHeaderProps): JSX.Element => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -140,7 +151,7 @@ export const TraceColumnHeader = ({
         description: 'Accessible label for the per-column options menu button in the traces table header',
       });
 
-  const showMenu = sortable || Boolean(onHide);
+  const showMenu = sortable || Boolean(onHide) || Boolean(action);
 
   const columnIcon =
     columnId === 'input' ? (
@@ -218,6 +229,7 @@ export const TraceColumnHeader = ({
             onSortAscending={onSortAscending}
             onSortDescending={onSortDescending}
             onHide={onHide}
+            action={action}
             triggerLabel={triggerLabel}
           />
         </span>

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
@@ -35,6 +35,7 @@ import type {
   SessionSelectionHandler,
   SortDirection,
   TraceColumnId,
+  TraceColumnHeaderAction,
   TraceHrefGetter,
   TraceTableColumn,
 } from './types';
@@ -130,6 +131,7 @@ export interface TracesTableProps {
   renderRunName?: (trace: ModelTraceInfoV3) => React.ReactNode;
   /** Hides the column with the given id — wired to the per-header menu's "Hide column" item. */
   onHideColumn: (columnId: string) => void;
+  columnHeaderActions?: Readonly<Partial<Record<string, TraceColumnHeaderAction>>>;
   /** Groups traces with a session id into collapsible session rows. Standalone traces remain rows. */
   isGroupedBySession?: boolean;
   /** Maximum lines shown by input and output previews before truncation. Defaults to one line. */
@@ -187,6 +189,7 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
     onFilterByTag,
     renderRunName,
     onHideColumn,
+    columnHeaderActions,
     isGroupedBySession = false,
     previewLineClamp = 1,
   }: TracesTableProps) {
@@ -580,6 +583,9 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
                     onSortDescending: () => onSort(columnId, 'desc'),
                   }
                 : { onSortAscending: noop, onSortDescending: noop };
+              // Prefer explicit labelText on the column def (for a11y on JSX headers), fall back to string headers.
+              const columnDef = header.column.columnDef as TraceTableColumn;
+              const labelText = columnDef.labelText ?? (typeof labelNode === 'string' ? labelNode : undefined);
               return (
                 <TableHeader
                   key={header.id}
@@ -593,10 +599,11 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
                   <TraceColumnHeader
                     columnId={columnId}
                     label={labelNode}
-                    labelText={typeof labelNode === 'string' ? labelNode : undefined}
+                    labelText={labelText}
                     sortable={isSortableTraceColumn(columnId)}
                     sortDirection={sort === columnId ? dir : 'none'}
                     onHide={() => onHideColumn(columnId)}
+                    action={columnHeaderActions?.[columnId]}
                     {...sortHandlers}
                   />
                 </TableHeader>

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.tsx
@@ -8,6 +8,7 @@ import type {
   PageSize,
   SortDirection,
   TraceColumnId,
+  TraceColumnHeaderAction,
   TraceHrefGetter,
   TraceTableColumn,
 } from './types';
@@ -66,6 +67,7 @@ export interface TracesTableViewProps {
   renderRunName?: (trace: ModelTraceInfoV3) => React.ReactNode;
   /** Hides the column with the given id — forwarded to the table's per-header menu. */
   onHideColumn: (columnId: string) => void;
+  columnHeaderActions?: Readonly<Partial<Record<string, TraceColumnHeaderAction>>>;
   /** Groups traces with a session id into collapsible session rows — forwarded to the table. */
   isGroupedBySession?: boolean;
   /** Maximum lines shown by input and output previews before truncation. Defaults to one line. */
@@ -204,6 +206,7 @@ export const TracesTableView: React.FC<TracesTableViewProps> = (props: TracesTab
       onFilterByTag={props.onFilterByTag}
       renderRunName={props.renderRunName}
       onHideColumn={props.onHideColumn}
+      columnHeaderActions={props.columnHeaderActions}
       isGroupedBySession={props.isGroupedBySession}
       previewLineClamp={props.previewLineClamp}
     />

--- a/mlflow/server/js/src/shared/web-shared/traces-table/columnLabels.ts
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/columnLabels.ts
@@ -16,6 +16,7 @@ export const TRACE_COLUMN_LABELS = defineMessages({
   tokens: { defaultMessage: 'Tokens', description: 'Header for the traces table tokens column' },
   cost: { defaultMessage: 'Cost', description: 'Header for the traces table cost column' },
   tags: { defaultMessage: 'Tags', description: 'Header for the traces table tags column' },
+  metadata: { defaultMessage: 'Metadata', description: 'Header for the traces table metadata column' },
 } as const);
 
 export const getTraceColumnLabel = (columnId: TraceColumnId, intl: IntlShape): string =>

--- a/mlflow/server/js/src/shared/web-shared/traces-table/columns.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/columns.tsx
@@ -17,6 +17,7 @@ import {
   TraceStartTimeCell,
   TraceStateCell,
   TraceTagsCell,
+  TraceMetadataCell,
   TraceTokensCell,
   TraceUserCell,
 } from './TraceCell';
@@ -191,6 +192,22 @@ export const STANDARD_COLUMNS: StandardColumnDef[] = [
           onSelect={onTraceSelected}
           accessibleLabel={openLabel(intl, trace.trace_id, 'tags')}
           onFilterByTag={onFilterByTag}
+        />
+      );
+    },
+  },
+  {
+    id: 'metadata',
+    ...COLUMN_SIZES.metadata,
+    header: () => <FormattedMessage {...TRACE_COLUMN_LABELS.metadata} />,
+    cell: (ctx) => {
+      const { intl, onTraceSelected } = getTableMeta(ctx);
+      const trace = ctx.row.original;
+      return (
+        <TraceMetadataCell
+          trace={trace}
+          onSelect={onTraceSelected}
+          accessibleLabel={openLabel(intl, trace.trace_id, 'metadata')}
         />
       );
     },

--- a/mlflow/server/js/src/shared/web-shared/traces-table/constants.ts
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/constants.ts
@@ -26,6 +26,7 @@ export const TRACE_COLUMN_IDS = [
   'tokens',
   'cost',
   'tags',
+  'metadata',
 ] as const;
 
 /**
@@ -73,4 +74,5 @@ export const COLUMN_SIZES: Record<TraceColumnId, ColumnSizeSpec> = {
   tokens: { size: 110, minSize: 80, maxSize: 220 },
   cost: { size: 110, minSize: 80, maxSize: 220 },
   tags: { size: 200, minSize: 120, maxSize: 600 },
+  metadata: { size: 160, minSize: 120, maxSize: 600 },
 };

--- a/mlflow/server/js/src/shared/web-shared/traces-table/hooks/useTraceColumnVisibility.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/hooks/useTraceColumnVisibility.test.ts
@@ -34,6 +34,7 @@ describe('useTraceColumnVisibility', () => {
       'source',
       'run_name',
       'tags',
+      'metadata',
     ]);
   });
 

--- a/mlflow/server/js/src/shared/web-shared/traces-table/hooks/useTraceColumnVisibility.ts
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/hooks/useTraceColumnVisibility.ts
@@ -1,10 +1,10 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, type Dispatch, type SetStateAction } from 'react';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { TRACE_COLUMN_IDS } from '../constants';
 import type { TraceColumnId } from '../types';
 
 /** Per-column visibility overrides. A column absent from the map falls back to its computed default. */
-type ColumnOverrides = Partial<Record<TraceColumnId, boolean>>;
+type ColumnOverrides = Record<string, boolean>;
 
 export interface UseTraceColumnVisibilityParams {
   /** localStorage key (the consumer scopes it, e.g. per experiment). */
@@ -13,6 +13,8 @@ export interface UseTraceColumnVisibilityParams {
   version: number;
   /** Computes a column's default visibility (may depend on live data the consumer knows about). */
   getDefaultVisible: (id: TraceColumnId) => boolean;
+  /** Recognizes consumer-defined dynamic column ids stored alongside the standard overrides. */
+  isDynamicColumnId?: (id: string) => boolean;
 }
 
 export interface TraceColumnVisibility {
@@ -25,6 +27,8 @@ export interface TraceColumnVisibility {
    * saved/shared view's columns into the user's own persisted state.
    */
   setColumns: (columns: TraceColumnId[]) => void;
+  dynamicVisibilityById: Record<string, boolean>;
+  setDynamicVisibility: Dispatch<SetStateAction<Record<string, boolean>>>;
 }
 
 /**
@@ -40,6 +44,7 @@ export const useTraceColumnVisibility = ({
   storageKey,
   version,
   getDefaultVisible,
+  isDynamicColumnId,
 }: UseTraceColumnVisibilityParams): TraceColumnVisibility => {
   const [overrides, setOverrides] = useLocalStorage<ColumnOverrides>({
     key: storageKey,
@@ -61,17 +66,58 @@ export const useTraceColumnVisibility = ({
     [overrides, getDefaultVisible, setOverrides],
   );
 
-  const resetToDefaults = useCallback(() => setOverrides({}), [setOverrides]);
+  const resetToDefaults = useCallback(
+    () =>
+      setOverrides((current) =>
+        isDynamicColumnId ? Object.fromEntries(Object.entries(current).filter(([id]) => isDynamicColumnId(id))) : {},
+      ),
+    [isDynamicColumnId, setOverrides],
+  );
 
   // Write an explicit override for every column so the adopted set is independent of the live
   // default (a column absent from `columns` is pinned hidden, not left to fall back to its default).
   const setColumns = useCallback(
     (columns: TraceColumnId[]) => {
-      const visible = new Set<string>(columns);
-      setOverrides(Object.fromEntries(TRACE_COLUMN_IDS.map((id) => [id, visible.has(id)])) as ColumnOverrides);
+      const wanted = new Set(columns);
+      setOverrides((current) => {
+        const nextOverrides: ColumnOverrides = isDynamicColumnId
+          ? Object.fromEntries(Object.entries(current).filter(([id]) => isDynamicColumnId(id)))
+          : {};
+        for (const id of TRACE_COLUMN_IDS) {
+          nextOverrides[id] = wanted.has(id);
+        }
+        return nextOverrides;
+      });
     },
-    [setOverrides],
+    [isDynamicColumnId, setOverrides],
   );
 
-  return { visibleColumns, toggleColumn, resetToDefaults, setColumns };
+  const dynamicVisibilityById = useMemo(
+    () =>
+      isDynamicColumnId ? Object.fromEntries(Object.entries(overrides).filter(([id]) => isDynamicColumnId(id))) : {},
+    [isDynamicColumnId, overrides],
+  );
+  const setDynamicVisibility = useCallback<Dispatch<SetStateAction<Record<string, boolean>>>>(
+    (next) =>
+      setOverrides((current) => {
+        const currentDynamic = isDynamicColumnId
+          ? Object.fromEntries(Object.entries(current).filter(([id]) => isDynamicColumnId(id)))
+          : {};
+        const resolved = typeof next === 'function' ? next(currentDynamic) : next;
+        return {
+          ...Object.fromEntries(Object.entries(current).filter(([id]) => !isDynamicColumnId?.(id))),
+          ...resolved,
+        };
+      }),
+    [isDynamicColumnId, setOverrides],
+  );
+
+  return {
+    visibleColumns,
+    toggleColumn,
+    resetToDefaults,
+    setColumns,
+    dynamicVisibilityById,
+    setDynamicVisibility,
+  };
 };

--- a/mlflow/server/js/src/shared/web-shared/traces-table/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/index.ts
@@ -12,6 +12,7 @@ export type {
   SessionHrefGetter,
   SessionSelectionHandler,
   TraceHrefGetter,
+  TraceColumnHeaderAction,
 } from './types';
 
 // Constants
@@ -75,6 +76,7 @@ export {
   TraceTokensCell,
   TraceCostCell,
   TraceTagsCell,
+  TraceMetadataCell,
 } from './TraceCell';
 
 // Filter model (generic AST + UI helpers; API-specific compilation stays consumer-side)

--- a/mlflow/server/js/src/shared/web-shared/traces-table/types.ts
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/types.ts
@@ -18,6 +18,8 @@ export type SessionCellRenderer = (traces: ModelTraceInfoV3[]) => ReactNode;
 /** A table column definition over a trace row — the type product code passes as an `extraColumns` entry. */
 export type TraceTableColumn = ColumnDef<ModelTraceInfoV3> & {
   renderSessionCell?: SessionCellRenderer;
+  /** Plain-text column name for the menu trigger's a11y label when the header is JSX instead of a string. */
+  labelText?: string;
 };
 
 /**
@@ -32,3 +34,9 @@ export type SessionSelectionHandler = (params: { trace: ModelTraceInfoV3; sessio
 
 /** Resolves the destination used by trace identity and preview cells. */
 export type TraceHrefGetter = (trace: ModelTraceInfoV3) => To | undefined;
+
+export interface TraceColumnHeaderAction {
+  label: ReactNode;
+  icon: ReactNode;
+  onClick: () => void;
+}


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25421

### What changes are proposed in this pull request?

Surfaces user-authored trace **tags** and **metadata** as opt-in columns in the Traces V4 table. Each key becomes its own column (`tag:<key>` / `custom_metadata:<key>`), grouped under **Tags** / **Metadata** sections in the column selector. The aggregate Tags/Metadata column headers gain an "Expand columns" action that reveals every field in that group at once, and per-field visibility is captured in saved views.

Mechanically:
- `useTraceColumnVisibility` gains an optional `isDynamicColumnId` so data-driven column overrides (the per-key columns) survive reset / saved-view restore instead of being wiped with the standard set.
- New `useTracesV4CustomColumns` discovers candidate keys per page (internal `mlflow.*` keys filtered out) and exposes Tags/Metadata groups, mirroring the existing assessment-columns hook.
- Saved views persist an optional `customColumns` map (opt-in: absent id ⇒ hidden), threaded through capture / restore / dirty exactly like `assessmentColumns`.
- Adds an aggregate `metadata` standard column (peer of `tags`) and icon headers for dynamic columns; the header menu keeps a specific accessible label for icon headers via an optional `labelText`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests



* Test that I can expand tag columns
* Tags are persisted in saved view






https://github.com/user-attachments/assets/fbd0ed8d-ec2c-46cc-b620-a7f883f75440






### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Traces V4 can now show user-authored trace tags and metadata as individual opt-in columns, with per-column visibility saved in views.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release