### PR TITLE
Extract the gateway setup into a composite action

### DIFF
--- a/.github/actions/setup-anthropic/action.yml
+++ b/.github/actions/setup-anthropic/action.yml
@@ -1,0 +1,54 @@
+name: "setup-anthropic"
+description: "Mint a Databricks AI Gateway bearer and emit the Claude CLI env values as outputs"
+inputs:
+  task:
+    description: "Names the automation spending the tokens, e.g. pr-review. Tags the requests for cost attribution."
+    required: true
+  host:
+    description: "Databricks workspace URL"
+    required: true
+  client-id:
+    description: "OAuth client ID of the service principal"
+    required: true
+  client-secret:
+    description: "OAuth client secret of the service principal"
+    required: true
+outputs:
+  base-url:
+    description: "Value for ANTHROPIC_BASE_URL"
+    value: ${{ steps.gateway.outputs.base-url }}
+  token:
+    description: "Value for ANTHROPIC_AUTH_TOKEN. Short-lived, and masked in logs."
+    value: ${{ steps.gateway.outputs.token }}
+  custom-headers:
+    description: "Value for ANTHROPIC_CUSTOM_HEADERS, carrying the request tags"
+    value: ${{ steps.gateway.outputs.custom-headers }}
+runs:
+  using: "composite"
+  steps:
+    # Only the short-lived bearer leaves this action; the client secret stays here.
+    - id: gateway
+      shell: bash
+      env:
+        DATABRICKS_HOST: ${{ inputs.host }}
+        DATABRICKS_CLIENT_ID: ${{ inputs.client-id }}
+        DATABRICKS_CLIENT_SECRET: ${{ inputs.client-secret }}
+        TASK: ${{ inputs.task }}
+      run: |
+        RESPONSE=$(curl -sS --max-time 15 \
+          -u "$DATABRICKS_CLIENT_ID:$DATABRICKS_CLIENT_SECRET" \
+          -d grant_type=client_credentials -d scope=ai-gateway \
+          "$DATABRICKS_HOST/oidc/v1/token")
+        TOKEN=$(jq -r '.access_token // empty' <<< "$RESPONSE")
+        if [ -z "$TOKEN" ]; then
+          # The body carries the OAuth error code, the only way to tell a bad
+          # secret from a missing workspace assignment.
+          echo "::error::Gateway token exchange failed: $(jq -r '.error_description // .error // "no access_token"' <<< "$RESPONSE")"
+          exit 1
+        fi
+        echo "::add-mask::$TOKEN"
+        echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+        # `%/` so a trailing slash on the input can't produce a `//` path.
+        echo "base-url=${DATABRICKS_HOST%/}/ai-gateway/anthropic" >> "$GITHUB_OUTPUT"
+        TAGS=$(jq -cn --arg repository "$GITHUB_REPOSITORY" --arg task "$TASK" '{$repository, $task}')
+        echo "custom-headers=Databricks-Ai-Gateway-Request-Tags: $TAGS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/review.yml"
+      - ".github/actions/setup-anthropic/**"
       - ".claude/scripts/**"
       - ".claude/skills/pr-review/**"
 
@@ -213,32 +214,14 @@ jobs:
 
           echo "$COMMENT_BODY" | python /tmp/parse_args.py >> "$GITHUB_OUTPUT"
 
-      # Only the short-lived bearer reaches the Claude step; the client secret
-      # stays in this step.
-      - name: Configure gateway
-        id: gateway
-        env:
-          DATABRICKS_HOST: ${{ secrets.DATABRICKS_GATEWAY_HOST }}
-          DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_GATEWAY_CLIENT_ID }}
-          DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_GATEWAY_CLIENT_SECRET }}
-        run: |
-          RESPONSE=$(curl -sS --max-time 15 \
-            -u "$DATABRICKS_CLIENT_ID:$DATABRICKS_CLIENT_SECRET" \
-            -d grant_type=client_credentials -d scope=ai-gateway \
-            "$DATABRICKS_HOST/oidc/v1/token")
-          TOKEN=$(jq -r '.access_token // empty' <<< "$RESPONSE")
-          if [ -z "$TOKEN" ]; then
-            # The body carries the OAuth error code, the only way to tell a bad
-            # secret from a missing workspace assignment.
-            echo "::error::Gateway token exchange failed: $(jq -r '.error_description // .error // "no access_token"' <<< "$RESPONSE")"
-            exit 1
-          fi
-          echo "::add-mask::$TOKEN"
-          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
-          # `%/` so a trailing slash on the secret can't produce a `//` path.
-          echo "base-url=${DATABRICKS_HOST%/}/ai-gateway/anthropic" >> "$GITHUB_OUTPUT"
-          TAGS=$(jq -cn --arg repository "$GITHUB_REPOSITORY" '{$repository, task: "pr-review"}')
-          echo "custom-headers=Databricks-Ai-Gateway-Request-Tags: $TAGS" >> "$GITHUB_OUTPUT"
+      - name: Set up Anthropic
+        id: anthropic
+        uses: ./base/.github/actions/setup-anthropic
+        with:
+          task: pr-review
+          host: ${{ secrets.DATABRICKS_GATEWAY_HOST }}
+          client-id: ${{ secrets.DATABRICKS_GATEWAY_CLIENT_ID }}
+          client-secret: ${{ secrets.DATABRICKS_GATEWAY_CLIENT_SECRET }}
 
       - name: Review
         id: review
@@ -246,9 +229,9 @@ jobs:
         env:
           # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
           GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
-          ANTHROPIC_BASE_URL: ${{ steps.gateway.outputs.base-url }}
-          ANTHROPIC_AUTH_TOKEN: ${{ steps.gateway.outputs.token }}
-          ANTHROPIC_CUSTOM_HEADERS: ${{ steps.gateway.outputs.custom-headers }}
+          ANTHROPIC_BASE_URL: ${{ steps.anthropic.outputs.base-url }}
+          ANTHROPIC_AUTH_TOKEN: ${{ steps.anthropic.outputs.token }}
+          ANTHROPIC_CUSTOM_HEADERS: ${{ steps.anthropic.outputs.custom-headers }}
           # The gateway's beta allowlist rejects several of the CLI's
           # experimental betas with HTTP 400.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
@@ -335,7 +318,7 @@ jobs:
         env:
           GH_TOKEN_READ: ${{ steps.app-token-read.outputs.token }}
           GH_TOKEN_WRITE: ${{ steps.app-token-write.outputs.token }}
-          GATEWAY_TOKEN: ${{ steps.gateway.outputs.token }}
+          GATEWAY_TOKEN: ${{ steps.anthropic.outputs.token }}
         run: |
           python <<'PY'
           import os


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #25409 and #25423

### What changes are proposed in this pull request?

`review.yml` reached the Databricks AI Gateway through ~20 inline lines: an OAuth exchange, the `/ai-gateway/anthropic` base URL, and the request-tags header. That is gateway plumbing rather than anything specific to reviewing PRs, so a second consumer (issue triage, say) would have to copy it.

This moves it into `.github/actions/setup-anthropic`:

```yaml
- uses: ./base/.github/actions/setup-anthropic
  id: gateway
  with:
    task: pr-review
    host: ${{ secrets.DATABRICKS_GATEWAY_HOST }}
    client-id: ${{ secrets.DATABRICKS_GATEWAY_CLIENT_ID }}
    client-secret: ${{ secrets.DATABRICKS_GATEWAY_CLIENT_SECRET }}
```

The caller still names its own `task`, so cost attribution stays visible at the call site while the header shape moves out of the workflow. Only the short-lived bearer leaves the action; the client secret stays inside it.

The action resolves from `base/`, the checkout #25432 made the job run everything else from, so it needs no checkout of its own and never comes from PR-controlled code.

### How is this PR tested?

- [x] Manual tests

The `pull_request` trigger runs `/pr-review` end to end, which exercises the action.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
