### PR TITLE
Stop running the review job from the PR checkout

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,14 +2,31 @@
 name: pr-review
 description: Review a pull request and emit a validated review payload.
 disable-model-invocation: true
-argument-hint: "<pr_url> <payload_path> <media_dir>"
-arguments: [pr_url, payload_path, media_dir]
+argument-hint: "<pr_url> <pr_checkout> <payload_path> <media_dir>"
+arguments: [pr_url, pr_checkout, payload_path, media_dir]
 ---
 
 # Review Pull Request
 
 Review $pr_url and write a JSON review payload to $payload_path. Do not post anything: writing
 that payload is the whole job.
+
+## The reviewed tree
+
+The PR is checked out at `$pr_checkout`, not in the working directory:
+
+```text
+$GITHUB_WORKSPACE/
+├── base/   # the working directory: this skill and the `skills` CLI come from
+│           # here, and nothing you review does
+└── pr/     # $pr_checkout, the reviewed tree: the PR merged into its base
+```
+
+The working directory holds a checkout of the same repository, so it looks like the code under
+review and is not guaranteed to match it. Everything aimed at the PR needs the prefix:
+`git -C $pr_checkout ...`, `$pr_checkout/<path>` to open or grep a file, and
+`cd $pr_checkout && ...` for anything that builds or runs repository code. The
+`uv run --package skills` commands below are the exception, and run unprefixed.
 
 ## Instructions
 
@@ -26,11 +43,11 @@ These reads are independent. Issue them as parallel tool calls in a single turn,
 gh pr view <pr_url> --json title,body
 ```
 
-**PR diff hunks**. The working tree is the merge ref (see step 3), so `HEAD^1 HEAD` is exactly the
-PR diff:
+**PR diff hunks**. `$pr_checkout` holds the merge ref (see step 3), so `HEAD^1 HEAD` is exactly
+the PR diff:
 
 ```bash
-git diff HEAD^1 HEAD | uv run --package skills skills annotate-diff
+git -C $pr_checkout diff HEAD^1 HEAD | uv run --package skills skills annotate-diff
 ```
 
 Each line comes back as `old_line new_line | <marker> content`, which gives you the `line` and
@@ -68,18 +85,19 @@ gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<pr_number> \
 Load the repository style rules applicable to the changed files:
 
 ```bash
-git diff --name-only HEAD^1 | uv run --package skills skills load-rules
+git -C $pr_checkout diff --name-only HEAD^1 | uv run --package skills skills load-rules
 ```
 
 ### 3. Analyze the change
 
-The working tree holds the PR merged into the base (`refs/pull/<pr_number>/merge`), so file contents
-reflect the post-merge state. Explore it for context beyond the diff (existing patterns, call sites
-of changed symbols, file conventions).
+`$pr_checkout` holds the PR merged into the base (`refs/pull/<pr_number>/merge`), so its file
+contents reflect the post-merge state. Explore it for context beyond the diff (existing patterns,
+call sites of changed symbols, file conventions), scoping every search to that directory.
 
 The merge ref's base parent is reachable as `HEAD^1`. When the diff doesn't show enough (verifying
 a refactor preserved behavior, reading a masked deleted file, or seeing the pre-change version of a
-heavily modified one), use `git show HEAD^1:<path>` rather than re-fetching the file over the API.
+heavily modified one), use `git -C $pr_checkout show HEAD^1:<path>` rather than re-fetching the file
+over the API.
 The checkout is shallow, so nothing older than `HEAD^1` exists: `git log` and `git blame` stop at
 the shallow boundary rather than reaching the commit that actually introduced a line. Neither
 errors, so don't trust them for pre-change history.

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -93,6 +93,7 @@ jobs:
     env:
       REVIEW_PAYLOAD: /tmp/review-payload.json
       REVIEW_MEDIA: /tmp/review-media
+      PR_CHECKOUT: ${{ github.workspace }}/pr
     steps:
       # Two app tokens with split scopes:
       # - app-token-read (read-only): used by the Claude step so prompt-injection
@@ -127,31 +128,49 @@ jobs:
         run: |
           printf '%s\n\n---\n\n🚀 [Review running...](%s)' "$COMMENT_BODY" "$JOB_RUN_URL" \
             | gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          token: ${{ steps.app-token-read.outputs.token }}
-          ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
-          # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
-          # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
-          fetch-depth: 2
+      # Each checkout owns a subdirectory, so neither cleans the other and the
+      # two can run together.
+      - parallel:
+          # Everything this job runs comes from here: the setup actions, the
+          # install scripts, the `.claude` config Claude loads (settings, hooks,
+          # skills), and the `skills` CLI. No `ref`, so this is `github.ref` at
+          # `github.sha`, the commit the workflow file itself was read from:
+          # the default branch on `issue_comment`, and the PR's merge ref on
+          # `pull_request`, where the two checkouts are the same tree and
+          # changes to this tooling get smoke-tested.
+          - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            with:
+              persist-credentials: false
+              token: ${{ steps.app-token-read.outputs.token }}
+              path: base
+          # The reviewed tree, passed to the review as a path. Nothing the job
+          # itself runs comes from here.
+          - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            with:
+              persist-credentials: false
+              token: ${{ steps.app-token-read.outputs.token }}
+              ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
+              path: pr
+              # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
+              # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
+              fetch-depth: 2
       # HEAD^2 of the merge ref is the PR head. Resolved before the review step,
-      # which runs with Bash in this tree.
+      # which runs Bash against that tree.
       - name: Pin reviewed head commit
         run: |
-          PR_HEAD_SHA=$(git rev-parse HEAD^2)
+          PR_HEAD_SHA=$(git -C "$PR_CHECKOUT" rev-parse HEAD^2)
           echo "PR_HEAD_SHA=$PR_HEAD_SHA" >> "$GITHUB_ENV"
       - parallel:
-          - uses: ./.github/actions/setup-python
+          - uses: ./base/.github/actions/setup-python
             with:
               pin-micro-version: false
-          - uses: ./.github/actions/setup-node
+          - uses: ./base/.github/actions/setup-node
           - name: Install Claude CLI
             run: |
-              .claude/scripts/install-claude.sh
+              base/.claude/scripts/install-claude.sh
           - name: Install agent-browser
             run: |
-              .claude/scripts/install-agent-browser.sh
+              base/.claude/scripts/install-agent-browser.sh
       - name: Verify tools
         run: |
           claude --version
@@ -223,6 +242,7 @@ jobs:
 
       - name: Review
         id: review
+        working-directory: base
         env:
           # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
           GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
@@ -248,11 +268,12 @@ jobs:
             --effort "$EFFORT" \
             --max-budget-usd 8 \
             --permission-mode auto \
+            --add-dir "$PR_CHECKOUT" \
             --allowed-tools "Bash(uv run --package skills skills:*)" \
             --print \
             --verbose \
             --output-format stream-json \
-            "/pr-review $PR_URL $REVIEW_PAYLOAD $REVIEW_MEDIA" \
+            "/pr-review $PR_URL $PR_CHECKOUT $REVIEW_PAYLOAD $REVIEW_MEDIA" \
             | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 30 minutes"
@@ -267,6 +288,7 @@ jobs:
       # smoke path stays non-mutating.
       - name: Upload review media
         if: github.event_name == 'issue_comment'
+        working-directory: base
         # Attaching media is a nicety; losing the whole review over it is not. Any
         # fault here must not take the job down before Post review.
         continue-on-error: true
@@ -292,6 +314,7 @@ jobs:
           mv /tmp/pinned-payload.json "$REVIEW_PAYLOAD"
 
       - name: Validate review payload
+        working-directory: base
         run: |
           uv run --package skills skills validate-review "$REVIEW_PAYLOAD"
           echo "::group::Review payload"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25409

### What changes are proposed in this pull request?

`review.yml` checks out `refs/pull/N/merge` at the workspace root and runs everything from that tree:

```yaml
- uses: ./.github/actions/setup-python
- run: .claude/scripts/install-claude.sh
- run: claude ... "/pr-review ..."     # loads .claude settings, hooks, skills
- run: uv run --package skills skills embed-media ...
```

All of it lands in the job that holds the gateway token, both app tokens, and `UPLOAD_MEDIA_TOKEN`, so PR-controlled code runs with those credentials in scope: a `PreToolUse` hook, an edited `pr-review` skill, or a `PATH` shim planted before the credential steps. `.claude/rules/github-actions.md` already says not to point local actions at a PR head checkout for this reason.

This splits the workspace in two:

```text
$GITHUB_WORKSPACE/
├── base/   # the commit the workflow file itself was read from; every step
│           # that runs repository code runs from here
└── pr/     # the reviewed merge ref, reaching Claude as a /pr-review argument
```

`base/` passes no `ref`, so it lands on `github.ref` at `github.sha`: the default branch on `issue_comment`, and the PR's merge ref on `pull_request`, which keeps changes to this tooling smoke-tested. Neither checkout cleans the other, so the two run in parallel.

The skill takes the reviewed tree as `$pr_checkout` and reaches it with `git -C`, and says why: the working directory is a checkout of the same repository, so it looks like the code under review while reflecting none of it.

### How is this PR tested?

- [x] Manual tests

The `pull_request` trigger runs `/pr-review` end to end against the new layout.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
