### PR TITLE
Set Content-Length for proxied artifact downloads

### DIFF
--- a/mlflow/server/artifact_router.py
+++ b/mlflow/server/artifact_router.py
@@ -120,6 +120,7 @@ async def download_artifact(artifact_path: str):
             headers={
                 "Content-Type": mime_type,
                 "Content-Disposition": _content_disposition(filename),
+                "Content-Length": str(os.path.getsize(dst)),
                 "X-Content-Type-Options": "nosniff",
             },
         )

--- a/tests/server/test_artifact_router.py
+++ b/tests/server/test_artifact_router.py
@@ -61,6 +61,7 @@ def test_download_remote_path_returns_streaming_response(client, tmp_path):
 
     assert resp.status_code == 200
     assert resp.content == test_data
+    assert resp.headers["Content-Length"] == str(len(test_data))
     assert "attachment" in resp.headers["Content-Disposition"]
     mock_repo.download_artifacts.assert_called_once()
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #25009

### What changes are proposed in this pull request?

Remote artifact downloads are materialized to a temporary file and served through FastAPI's `StreamingResponse`. This change adds the materialized file size as the `Content-Length` response header, preserving streaming while allowing intermediaries to frame the response reliably.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

The remote download test verifies the response body and `Content-Length` value through the FastAPI route.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Proxied remote artifact downloads now include a content length, improving compatibility with buffering and HTTP/1.0 intermediaries.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release