### PR TITLE
Document masking secrets generated mid-job in the Actions rules

### DIFF
--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -125,8 +125,10 @@ Every workflow in this repo sets top-level `defaults.run.shell: bash` (enforced 
 Values that come from `secrets.*` are masked automatically. Anything a step
 mints at runtime (an OAuth token exchanged over `curl`, a random passphrase, a
 value decoded out of another secret) is not, so the first command that echoes it
-prints it in clear text. Emit `::add-mask::` the moment the value exists, before
-it reaches `$GITHUB_OUTPUT`, `$GITHUB_ENV`, or any other command.
+prints it in clear text. Emit
+[`::add-mask::`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#masking-a-value-in-a-log)
+the moment the value exists, before it reaches `$GITHUB_OUTPUT`,
+`$GITHUB_ENV`, or any other command.
 
 ```yaml
 # Bad: nothing stops a later command from printing the token
@@ -147,4 +149,4 @@ a secret.
 
 The mask covers only the job that registered it, and a masked value cannot be
 handed to another job through job-level `outputs`: GitHub redacts it on the
-runner. Mint and mask it again in the job that needs it. ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#masking-a-value-in-a-log))
+runner. Mint and mask it again in the job that needs it.

--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -119,3 +119,28 @@ Set `sparse-checkout-cone-mode: false` only when you need to target individual f
 ## `pipefail` Is Already On
 
 Every workflow in this repo sets top-level `defaults.run.shell: bash` (enforced by [`.github/policy.rego`](../../.github/policy.rego)). GitHub Actions runs `shell: bash` as `bash --noprofile --norc -eo pipefail {0}`, so `pipefail` is already enabled. Don't ask for `set -o pipefail` in workflow `run:` steps. ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defaultsrunshell))
+
+## Mask Secrets Generated Mid-Job
+
+Values that come from `secrets.*` are masked automatically. Anything a step
+mints at runtime (an OAuth token exchanged over `curl`, a random passphrase, a
+value decoded out of another secret) is not, so the first command that echoes it
+prints it in clear text. Emit `::add-mask::` the moment the value exists, before
+it reaches `$GITHUB_OUTPUT`, `$GITHUB_ENV`, or any other command.
+
+```yaml
+# Bad: nothing stops a later command (or `set -x`) from printing the token
+- run: |
+    TOKEN=$(curl -sS ... | jq -r .access_token)
+    echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+# Good
+- run: |
+    TOKEN=$(curl -sS ... | jq -r .access_token)
+    echo "::add-mask::$TOKEN"
+    echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+```
+
+The mask covers only the job that registered it, and a masked value cannot be
+handed to another job through job-level `outputs`: GitHub redacts it on the
+runner. Mint and mask it again in the job that needs it.

--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -143,4 +143,4 @@ it reaches `$GITHUB_OUTPUT`, `$GITHUB_ENV`, or any other command.
 
 The mask covers only the job that registered it, and a masked value cannot be
 handed to another job through job-level `outputs`: GitHub redacts it on the
-runner. Mint and mask it again in the job that needs it.
+runner. Mint and mask it again in the job that needs it. ([docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#masking-a-value-in-a-log))

--- a/.claude/rules/github-actions.md
+++ b/.claude/rules/github-actions.md
@@ -129,7 +129,7 @@ prints it in clear text. Emit `::add-mask::` the moment the value exists, before
 it reaches `$GITHUB_OUTPUT`, `$GITHUB_ENV`, or any other command.
 
 ```yaml
-# Bad: nothing stops a later command (or `set -x`) from printing the token
+# Bad: nothing stops a later command from printing the token
 - run: |
     TOKEN=$(curl -sS ... | jq -r .access_token)
     echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
@@ -140,6 +140,10 @@ it reaches `$GITHUB_OUTPUT`, `$GITHUB_ENV`, or any other command.
     echo "::add-mask::$TOKEN"
     echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 ```
+
+`set -x` needs separate care: xtrace prints the assignment itself, so the value
+is in the log before the mask can register. Don't enable it in a step that mints
+a secret.
 
 The mask covers only the job that registered it, and a masked value cannot be
 handed to another job through job-level `outputs`: GitHub redacts it on the


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds a `Mask Secrets Generated Mid-Job` section to `.claude/rules/github-actions.md`.

Values from `secrets.*` are masked automatically, but anything a step mints at runtime (an OAuth token exchanged over `curl`, a random passphrase) is not, so it leaks the first time a command echoes it or `set -x` traces it. The rule says to emit `::add-mask::` as soon as the value exists, and notes that masks are per-job and cannot cross a job boundary through job-level `outputs`.

`.github/actions/setup-gateway/action.yml` and `.github/workflows/ui-preview.yml` already follow this; the rule just writes it down.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release