### PR TITLE
Skip full test suites when only `review.yml` changes

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -20,6 +20,7 @@ on:
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
       - ".claude/**"
+      - ".github/workflows/review.yml"
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -15,6 +15,7 @@ on:
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
       - ".claude/**"
+      - ".github/workflows/review.yml"
   workflow_dispatch:
     inputs:
       repository:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -15,6 +15,7 @@ on:
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
       - ".claude/**"
+      - ".github/workflows/review.yml"
   schedule:
     # Run this action daily at 13:00 UTC
     - cron: "0 13 * * *"

--- a/.github/workflows/fs2db.yml
+++ b/.github/workflows/fs2db.yml
@@ -20,6 +20,7 @@ on:
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
       - ".claude/**"
+      - ".github/workflows/review.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,6 +15,7 @@ on:
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
       - ".claude/**"
+      - ".github/workflows/review.yml"
   push:
     branches:
       - master

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -19,6 +19,7 @@ on:
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
       - ".claude/**"
+      - ".github/workflows/review.yml"
   schedule:
     # Run this workflow daily at 13:00 UTC
     - cron: "0 13 * * *"

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -15,6 +15,7 @@ on:
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
       - ".claude/**"
+      - ".github/workflows/review.yml"
   push:
     branches:
       - master

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -15,6 +15,7 @@ on:
       - "mlflow/server/js/**"
       - ".github/workflows/js.yml"
       - ".claude/**"
+      - ".github/workflows/review.yml"
   push:
     branches:
       - master


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25423

### What changes are proposed in this pull request?

Editing `review.yml` currently triggers the full test matrix. #25423 was a four-line workflow change and still ran `python`, `models`, `evaluate`, `genai`, `pyfunc`, `database`, and the rest.

`review.yml` only configures the `/review` bot, so it can't affect those suites. This adds it to the `paths-ignore` list that already exempts `.claude/**` for the same reason, across the eight workflows that share that list.

`review.yml` keeps its own `pull_request` trigger on its own path, so changes to it still get a smoke run.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
