### PR TITLE
Render agent span types and guardrail status

### DIFF
--- a/docs/docs/genai/concepts/span.mdx
+++ b/docs/docs/genai/concepts/span.mdx
@@ -197,6 +197,8 @@ retrieved_docs = retrieve_relevant_documents(user_query)
 The `GUARDRAIL` span type represents a policy or safety check. Set the span's inputs to the value
 being checked and its outputs to the guardrail response or explanation. To show the result in the
 MLflow UI, set the `mlflow.guardrail.status` attribute to `"passed"` or `"blocked"`.
+A successful sanitization is `"passed"` because the guardrail allows the rewritten payload. Use
+`"blocked"` when the operation does not proceed, including when sanitization fails.
 
 ```python
 import mlflow

--- a/docs/docs/genai/concepts/span.mdx
+++ b/docs/docs/genai/concepts/span.mdx
@@ -76,6 +76,10 @@ Span types are a way to categorize spans within a trace. MLflow provides a set o
     | `"PARSER"`     | Represents a parsing operation, transforming text into a structured format.            |
     | `"RERANKER"`   | Represents a re-ranking operation, ordering the retrieved contexts based on relevance. |
     | `"MEMORY"`     | Represents a memory operation, such as persisting context in a long-term memory db.    |
+    | `"WORKFLOW"`   | Represents a workflow that coordinates multiple operations.                           |
+    | `"TASK"`       | Represents a discrete task within an agent or workflow.                                |
+    | `"GUARDRAIL"`  | Represents a guardrail check that can allow or block an operation.                     |
+    | `"EVALUATOR"`  | Represents an evaluation operation.                                                    |
     | `"UNKNOWN"`    | A default span type that is used when no other span type is specified.                 |
   </TabItem>
   <TabItem value="usage" label="Setting Span Types">
@@ -186,6 +190,24 @@ def retrieve_relevant_documents(query: str):
 # Example usage
 user_query = "MLflow Tracing benefits"
 retrieved_docs = retrieve_relevant_documents(user_query)
+```
+
+### Guardrail Spans
+
+The `GUARDRAIL` span type represents a policy or safety check. Set the span's inputs to the value
+being checked and its outputs to the guardrail response or explanation. To show the result in the
+MLflow UI, set the `mlflow.guardrail.status` attribute to `"passed"` or `"blocked"`.
+
+```python
+import mlflow
+from mlflow.entities import SpanType
+
+
+with mlflow.start_span(name="check_request", span_type=SpanType.GUARDRAIL) as span:
+    span.set_inputs({"request": request})
+    passed, explanation = check_request(request)
+    span.set_attribute("mlflow.guardrail.status", "passed" if passed else "blocked")
+    span.set_outputs({"explanation": explanation})
 ```
 
 ## Span Links

--- a/mlflow/gateway/guardrails.py
+++ b/mlflow/gateway/guardrails.py
@@ -32,6 +32,7 @@ ScorerResult = bool | str | Feedback | list[Feedback]
 # Header added to internal sanitization requests so the gateway can skip guardrails
 # on the call, preventing recursive guardrail execution loops.
 _SANITIZE_BYPASS_HEADER = "X-MLflow-Guardrail-Bypass"
+_GUARDRAIL_STATUS_ATTRIBUTE = "mlflow.guardrail.status"
 _MAX_RATIONALE_LEN = 500
 
 # Only forward these headers to internal sanitization calls — forwarding all
@@ -351,6 +352,7 @@ class JudgeGuardrail(Guardrail):
                 result = await asyncio.to_thread(self._invoke_judge, inputs=request)
                 passed = self._is_passing(result)
                 jspan.set_outputs({"passed": passed, "rationale": self._get_rationale(result)})
+            gspan.set_attribute(_GUARDRAIL_STATUS_ATTRIBUTE, "passed" if passed else "blocked")
             output = await self._enforce(
                 request,
                 result,
@@ -358,6 +360,8 @@ class JudgeGuardrail(Guardrail):
                 usage_tracking=usage_tracking,
                 payload_schema=payload_schema,
             )
+            if not passed:
+                gspan.set_attribute(_GUARDRAIL_STATUS_ATTRIBUTE, "passed")
             gspan.set_outputs(output)
             return output
 
@@ -388,6 +392,7 @@ class JudgeGuardrail(Guardrail):
                 )
                 passed = self._is_passing(result)
                 jspan.set_outputs({"passed": passed, "rationale": self._get_rationale(result)})
+            gspan.set_attribute(_GUARDRAIL_STATUS_ATTRIBUTE, "passed" if passed else "blocked")
             output = await self._enforce(
                 response,
                 result,
@@ -395,6 +400,8 @@ class JudgeGuardrail(Guardrail):
                 usage_tracking=usage_tracking,
                 payload_schema=payload_schema,
             )
+            if not passed:
+                gspan.set_attribute(_GUARDRAIL_STATUS_ATTRIBUTE, "passed")
             gspan.set_outputs(output)
             return output
 

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3571,6 +3571,10 @@
     "defaultMessage": "Cancel",
     "description": "Experiment page > new run modal > \"cancel\" button label"
   },
+  "CU5zyF": {
+    "defaultMessage": "Passed",
+    "description": "Status label for a guardrail span that allowed an operation"
+  },
   "CUKIO0": {
     "defaultMessage": "The \"{alias}\" alias is also being used on version {otherVersion}. Adding it to this version will remove it from version {otherVersion}.",
     "description": "Alias editor > Warning about reusing alias from the other version"
@@ -14235,6 +14239,10 @@
     "defaultMessage": "Last updated by",
     "description": "Column selector label for the last-updated-by column"
   },
+  "t3kDZq": {
+    "defaultMessage": "Blocked",
+    "description": "Status label for a guardrail span that blocked an operation"
+  },
   "t3mHNt": {
     "defaultMessage": "Errors",
     "description": "Title for the errors chart"
@@ -15322,6 +15330,10 @@
   "xiiaIF": {
     "defaultMessage": "Run on all future traces",
     "description": "Label for toggle to enable automatic evaluation"
+  },
+  "xkKQ/b": {
+    "defaultMessage": "Guardrail result",
+    "description": "Label for the result of a guardrail span in the model trace explorer"
   },
   "xmPKKq": {
     "defaultMessage": "Model Version:",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2555,6 +2555,10 @@
     "defaultMessage": "Created by:",
     "description": "MCP compare metadata created by label"
   },
+  "8e7obo": {
+    "defaultMessage": "Task",
+    "description": "Display name for a task span in the model trace explorer"
+  },
   "8eVxXM": {
     "defaultMessage": "Cancel",
     "description": "Cancel delete webhook button"
@@ -10055,6 +10059,10 @@
     "defaultMessage": "Disable grouped runs to compare parameters, tag, or attributes",
     "description": "Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > disable group runs tooltip message"
   },
+  "ct0u/N": {
+    "defaultMessage": "Workflow",
+    "description": "Display name for a workflow span in the model trace explorer"
+  },
   "cto1kL": {
     "defaultMessage": "About tool definitions",
     "description": "Aria label for the info popover next to the Tools section header"
@@ -14179,6 +14187,10 @@
     "defaultMessage": "Use workspace settings",
     "description": "Label for a radio button that configures the x-axis on a line chart. This option is for using global workspace settings."
   },
+  "srmY5V": {
+    "defaultMessage": "Guardrail",
+    "description": "Display name for a guardrail span in the model trace explorer"
+  },
   "ss//L4": {
     "defaultMessage": "{subMessage}, go back to <link>the home page.</link>",
     "description": "Default error message for error views in MLflow"
@@ -14766,6 +14778,10 @@
   "vedifc": {
     "defaultMessage": "Enter API key or select saved key",
     "description": "Placeholder for API key combobox input"
+  },
+  "vf4FHp": {
+    "defaultMessage": "Evaluator",
+    "description": "Display name for an evaluator span in the model trace explorer"
   },
   "vfJdto": {
     "defaultMessage": "This experiment has reached the limit of {maxViews} custom views. Delete a view before creating a new one.",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
@@ -1,4 +1,5 @@
 import type { TimelineTreeNode } from './timeline-tree/TimelineTree.types';
+import type { ModelTraceGuardrailStatus } from './spanAttributeReader';
 
 export const MLFLOW_TRACE_SCHEMA_VERSION_KEY = 'mlflow.trace_schema.version';
 
@@ -59,7 +60,7 @@ export enum ModelIconType {
   EVALUATOR = 'evaluator',
 }
 
-export type ModelTraceGuardrailStatus = 'passed' | 'blocked';
+export type { ModelTraceGuardrailStatus };
 
 /**
  * Represents a single model trace span.

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
@@ -20,6 +20,10 @@ export enum ModelSpanType {
   EMBEDDING = 'EMBEDDING',
   RERANKER = 'RERANKER',
   MEMORY = 'MEMORY',
+  WORKFLOW = 'WORKFLOW',
+  TASK = 'TASK',
+  GUARDRAIL = 'GUARDRAIL',
+  EVALUATOR = 'EVALUATOR',
   UNKNOWN = 'UNKNOWN',
 }
 
@@ -49,7 +53,13 @@ export enum ModelIconType {
   USER = 'user',
   SYSTEM = 'system',
   SAVE = 'save',
+  WORKFLOW = 'workflow',
+  TASK = 'task',
+  GUARDRAIL = 'guardrail',
+  EVALUATOR = 'evaluator',
 }
+
+export type ModelTraceGuardrailStatus = 'passed' | 'blocked';
 
 /**
  * Represents a single model trace span.
@@ -347,6 +357,7 @@ export interface ModelTraceSpanNode
   modelName?: string;
   cost?: SpanCostInfo;
   linkedGatewayTraceId?: string;
+  guardrailStatus?: ModelTraceGuardrailStatus;
   // Severity classification, sourced from `mlflow.spanLogLevel`. Spans without
   // an explicit level have this undefined; the trace-explorer filter treats
   // missing as DEBUG so old/unclassified spans stay visible by default.

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -47,7 +47,11 @@ import {
   isSessionLevelAssessment,
   createTraceV4SerializedLocation,
   parseTraceV4SerializedLocation,
+  getDisplayNameForSpanType,
+  getIconTypeForSpan,
+  getGuardrailStatus,
 } from './ModelTraceExplorer.utils';
+import { ModelIconType } from './ModelTrace.types';
 import { TEST_SPAN_FILTER_STATE } from './timeline-tree/TimelineTree.test-utils';
 
 describe('parseTraceToTree', () => {
@@ -166,6 +170,32 @@ describe('parseTraceToTree', () => {
     expect(rootNode?.children?.[0].key).toBe('child1');
     expect(rootNode?.children?.[1].key).toBe('child2');
     expect(rootNode?.children?.[2].key).toBe('child3');
+  });
+});
+
+describe('span type presentation', () => {
+  it.each([
+    [ModelSpanType.WORKFLOW, 'Workflow', ModelIconType.WORKFLOW],
+    [ModelSpanType.TASK, 'Task', ModelIconType.TASK],
+    [ModelSpanType.GUARDRAIL, 'Guardrail', ModelIconType.GUARDRAIL],
+    [ModelSpanType.EVALUATOR, 'Evaluator', ModelIconType.EVALUATOR],
+  ])('renders %s with an explicit display name and icon', (spanType, displayName, iconType) => {
+    expect(getDisplayNameForSpanType(spanType)).toBe(displayName);
+    expect(getIconTypeForSpan(spanType)).toBe(iconType);
+  });
+
+  it('retains generic fallbacks for custom span types', () => {
+    expect(getDisplayNameForSpanType('ROUTER')).toBe('ROUTER');
+    expect(getIconTypeForSpan('ROUTER')).toBe(ModelIconType.FUNCTION);
+  });
+
+  it.each([
+    ['passed', 'passed'],
+    ['blocked', 'blocked'],
+    ['warning', undefined],
+    [undefined, undefined],
+  ] as const)('parses guardrail status %s', (value, expected) => {
+    expect(getGuardrailStatus(value)).toBe(expected);
   });
 });
 
@@ -836,6 +866,30 @@ describe('normalizeNewSpanData', () => {
     const normalized = normalizeNewSpanData(MOCK_V3_SPANS[0], 0, 0, [], {}, '');
     expect(normalized.modelName).toBeUndefined();
     expect(normalized.cost).toBeUndefined();
+  });
+
+  it.each(['passed', 'blocked'] as const)('extracts a valid %s guardrail status', (status) => {
+    const guardrailSpan: ModelTraceSpanV3 = {
+      ...MOCK_V3_SPANS[0],
+      attributes: {
+        ...MOCK_V3_SPANS[0].attributes,
+        'mlflow.guardrail.status': status,
+      },
+    };
+
+    expect(normalizeNewSpanData(guardrailSpan, 0, 0, [], {}, '').guardrailStatus).toBe(status);
+  });
+
+  it('ignores an invalid guardrail status', () => {
+    const guardrailSpan: ModelTraceSpanV3 = {
+      ...MOCK_V3_SPANS[0],
+      attributes: {
+        ...MOCK_V3_SPANS[0].attributes,
+        'mlflow.guardrail.status': 'warning',
+      },
+    };
+
+    expect(normalizeNewSpanData(guardrailSpan, 0, 0, [], {}, '').guardrailStatus).toBeUndefined();
   });
 });
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
+import type { IntlShape } from '@databricks/i18n';
 
 import type {
   Assessment,
@@ -174,18 +175,22 @@ describe('parseTraceToTree', () => {
 });
 
 describe('span type presentation', () => {
+  const intl = {
+    formatMessage: ({ defaultMessage }: { defaultMessage?: string }) => defaultMessage,
+  } as IntlShape;
+
   it.each([
     [ModelSpanType.WORKFLOW, 'Workflow', ModelIconType.WORKFLOW],
     [ModelSpanType.TASK, 'Task', ModelIconType.TASK],
     [ModelSpanType.GUARDRAIL, 'Guardrail', ModelIconType.GUARDRAIL],
     [ModelSpanType.EVALUATOR, 'Evaluator', ModelIconType.EVALUATOR],
   ])('renders %s with an explicit display name and icon', (spanType, displayName, iconType) => {
-    expect(getDisplayNameForSpanType(spanType)).toBe(displayName);
+    expect(getDisplayNameForSpanType(spanType, intl)).toBe(displayName);
     expect(getIconTypeForSpan(spanType)).toBe(iconType);
   });
 
   it('retains generic fallbacks for custom span types', () => {
-    expect(getDisplayNameForSpanType('ROUTER')).toBe('ROUTER');
+    expect(getDisplayNameForSpanType('ROUTER', intl)).toBe('ROUTER');
     expect(getIconTypeForSpan('ROUTER')).toBe(ModelIconType.FUNCTION);
   });
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -16,6 +16,7 @@ import {
   isEmpty,
 } from 'lodash';
 import { useMemo } from 'react';
+import type { IntlShape } from '@databricks/i18n';
 
 import type {
   SearchMatch,
@@ -141,7 +142,7 @@ export function getIconTypeForSpan(spanType: ModelSpanType | string): ModelIconT
   }
 }
 
-export function getDisplayNameForSpanType(spanType: ModelSpanType | string): string {
+export function getDisplayNameForSpanType(spanType: ModelSpanType | string, intl: IntlShape): string {
   switch (spanType) {
     case ModelSpanType.LLM:
       return 'LLM';
@@ -164,13 +165,25 @@ export function getDisplayNameForSpanType(spanType: ModelSpanType | string): str
     case ModelSpanType.MEMORY:
       return 'Memory';
     case ModelSpanType.WORKFLOW:
-      return 'Workflow';
+      return intl.formatMessage({
+        defaultMessage: 'Workflow',
+        description: 'Display name for a workflow span in the model trace explorer',
+      });
     case ModelSpanType.TASK:
-      return 'Task';
+      return intl.formatMessage({
+        defaultMessage: 'Task',
+        description: 'Display name for a task span in the model trace explorer',
+      });
     case ModelSpanType.GUARDRAIL:
-      return 'Guardrail';
+      return intl.formatMessage({
+        defaultMessage: 'Guardrail',
+        description: 'Display name for a guardrail span in the model trace explorer',
+      });
     case ModelSpanType.EVALUATOR:
-      return 'Evaluator';
+      return intl.formatMessage({
+        defaultMessage: 'Evaluator',
+        description: 'Display name for an evaluator span in the model trace explorer',
+      });
     case ModelSpanType.FUNCTION:
       return 'Function';
     case ModelSpanType.UNKNOWN:

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -42,7 +42,6 @@ import type {
   ModelTraceLocation,
   ModelTraceInputAudio,
   ModelTraceSpanLink,
-  ModelTraceGuardrailStatus,
 } from './ModelTrace.types';
 import {
   ModelSpanType,
@@ -92,6 +91,7 @@ import {
   TOKEN_USAGE_METADATA_KEY,
 } from './constants';
 import { getExperimentPageTracesTabRoute } from './routes';
+import { getGuardrailStatus, MLFLOW_GUARDRAIL_STATUS_ATTRIBUTE_KEY } from './spanAttributeReader';
 
 export const FETCH_TRACE_INFO_QUERY_KEY = 'model-trace-info-v3';
 
@@ -201,12 +201,7 @@ export function tryDeserializeAttribute(value: string): any {
   }
 }
 
-export const MLFLOW_GUARDRAIL_STATUS_ATTRIBUTE_KEY = 'mlflow.guardrail.status';
-
-export const getGuardrailStatus = (value: unknown): ModelTraceGuardrailStatus | undefined => {
-  const status = tryDeserializeAttribute(String(value));
-  return status === 'passed' || status === 'blocked' ? status : undefined;
-};
+export { getGuardrailStatus } from './spanAttributeReader';
 
 export const SPAN_LOG_LEVEL_ATTRIBUTE_KEY = 'mlflow.spanLogLevel';
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -41,6 +41,7 @@ import type {
   ModelTraceLocation,
   ModelTraceInputAudio,
   ModelTraceSpanLink,
+  ModelTraceGuardrailStatus,
 } from './ModelTrace.types';
 import {
   ModelSpanType,
@@ -123,6 +124,14 @@ export function getIconTypeForSpan(spanType: ModelSpanType | string): ModelIconT
       return ModelIconType.SORT;
     case ModelSpanType.MEMORY:
       return ModelIconType.SAVE;
+    case ModelSpanType.WORKFLOW:
+      return ModelIconType.WORKFLOW;
+    case ModelSpanType.TASK:
+      return ModelIconType.TASK;
+    case ModelSpanType.GUARDRAIL:
+      return ModelIconType.GUARDRAIL;
+    case ModelSpanType.EVALUATOR:
+      return ModelIconType.EVALUATOR;
     case ModelSpanType.FUNCTION:
       return ModelIconType.FUNCTION;
     case ModelSpanType.UNKNOWN:
@@ -154,6 +163,14 @@ export function getDisplayNameForSpanType(spanType: ModelSpanType | string): str
       return 'Reranker';
     case ModelSpanType.MEMORY:
       return 'Memory';
+    case ModelSpanType.WORKFLOW:
+      return 'Workflow';
+    case ModelSpanType.TASK:
+      return 'Task';
+    case ModelSpanType.GUARDRAIL:
+      return 'Guardrail';
+    case ModelSpanType.EVALUATOR:
+      return 'Evaluator';
     case ModelSpanType.FUNCTION:
       return 'Function';
     case ModelSpanType.UNKNOWN:
@@ -170,6 +187,13 @@ export function tryDeserializeAttribute(value: string): any {
     return value;
   }
 }
+
+export const MLFLOW_GUARDRAIL_STATUS_ATTRIBUTE_KEY = 'mlflow.guardrail.status';
+
+export const getGuardrailStatus = (value: unknown): ModelTraceGuardrailStatus | undefined => {
+  const status = tryDeserializeAttribute(String(value));
+  return status === 'passed' || status === 'blocked' ? status : undefined;
+};
 
 export const SPAN_LOG_LEVEL_ATTRIBUTE_KEY = 'mlflow.spanLogLevel';
 
@@ -559,6 +583,7 @@ export const normalizeNewSpanData = (
     getSpanAttribute(span.attributes, SPAN_ATTRIBUTE_LINKED_GATEWAY_TRACE_ID_KEY) as string,
   );
   const logLevel = parseSpanLogLevel(getSpanAttribute(span.attributes, SPAN_LOG_LEVEL_ATTRIBUTE_KEY));
+  const guardrailStatus = getGuardrailStatus(getSpanAttribute(span.attributes, MLFLOW_GUARDRAIL_STATUS_ATTRIBUTE_KEY));
 
   // remove other private mlflow attributes
   const attributes = mapValues(
@@ -599,6 +624,7 @@ export const normalizeNewSpanData = (
     cost,
     linkedGatewayTraceId,
     logLevel,
+    guardrailStatus,
   };
 };
 
@@ -807,6 +833,9 @@ export function parseModelTraceToTreeWithMultipleRoots(trace: ModelTrace): Model
     // v1 spans
     const spanType = span.span_type ?? ModelSpanType.UNKNOWN;
     const logLevel = parseSpanLogLevel(getSpanAttribute(span.attributes, SPAN_LOG_LEVEL_ATTRIBUTE_KEY));
+    const guardrailStatus = getGuardrailStatus(
+      getSpanAttribute(span.attributes, MLFLOW_GUARDRAIL_STATUS_ATTRIBUTE_KEY),
+    );
     return {
       title: span.name,
       icon: <ModelTraceExplorerIcon type={getIconTypeForSpan(spanType)} />,
@@ -825,6 +854,7 @@ export function parseModelTraceToTreeWithMultipleRoots(trace: ModelTrace): Model
       assessments: [],
       traceId,
       logLevel,
+      guardrailStatus,
     };
   }
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerIcon.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerIcon.tsx
@@ -15,6 +15,10 @@ import {
   UserIcon,
   GearIcon,
   SaveIcon,
+  WorkflowsIcon,
+  ClipboardIcon,
+  ShieldIcon,
+  SparkleDoubleIcon,
 } from '@databricks/design-system';
 
 import { ModelIconType } from './ModelTrace.types';
@@ -57,6 +61,10 @@ export const ModelTraceExplorerIcon = ({
     [ModelIconType.USER]: <UserIcon color={iconColor} />,
     [ModelIconType.SYSTEM]: <GearIcon color={iconColor} />,
     [ModelIconType.SAVE]: <SaveIcon color={iconColor} />,
+    [ModelIconType.WORKFLOW]: <WorkflowsIcon color={iconColor} />,
+    [ModelIconType.TASK]: <ClipboardIcon color={iconColor} />,
+    [ModelIconType.GUARDRAIL]: <ShieldIcon color={iconColor} />,
+    [ModelIconType.EVALUATOR]: <SparkleDoubleIcon color={iconColor} />,
   };
 
   // custom colors depending on span type

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerDefaultSpanView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerDefaultSpanView.tsx
@@ -5,11 +5,12 @@ import { useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 
 import type { ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
-import { CodeSnippetRenderMode } from '../ModelTrace.types';
+import { CodeSnippetRenderMode, ModelSpanType } from '../ModelTrace.types';
 import { createListFromObject, buildAggregatedJsonFromKeyValueList } from '../ModelTraceExplorer.utils';
 import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet';
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
 import { ModelTraceExplorerFieldRenderer } from '../field-renderers/ModelTraceExplorerFieldRenderer';
+import { ModelTraceExplorerGuardrailSpanView } from './ModelTraceExplorerGuardrailSpanView';
 
 export function ModelTraceExplorerDefaultSpanView({
   activeSpan,
@@ -41,6 +42,9 @@ export function ModelTraceExplorerDefaultSpanView({
 
   return (
     <div data-testid="model-trace-explorer-default-span-view">
+      {renderMode === 'default' && activeSpan.type === ModelSpanType.GUARDRAIL && activeSpan.guardrailStatus && (
+        <ModelTraceExplorerGuardrailSpanView status={activeSpan.guardrailStatus} />
+      )}
       {containsInputs && (
         <ModelTraceExplorerCollapsibleSection
           withBorder

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerDefaultSpanView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerDefaultSpanView.tsx
@@ -42,7 +42,7 @@ export function ModelTraceExplorerDefaultSpanView({
 
   return (
     <div data-testid="model-trace-explorer-default-span-view">
-      {renderMode === 'default' && activeSpan.type === ModelSpanType.GUARDRAIL && activeSpan.guardrailStatus && (
+      {activeSpan.type === ModelSpanType.GUARDRAIL && activeSpan.guardrailStatus && (
         <ModelTraceExplorerGuardrailSpanView status={activeSpan.guardrailStatus} />
       )}
       {containsInputs && (

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerGuardrailSpanView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerGuardrailSpanView.tsx
@@ -1,0 +1,47 @@
+import { CheckCircleIcon, Tag, Typography, XCircleIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import type { ModelTraceGuardrailStatus } from '../ModelTrace.types';
+
+export const ModelTraceExplorerGuardrailSpanView = ({ status }: { status: ModelTraceGuardrailStatus }) => {
+  const { theme } = useDesignSystemTheme();
+  const passed = status === 'passed';
+
+  return (
+    <div
+      data-testid="model-trace-explorer-guardrail-span-view"
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: theme.spacing.sm,
+        marginBottom: theme.spacing.sm,
+        padding: theme.spacing.sm,
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.borders.borderRadiusSm,
+      }}
+    >
+      <Typography.Text color="secondary">
+        <FormattedMessage
+          defaultMessage="Guardrail result"
+          description="Label for the result of a guardrail span in the model trace explorer"
+        />
+      </Typography.Text>
+      <Tag
+        componentId="shared.model-trace-explorer.guardrail-status"
+        icon={passed ? <CheckCircleIcon color="success" /> : <XCircleIcon color="danger" />}
+      >
+        {passed ? (
+          <FormattedMessage
+            defaultMessage="Passed"
+            description="Status label for a guardrail span that allowed an operation"
+          />
+        ) : (
+          <FormattedMessage
+            defaultMessage="Blocked"
+            description="Status label for a guardrail span that blocked an operation"
+          />
+        )}
+      </Tag>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPane.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPane.test.tsx
@@ -8,6 +8,7 @@ import { IntlProvider } from '@databricks/i18n';
 import { ModelTraceExplorerChatTab } from './ModelTraceExplorerChatTab';
 import { ModelTraceExplorerContentTab } from './ModelTraceExplorerContentTab';
 import type { ModelTraceSpan, ModelTraceSpanNode } from '../ModelTrace.types';
+import { ModelSpanType } from '../ModelTrace.types';
 import {
   mockSpans,
   MOCK_RETRIEVER_SPAN,
@@ -102,5 +103,50 @@ describe('ModelTraceExplorerRightPane', () => {
     expect(screen.queryByText('generations')).toBeInTheDocument();
     expect(screen.queryByText('llm_output')).toBeInTheDocument();
     expect(screen.queryAllByText('See more').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it.each([
+    ['passed', 'Passed'],
+    ['blocked', 'Blocked'],
+  ] as const)('shows a structured %s guardrail result with its input and output', (status, label) => {
+    render(
+      <ModelTraceExplorerContentTab
+        activeSpan={{
+          ...MOCK_CHAT_SPAN,
+          type: ModelSpanType.GUARDRAIL,
+          inputs: { request: 'Delete all records' },
+          outputs: { explanation: 'Destructive operation policy' },
+          guardrailStatus: status,
+        }}
+        searchFilter=""
+        activeMatch={null}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByTestId('model-trace-explorer-guardrail-span-view')).toBeInTheDocument();
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByText('Delete all records')).toBeInTheDocument();
+    expect(screen.getByText('Destructive operation policy')).toBeInTheDocument();
+  });
+
+  it('uses the generic input and output view when a guardrail status is unavailable', () => {
+    render(
+      <ModelTraceExplorerContentTab
+        activeSpan={{
+          ...MOCK_CHAT_SPAN,
+          type: ModelSpanType.GUARDRAIL,
+          inputs: { request: 'Check this request' },
+          outputs: { explanation: 'No recognized result' },
+        }}
+        searchFilter=""
+        activeMatch={null}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.queryByTestId('model-trace-explorer-guardrail-span-view')).not.toBeInTheDocument();
+    expect(screen.getByText('Check this request')).toBeInTheDocument();
+    expect(screen.getByText('No recognized result')).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPane.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPane.test.tsx
@@ -149,4 +149,25 @@ describe('ModelTraceExplorerRightPane', () => {
     expect(screen.getByText('Check this request')).toBeInTheDocument();
     expect(screen.getByText('No recognized result')).toBeInTheDocument();
   });
+
+  it.each(['json', 'table'] as const)('keeps the guardrail result visible in %s mode', async (renderMode) => {
+    const user = userEvent.setup();
+    render(
+      <ModelTraceExplorerContentTab
+        activeSpan={{
+          ...MOCK_CHAT_SPAN,
+          type: ModelSpanType.GUARDRAIL,
+          guardrailStatus: 'blocked',
+        }}
+        searchFilter=""
+        activeMatch={null}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await user.click(screen.getByRole('radio', { name: renderMode === 'json' ? 'JSON' : 'Table' }));
+
+    expect(screen.getByTestId('model-trace-explorer-guardrail-span-view')).toBeInTheDocument();
+    expect(screen.getByText('Blocked')).toBeInTheDocument();
+  });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/spanAttributeReader.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/spanAttributeReader.ts
@@ -1,5 +1,9 @@
 import type { ModelTraceSpan } from './ModelTrace.types';
 
+export type ModelTraceGuardrailStatus = 'passed' | 'blocked';
+
+export const MLFLOW_GUARDRAIL_STATUS_ATTRIBUTE_KEY = 'mlflow.guardrail.status';
+
 /**
  * Extract an attribute value from span attributes.
  * V3 traces have flat objects: { 'mlflow.spanInputs': '{"x": 10}' }
@@ -26,4 +30,18 @@ export const getSpanAttribute = (
 
   // V4 values are typed - return whichever type is present
   return attribute.value.string_value ?? attribute.value.int_value ?? attribute.value.bool_value;
+};
+
+export const getGuardrailStatus = (value: unknown): ModelTraceGuardrailStatus | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  let status = value;
+  try {
+    status = JSON.parse(value);
+  } catch {
+    // Unquoted span attribute values are valid here.
+  }
+  return status === 'passed' || status === 'blocked' ? status : undefined;
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/timeline-tree/TimelineTreeFilterButton.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/timeline-tree/TimelineTreeFilterButton.test.tsx
@@ -9,7 +9,7 @@ import { IntlProvider } from '@databricks/i18n';
 import { TEST_SPAN_FILTER_STATE } from './TimelineTree.test-utils';
 import { TimelineTreeFilterButton } from './TimelineTreeFilterButton';
 import type { SpanFilterState } from '../ModelTrace.types';
-import { SpanLogLevel } from '../ModelTrace.types';
+import { ModelSpanType, SpanLogLevel } from '../ModelTrace.types';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
 jest.setTimeout(30000);
@@ -26,6 +26,26 @@ const TestWrapper = () => {
         <span>{'Show exceptions ' + String(spanFilterState.showExceptions)}</span>
         <span>{'Show chain spans ' + String(spanFilterState.spanTypeDisplayState['CHAIN'])}</span>
         <span>{'Min log level ' + String(spanFilterState.minLogLevel)}</span>
+      </DesignSystemProvider>
+    </IntlProvider>
+  );
+};
+
+const NewSpanTypesWrapper = () => {
+  const [spanFilterState, setSpanFilterState] = useState<SpanFilterState>({
+    ...TEST_SPAN_FILTER_STATE,
+    spanTypeDisplayState: {
+      [ModelSpanType.WORKFLOW]: true,
+      [ModelSpanType.TASK]: true,
+      [ModelSpanType.GUARDRAIL]: true,
+      [ModelSpanType.EVALUATOR]: true,
+    },
+  });
+
+  return (
+    <IntlProvider locale="en">
+      <DesignSystemProvider>
+        <TimelineTreeFilterButton spanFilterState={spanFilterState} setSpanFilterState={setSpanFilterState} />
       </DesignSystemProvider>
     </IntlProvider>
   );
@@ -77,5 +97,15 @@ describe('TimelineTreeFilterButton', () => {
     // (Hover assertions are covered by InfoTooltip's own tests; here we just
     // verify the trigger is rendered so we don't accidentally drop it again.)
     expect(await screen.findByText('Minimum log level')).toBeInTheDocument();
+  });
+
+  it('renders localized names for agent span types', async () => {
+    render(<NewSpanTypesWrapper />);
+    await userEvent.click(screen.getByRole('button', { name: 'Filter' }));
+
+    expect(screen.getByRole('checkbox', { name: 'Workflow' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Task' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Guardrail' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Evaluator' })).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/timeline-tree/TimelineTreeFilterButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/timeline-tree/TimelineTreeFilterButton.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
   useDesignSystemTheme,
 } from '@databricks/design-system';
-import { FormattedMessage } from '@databricks/i18n';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
 
 import type { SpanFilterState } from '../ModelTrace.types';
 import { SpanLogLevel } from '../ModelTrace.types';
@@ -64,6 +64,7 @@ export const TimelineTreeFilterButton = ({
   setSpanFilterState: (state: SpanFilterState) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
   const sliderIndex = indexFromLogLevel(spanFilterState.minLogLevel);
   const currentLevel = LOG_LEVEL_ORDER[sliderIndex];
   const description = LEVEL_DESCRIPTIONS[currentLevel];
@@ -124,7 +125,7 @@ export const TimelineTreeFilterButton = ({
               >
                 {icon}
                 <Typography.Text css={{ marginLeft: theme.spacing.xs }}>
-                  {getDisplayNameForSpanType(spanType)}
+                  {getDisplayNameForSpanType(spanType, intl)}
                 </Typography.Text>
               </Checkbox>
             );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTrace.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTrace.types.ts
@@ -3,6 +3,7 @@ import type { SpanTokenUsage } from './ModelTraceTokenUsage.utils';
 // Reuse the shared OTLP value shape so a v1-typed ModelTrace (what OSS consumers hold) is
 // structurally assignable to v2's ModelTrace at the entrypoint boundary.
 import type { ModelTraceOtelAnyValue } from '../ModelTrace.types';
+import type { ModelTraceGuardrailStatus } from '../spanAttributeReader';
 
 export const MLFLOW_TRACE_SCHEMA_VERSION_KEY = 'mlflow.trace_schema.version';
 
@@ -24,6 +25,10 @@ export enum ModelSpanType {
   EMBEDDING = 'EMBEDDING',
   RERANKER = 'RERANKER',
   MEMORY = 'MEMORY',
+  WORKFLOW = 'WORKFLOW',
+  TASK = 'TASK',
+  GUARDRAIL = 'GUARDRAIL',
+  EVALUATOR = 'EVALUATOR',
   UNKNOWN = 'UNKNOWN',
 }
 
@@ -43,7 +48,13 @@ export enum ModelIconType {
   USER = 'user',
   SYSTEM = 'system',
   SAVE = 'save',
+  WORKFLOW = 'workflow',
+  TASK = 'task',
+  GUARDRAIL = 'guardrail',
+  EVALUATOR = 'evaluator',
 }
+
+export type { ModelTraceGuardrailStatus };
 
 /**
  * Represents a single model trace span.
@@ -358,6 +369,7 @@ export interface ModelTraceSpanNode extends TimelineTreeNode, Pick<ModelTraceSpa
   modelName?: string;
   cost?: SpanCostInfo;
   linkedGatewayTraceId?: string;
+  guardrailStatus?: ModelTraceGuardrailStatus;
   tokenUsage?: SpanTokenUsage;
 }
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorer.utils.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
+import type { IntlShape } from '@databricks/i18n';
 
 import type {
   Assessment,
@@ -6,7 +7,7 @@ import type {
   ModelTraceSpanNode,
   RawModelTraceChatMessage,
 } from './ModelTrace.types';
-import { ModelSpanType, type ModelTraceSpanV3 } from './ModelTrace.types';
+import { ModelIconType, ModelSpanType, type ModelTraceSpanV3 } from './ModelTrace.types';
 import {
   MOCK_CHAT_SPAN,
   MOCK_CHAT_TOOL_CALL_SPAN,
@@ -45,6 +46,8 @@ import {
   createTraceV4SerializedLocation,
   parseTraceV4SerializedLocation,
   getRootSpanTimeToFirstTokenMs,
+  getDisplayNameForSpanType,
+  getIconTypeForSpan,
 } from './ModelTraceExplorer.utils';
 import { SPAN_ATTRIBUTE_TIME_TO_FIRST_TOKEN_MS_KEY } from '../constants';
 import { TEST_SPAN_FILTER_STATE } from './timeline-tree/TimelineTree.test-utils';
@@ -165,6 +168,27 @@ describe('parseTraceToTree', () => {
     expect(rootNode?.children?.[0].key).toBe('child1');
     expect(rootNode?.children?.[1].key).toBe('child2');
     expect(rootNode?.children?.[2].key).toBe('child3');
+  });
+});
+
+describe('span type presentation', () => {
+  const intl = {
+    formatMessage: ({ defaultMessage }: { defaultMessage?: string }) => defaultMessage,
+  } as IntlShape;
+
+  it.each([
+    [ModelSpanType.WORKFLOW, 'Workflow', ModelIconType.WORKFLOW],
+    [ModelSpanType.TASK, 'Task', ModelIconType.TASK],
+    [ModelSpanType.GUARDRAIL, 'Guardrail', ModelIconType.GUARDRAIL],
+    [ModelSpanType.EVALUATOR, 'Evaluator', ModelIconType.EVALUATOR],
+  ])('renders %s with an explicit display name and icon', (spanType, displayName, iconType) => {
+    expect(getDisplayNameForSpanType(spanType, intl)).toBe(displayName);
+    expect(getIconTypeForSpan(spanType)).toBe(iconType);
+  });
+
+  it('retains generic fallbacks for custom span types', () => {
+    expect(getDisplayNameForSpanType('ROUTER', intl)).toBe('ROUTER');
+    expect(getIconTypeForSpan('ROUTER')).toBe(ModelIconType.FUNCTION);
   });
 });
 
@@ -888,6 +912,19 @@ describe('normalizeNewSpanData', () => {
 
     const normalized = normalizeNewSpanData(spanWithModel, 0, 0, [], {}, '');
     expect(normalized.modelName).toBe('gpt-4o-mini');
+  });
+
+  it('should extract guardrail status from mlflow.guardrail.status attribute', () => {
+    const guardrailSpan: ModelTraceSpanV3 = {
+      ...MOCK_V3_SPANS[0],
+      attributes: {
+        ...MOCK_V3_SPANS[0].attributes,
+        'mlflow.guardrail.status': JSON.stringify('blocked'),
+      },
+    };
+
+    const normalized = normalizeNewSpanData(guardrailSpan, 0, 0, [], {}, '');
+    expect(normalized.guardrailStatus).toBe('blocked');
   });
 
   it('should extract cost from mlflow.llm.cost attribute', () => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorer.utils.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lodash';
 
 import Utils from '../../../../common/utils/Utils';
+import type { IntlShape } from '@databricks/i18n';
 
 import type {
   SearchMatch,
@@ -57,7 +58,7 @@ import { normalizeDspyChatInput, normalizeDspyChatOutput } from '../chat-utils/d
 import { normalizeVercelAIChatInput, normalizeVercelAIChatOutput } from '../chat-utils/vercelai';
 import { isOtelGenAIChatMessage, normalizeOtelGenAIChatMessage } from '../chat-utils/otel';
 import { normalizePydanticAIChatInput, normalizePydanticAIChatOutput } from '../chat-utils/pydanticai';
-import { getSpanAttribute } from '../spanAttributeReader';
+import { getGuardrailStatus, getSpanAttribute, MLFLOW_GUARDRAIL_STATUS_ATTRIBUTE_KEY } from '../spanAttributeReader';
 import { decodeOtelAnyValue, isOtelAnyValue } from '../../genai-traces-table/utils/TraceUtils';
 import { normalizeMistralChatInput, normalizeMistralChatOutput } from '../chat-utils/mistral';
 import {
@@ -127,6 +128,14 @@ export function getIconTypeForSpan(spanType: ModelSpanType | string): ModelIconT
       return ModelIconType.SORT;
     case ModelSpanType.MEMORY:
       return ModelIconType.SAVE;
+    case ModelSpanType.WORKFLOW:
+      return ModelIconType.WORKFLOW;
+    case ModelSpanType.TASK:
+      return ModelIconType.TASK;
+    case ModelSpanType.GUARDRAIL:
+      return ModelIconType.GUARDRAIL;
+    case ModelSpanType.EVALUATOR:
+      return ModelIconType.EVALUATOR;
     case ModelSpanType.FUNCTION:
       return ModelIconType.FUNCTION;
     case ModelSpanType.UNKNOWN:
@@ -136,7 +145,7 @@ export function getIconTypeForSpan(spanType: ModelSpanType | string): ModelIconT
   }
 }
 
-export function getDisplayNameForSpanType(spanType: ModelSpanType | string): string {
+export function getDisplayNameForSpanType(spanType: ModelSpanType | string, intl: IntlShape): string {
   switch (spanType) {
     case ModelSpanType.LLM:
       return 'LLM';
@@ -158,6 +167,26 @@ export function getDisplayNameForSpanType(spanType: ModelSpanType | string): str
       return 'Reranker';
     case ModelSpanType.MEMORY:
       return 'Memory';
+    case ModelSpanType.WORKFLOW:
+      return intl.formatMessage({
+        defaultMessage: 'Workflow',
+        description: 'Display name for a workflow span in the model trace explorer',
+      });
+    case ModelSpanType.TASK:
+      return intl.formatMessage({
+        defaultMessage: 'Task',
+        description: 'Display name for a task span in the model trace explorer',
+      });
+    case ModelSpanType.GUARDRAIL:
+      return intl.formatMessage({
+        defaultMessage: 'Guardrail',
+        description: 'Display name for a guardrail span in the model trace explorer',
+      });
+    case ModelSpanType.EVALUATOR:
+      return intl.formatMessage({
+        defaultMessage: 'Evaluator',
+        description: 'Display name for an evaluator span in the model trace explorer',
+      });
     case ModelSpanType.FUNCTION:
       return 'Function';
     case ModelSpanType.UNKNOWN:
@@ -518,6 +547,7 @@ export const normalizeNewSpanData = (
   const linkedGatewayTraceId = tryDeserializeAttribute(
     getSpanAttribute(span.attributes, SPAN_ATTRIBUTE_LINKED_GATEWAY_TRACE_ID_KEY) as string,
   );
+  const guardrailStatus = getGuardrailStatus(getSpanAttribute(span.attributes, MLFLOW_GUARDRAIL_STATUS_ATTRIBUTE_KEY));
 
   // remove other private mlflow attributes
   const attributes = mapValues(
@@ -555,6 +585,7 @@ export const normalizeNewSpanData = (
     modelName,
     cost,
     linkedGatewayTraceId,
+    guardrailStatus,
     tokenUsage: getSpanTokenUsage({ attributes: span.attributes }),
   };
 };
@@ -722,6 +753,9 @@ export function parseModelTraceToTreeWithMultipleRoots(trace: ModelTrace): Model
 
     // v1 spans
     const spanType = span.span_type ?? ModelSpanType.UNKNOWN;
+    const guardrailStatus = getGuardrailStatus(
+      getSpanAttribute(span.attributes, MLFLOW_GUARDRAIL_STATUS_ATTRIBUTE_KEY),
+    );
     return {
       title: span.name,
       icon: <ModelTraceExplorerIcon type={getIconTypeForSpan(spanType)} />,
@@ -739,6 +773,7 @@ export function parseModelTraceToTreeWithMultipleRoots(trace: ModelTrace): Model
       parentId: span.parent_id ?? span.parent_span_id,
       assessments: [],
       traceId,
+      guardrailStatus,
       tokenUsage: getSpanTokenUsage({ attributes: span.attributes }),
     };
   }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorerIcon.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorerIcon.tsx
@@ -15,6 +15,10 @@ import {
   UserIcon,
   GearIcon,
   SaveIcon,
+  WorkflowsIcon,
+  ClipboardIcon,
+  ShieldIcon,
+  SparkleDoubleIcon,
 } from '@databricks/design-system';
 
 import { ModelIconType } from './ModelTrace.types';
@@ -60,6 +64,10 @@ export const ModelTraceExplorerIcon = ({
     [ModelIconType.USER]: <UserIcon color={iconColor} />,
     [ModelIconType.SYSTEM]: <GearIcon color={iconColor} />,
     [ModelIconType.SAVE]: <SaveIcon color={iconColor} />,
+    [ModelIconType.WORKFLOW]: <WorkflowsIcon color={iconColor} />,
+    [ModelIconType.TASK]: <ClipboardIcon color={iconColor} />,
+    [ModelIconType.GUARDRAIL]: <ShieldIcon color={iconColor} />,
+    [ModelIconType.EVALUATOR]: <SparkleDoubleIcon color={iconColor} />,
   };
 
   // custom colors depending on span type

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerDefaultSpanView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerDefaultSpanView.tsx
@@ -6,6 +6,7 @@ import { FormattedMessage } from '@databricks/i18n';
 
 import {
   CodeSnippetRenderMode,
+  ModelSpanType,
   type ModelTraceChatMessage,
   type ModelTraceExplorerRenderMode,
   type ModelTraceSpanNode,
@@ -18,6 +19,7 @@ import { ModelTraceExplorerFieldRenderer } from '../field-renderers/ModelTraceEx
 import { ModelTraceExplorerChatSections } from './ModelTraceExplorerChatSections';
 import { ModelTraceExplorerChatTool } from './ModelTraceExplorerChatTool';
 import { ModelTraceExplorerConversation } from './ModelTraceExplorerConversation';
+import { ModelTraceExplorerGuardrailSpanView } from '../../right-pane/ModelTraceExplorerGuardrailSpanView';
 
 type ModelTraceExplorerSectionRenderMode = 'pretty' | Extract<ModelTraceExplorerRenderMode, 'json' | 'yaml'>;
 
@@ -301,6 +303,9 @@ export function ModelTraceExplorerDefaultSpanView({
       }}
       data-testid="model-trace-explorer-default-span-view"
     >
+      {activeSpan.type === ModelSpanType.GUARDRAIL && activeSpan.guardrailStatus && (
+        <ModelTraceExplorerGuardrailSpanView status={activeSpan.guardrailStatus} />
+      )}
       {containsTools && (
         <ModelTraceExplorerCollapsibleSection
           withBorder

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerRightPane.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerRightPane.test.tsx
@@ -8,6 +8,7 @@ import { IntlProvider } from '@databricks/i18n';
 
 import { ModelTraceExplorerContentTab } from './ModelTraceExplorerContentTab';
 import type { ModelTraceSpan } from '../ModelTrace.types';
+import { ModelSpanType } from '../ModelTrace.types';
 import { mockSpans, MOCK_RETRIEVER_SPAN, MOCK_CHAT_SPAN } from '../../ModelTraceExplorer.test-utils';
 import { ModelTraceExplorerPreferencesProvider } from '../ModelTraceExplorerPreferencesContext';
 
@@ -106,5 +107,51 @@ describe('ModelTraceExplorerRightPane', () => {
 
     expect(screen.getByRole('button', { name: 'YAML' })).toBeInTheDocument();
     expect(screen.getByTestId('model-trace-explorer-content-tab')).toHaveTextContent('generations:');
+  });
+
+  it.each([
+    ['passed', 'Passed'],
+    ['blocked', 'Blocked'],
+  ] as const)('shows a structured %s guardrail result with its input and output', (status, label) => {
+    render(
+      <ModelTraceExplorerContentTab
+        activeSpan={{
+          ...MOCK_CHAT_SPAN,
+          type: ModelSpanType.GUARDRAIL,
+          inputs: { request: 'Delete all records' },
+          outputs: { explanation: 'Destructive operation policy' },
+          guardrailStatus: status,
+        }}
+        searchFilter=""
+        activeMatch={null}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByTestId('model-trace-explorer-guardrail-span-view')).toBeInTheDocument();
+    expect(screen.getByText(label)).toBeInTheDocument();
+    expect(screen.getByText('Delete all records')).toBeInTheDocument();
+    expect(screen.getByText('Destructive operation policy')).toBeInTheDocument();
+  });
+
+  it.each(['JSON', 'YAML'] as const)('keeps the guardrail result visible in %s mode', async (renderMode) => {
+    render(
+      <ModelTraceExplorerContentTab
+        activeSpan={{
+          ...MOCK_CHAT_SPAN,
+          type: ModelSpanType.GUARDRAIL,
+          guardrailStatus: 'blocked',
+        }}
+        searchFilter=""
+        activeMatch={null}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    await userEvent.click(screen.getAllByText('Pretty')[0]);
+    await userEvent.click(screen.getByText(renderMode));
+
+    expect(screen.getByTestId('model-trace-explorer-guardrail-span-view')).toBeInTheDocument();
+    expect(screen.getByText('Blocked')).toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/timeline-tree/TimelineTreeFilterButton.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/timeline-tree/TimelineTreeFilterButton.test.tsx
@@ -10,12 +10,22 @@ import { IntlProvider } from '@databricks/i18n';
 import { TEST_SPAN_FILTER_STATE } from './TimelineTree.test-utils';
 import { TimelineTreeFilterButton } from './TimelineTreeFilterButton';
 import type { SpanFilterState } from '../ModelTrace.types';
+import { ModelSpanType } from '../ModelTrace.types';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
 jest.setTimeout(30000);
 
 const TestWrapper = () => {
-  const [spanFilterState, setSpanFilterState] = useState<SpanFilterState>(TEST_SPAN_FILTER_STATE);
+  const [spanFilterState, setSpanFilterState] = useState<SpanFilterState>({
+    ...TEST_SPAN_FILTER_STATE,
+    spanTypeDisplayState: {
+      ...TEST_SPAN_FILTER_STATE.spanTypeDisplayState,
+      [ModelSpanType.WORKFLOW]: true,
+      [ModelSpanType.TASK]: true,
+      [ModelSpanType.GUARDRAIL]: true,
+      [ModelSpanType.EVALUATOR]: true,
+    },
+  });
 
   return (
     <IntlProvider locale="en">
@@ -39,6 +49,10 @@ describe('TimelineTreeFilterButton', () => {
 
     // assert that the filter submenu is open
     expect(await screen.findByRole('menuitemcheckbox', { name: 'Chain' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Workflow' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Task' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Guardrail' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Evaluator' })).toBeInTheDocument();
 
     // Check that the show parents checkbox toggles the state
     expect(screen.getByText('Show parents true')).toBeInTheDocument();

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/timeline-tree/TimelineTreeFilterButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/timeline-tree/TimelineTreeFilterButton.tsx
@@ -133,7 +133,7 @@ export const TimelineTreeFilterButton = ({
                   }
                 >
                   <DropdownMenu.ItemIndicator />
-                  {getDisplayNameForSpanType(spanType)}
+                  {getDisplayNameForSpanType(spanType, intl)}
                 </DropdownMenu.CheckboxItem>
               ))}
               <DropdownMenu.Separator />

--- a/tests/gateway/test_guardrails.py
+++ b/tests/gateway/test_guardrails.py
@@ -595,6 +595,7 @@ async def test_process_request_creates_guardrail_and_judge_spans(tracing_experim
     gspan = spans["guardrail/safety"]
     jspan = spans["judge"]
     assert gspan.span_type == SpanType.GUARDRAIL
+    assert gspan.attributes["mlflow.guardrail.status"] == "passed"
     assert jspan.span_type == SpanType.EVALUATOR
     assert jspan.outputs == {"passed": True, "rationale": "some rationale"}
     assert jspan.parent_id == gspan.span_id
@@ -629,6 +630,7 @@ async def test_process_response_creates_guardrail_and_judge_spans(tracing_experi
     gspan = spans["guardrail/pii"]
     jspan = spans["judge"]
     assert gspan.span_type == SpanType.GUARDRAIL
+    assert gspan.attributes["mlflow.guardrail.status"] == "passed"
     assert jspan.span_type == SpanType.EVALUATOR
     assert jspan.parent_id == gspan.span_id
 
@@ -667,6 +669,53 @@ async def test_sanitization_creates_span_when_usage_tracking_on(tracing_experime
     jspan = spans["judge"]
     san_span = spans["sanitization"]
     assert san_span.span_type == SpanType.LLM
+    assert gspan.attributes["mlflow.guardrail.status"] == "passed"
+    assert gspan.outputs == sanitized
     assert jspan.outputs == {"passed": False, "rationale": "contains PII"}
     assert jspan.parent_id == gspan.span_id
     assert san_span.parent_id == gspan.span_id
+
+
+@pytest.mark.asyncio
+async def test_validation_block_records_blocked_status(tracing_experiment):
+    scorer = _SimpleScorer(_feedback(value=False, rationale="unsafe"))
+    guard = JudgeGuardrail(scorer, GuardrailStage.BEFORE, GuardrailAction.VALIDATION, "safety")
+
+    @mlflow.trace
+    async def _run():
+        return await guard.process_request(_make_request(), usage_tracking=True)
+
+    with pytest.raises(GuardrailViolation, match="unsafe"):
+        await _run()
+
+    spans = _get_span_map(tracing_experiment)
+    gspan = spans["guardrail/safety"]
+    assert gspan.attributes["mlflow.guardrail.status"] == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_sanitization_failure_records_blocked_status(tracing_experiment):
+    scorer = _SimpleScorer(_feedback(value=False, rationale="contains PII"))
+    guard = JudgeGuardrail(
+        scorer,
+        GuardrailStage.BEFORE,
+        GuardrailAction.SANITIZATION,
+        "pii-guard",
+        action_llm_url="http://localhost:5000",
+        action_endpoint_name="ep-sanitizer",
+    )
+
+    @mlflow.trace
+    async def _run():
+        with mock.patch(
+            "mlflow.gateway.guardrails.send_request",
+            mock.AsyncMock(return_value={"choices": [{"message": {"content": "not json"}}]}),
+        ):
+            return await guard.process_request(_make_request(), usage_tracking=True)
+
+    with pytest.raises(GuardrailViolation, match="invalid JSON"):
+        await _run()
+
+    spans = _get_span_map(tracing_experiment)
+    gspan = spans["guardrail/pii-guard"]
+    assert gspan.attributes["mlflow.guardrail.status"] == "blocked"


### PR DESCRIPTION
### Related Issues/PRs

Closes #25434

### What changes are proposed in this pull request?

MLflow already defines `WORKFLOW`, `TASK`, `GUARDRAIL`, and `EVALUATOR` span types, but the trace explorer presents them with generic fallbacks. This PR gives each type a localized display name and a distinct design-system icon in both the legacy and redesigned trace explorers.

Guardrail spans also gain a compact result view. The view reads a documented `mlflow.guardrail.status` attribute and shows a Passed or Blocked badge above the existing input and output content. The badge remains visible in every content render mode. Missing or malformed status values continue to use the generic span view.

The AI Gateway now writes the guardrail status for these outcomes:

- successful validation: `passed`
- blocked validation: `blocked`
- successful sanitization: `passed`, with the sanitized payload recorded as the span output
- failed sanitization: `blocked`

Successful sanitization is considered passed because the guardrail completed its configured action and allowed the sanitized request or response to continue.

The change is additive. It does not modify the REST API or trace storage schema, and unknown custom span types still use the existing generic fallback.

### Screenshots

The screenshots use the same synthetic trace before and after this change. Before, workflow, task, guardrail, and evaluator spans all use the generic function icon, and the selected guardrail has no result summary. After, each span type has a distinct icon and the guardrail result appears above its input and output.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/anxkhn/mlflow/pr-assets/agent-span-rendering/pr-assets/before-agent-spans.png" alt="Trace explorer before the change, with generic function icons and no guardrail result" width="720" /> | <img src="https://raw.githubusercontent.com/anxkhn/mlflow/pr-assets/agent-span-rendering/pr-assets/after-agent-spans.png" alt="Trace explorer after the change, with distinct agent span icons and a Passed guardrail result" width="720" /> |

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Automated checks:

```text
uv run --python 3.10 pytest tests/gateway/test_guardrails.py
43 passed

yarn test ModelTraceExplorer.utils.test.tsx ModelTraceExplorerRightPane.test.tsx TimelineTreeFilterButton.test.tsx --runInBand
6 suites passed, 251 tests passed

yarn type-check
yarn i18n:check
yarn eslint <changed TypeScript files>
yarn prettier <changed TypeScript files> --check
uv run --python 3.10 ruff check mlflow/gateway/guardrails.py tests/gateway/test_guardrails.py
uv run --python 3.10 ruff format --check mlflow/gateway/guardrails.py tests/gateway/test_guardrails.py
uv run --python 3.10 clint mlflow/gateway/guardrails.py tests/gateway/test_guardrails.py
```

The tests cover both trace explorer versions, span labels and icons, localization, passed and blocked guardrails, malformed or missing status values, all supported content render modes, and gateway validation and sanitization outcomes.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] API references
  - [x] Instructions

The span concepts page now documents `mlflow.guardrail.status`, its accepted values, and sanitization semantics.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

This change documents a span attribute and improves trace presentation. It does not introduce a new fluent workflow that the skills repository needs to teach.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. MLflow now renders workflow, task, guardrail, and evaluator spans with dedicated labels and icons, and displays guardrail pass or block status directly in the trace explorer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
