### PR TITLE
Add a composite action for Databricks AI Gateway setup

### DIFF
--- a/.github/actions/databricks-gateway/action.yml
+++ b/.github/actions/databricks-gateway/action.yml
@@ -1,0 +1,54 @@
+name: "databricks-gateway"
+description: "Mint a Databricks AI Gateway bearer and expose the Claude CLI environment"
+inputs:
+  task:
+    description: "Names the automation spending the tokens, e.g. pr-review. Tags the requests for cost attribution."
+    required: true
+  host:
+    description: "Databricks workspace URL"
+    required: true
+  client-id:
+    description: "OAuth client ID of the service principal"
+    required: true
+  client-secret:
+    description: "OAuth client secret of the service principal"
+    required: true
+outputs:
+  base-url:
+    description: "Value for ANTHROPIC_BASE_URL"
+    value: ${{ steps.gateway.outputs.base-url }}
+  token:
+    description: "Value for ANTHROPIC_AUTH_TOKEN. Short-lived, and masked in logs."
+    value: ${{ steps.gateway.outputs.token }}
+  custom-headers:
+    description: "Value for ANTHROPIC_CUSTOM_HEADERS, carrying the request tags"
+    value: ${{ steps.gateway.outputs.custom-headers }}
+runs:
+  using: "composite"
+  steps:
+    # Only the short-lived bearer leaves this action; the client secret stays here.
+    - id: gateway
+      shell: bash
+      env:
+        DATABRICKS_HOST: ${{ inputs.host }}
+        DATABRICKS_CLIENT_ID: ${{ inputs.client-id }}
+        DATABRICKS_CLIENT_SECRET: ${{ inputs.client-secret }}
+        TASK: ${{ inputs.task }}
+      run: |
+        RESPONSE=$(curl -sS --max-time 15 \
+          -u "$DATABRICKS_CLIENT_ID:$DATABRICKS_CLIENT_SECRET" \
+          -d grant_type=client_credentials -d scope=ai-gateway \
+          "$DATABRICKS_HOST/oidc/v1/token")
+        TOKEN=$(jq -r '.access_token // empty' <<< "$RESPONSE")
+        if [ -z "$TOKEN" ]; then
+          # The body carries the OAuth error code, the only way to tell a bad
+          # secret from a missing workspace assignment.
+          echo "::error::Gateway token exchange failed: $(jq -r '.error_description // .error // "no access_token"' <<< "$RESPONSE")"
+          exit 1
+        fi
+        echo "::add-mask::$TOKEN"
+        echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+        # `%/` so a trailing slash on the input can't produce a `//` path.
+        echo "base-url=${DATABRICKS_HOST%/}/ai-gateway/anthropic" >> "$GITHUB_OUTPUT"
+        TAGS=$(jq -cn --arg repository "$GITHUB_REPOSITORY" --arg task "$TASK" '{$repository, $task}')
+        echo "custom-headers=Databricks-Ai-Gateway-Request-Tags: $TAGS" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25409, #25423. Wired up in #25430.

### What changes are proposed in this pull request?

`review.yml` reaches the Databricks AI Gateway through ~20 inline lines: an OAuth exchange, the `/ai-gateway/anthropic` base URL, and the request-tags header. That is gateway plumbing rather than anything specific to reviewing PRs, so a second consumer (issue triage, say) would have to copy it.

This adds the action on its own. Callers pass their own `task` and get `base-url`, `token`, and `custom-headers`:

```yaml
- uses: ./trusted/.github/actions/databricks-gateway
  id: gateway
  with:
    task: pr-review
    host: ${{ secrets.DATABRICKS_GATEWAY_HOST }}
    client-id: ${{ secrets.DATABRICKS_GATEWAY_CLIENT_ID }}
    client-secret: ${{ secrets.DATABRICKS_GATEWAY_CLIENT_SECRET }}
```

Nothing uses it yet; #25430 switches `review.yml` over and carries the checkout changes that keep the action out of the reviewed PR's tree.

Secrets are inputs rather than inherited, since composite actions don't get them implicitly.

### How is this PR tested?

- [x] Manual tests

Exercised end to end as part of #25430, whose `/pr-review` smoke run passed against the real gateway. This PR alone touches no workflow, so it gets no run of its own.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
