### PR TITLE
fix: Make initial table creation idempotent in db upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,7 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    InitialBase.metadata.create_all(engine, checkfirst=True)
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What
When running `mlflow db upgrade` after upgrading from an older MLflow version, the backend fails with `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")`. This happens because `_initialize_tables()` calls `InitialBase.metadata.create_all(engine)` without checking if tables already exist. If the `secrets` table was already created (e.g., from a previous partial migration or manual creation), the operation fails.

## Fix
The fix adds `checkfirst=True` to the `create_all()` call in `_initialize_tables()`. This makes the table creation idempotent—SQLAlchemy will only create tables that do not already exist, avoiding the conflict. This change is minimal and preserves existing behavior for a fresh database.

Closes #19943
