### PR TITLE
Point the auto mode classifier at the gateway

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -232,6 +232,12 @@ jobs:
           ANTHROPIC_BASE_URL: ${{ steps.anthropic.outputs.base-url }}
           ANTHROPIC_AUTH_TOKEN: ${{ steps.anthropic.outputs.token }}
           ANTHROPIC_CUSTOM_HEADERS: ${{ steps.anthropic.outputs.custom-headers }}
+          # The auto mode permission classifier picks its model from the sonnet
+          # and opus aliases rather than `--model`, so without these it requests
+          # a bare `claude-sonnet-5` that the gateway does not serve and every
+          # ambiguous Bash command gets denied.
+          ANTHROPIC_DEFAULT_SONNET_MODEL: databricks-claude-sonnet-5
+          ANTHROPIC_DEFAULT_OPUS_MODEL: databricks-claude-opus-5
           # The gateway's beta allowlist rejects several of the CLI's
           # experimental betas with HTTP 400.
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"


### PR DESCRIPTION
### Related Issues/PRs

Relates to anthropics/claude-code#38618, anthropics/claude-code#86673

### What changes are proposed in this pull request?

The review job runs `--permission-mode auto`, whose permission classifier picks
its model from the `sonnet`/`opus` aliases rather than from `--model`. It
therefore asked the gateway for a bare `claude-sonnet-5`, but the gateway only
serves `databricks-*` endpoints. That call failed, and since the classifier
fails closed with no retry, the tool was denied with a misleading `temporarily
unavailable` error.

Setting the two alias env vars maps the classifier onto real gateway endpoints.
Both are set rather than just sonnet because the classifier's tier varies by CLI
version.

The main loop was always correct (`databricks-claude-sonnet-5`); only the
classifier's side query used the bare name. `CLAUDE_CODE_AUTO_MODE_MODEL` was
tried first and had no effect.

### How is this PR tested?

- [x] Manual tests

Reproduced against a local stub gateway that logs each request's model. Before,
the classifier issued 10 requests for a bare `claude-sonnet-5`; after, they all
use the prefixed `databricks-claude-sonnet-5`. Verified on both sonnet and opus
session models.

The stub cannot return a parseable verdict, so this confirms the routing fix
rather than an end-to-end approval. In practice the error appeared on 7 of 11
recent review runs, once per run, on the first command auto mode could not
classify locally.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
