### PR TITLE
Remove dead code from the `skills` GitHub helpers

### DIFF
--- a/.claude/skills/src/skills/github/__init__.py
+++ b/.claude/skills/src/skills/github/__init__.py
@@ -1,23 +1,10 @@
 from skills.github.client import GitHubClient
-from skills.github.types import (
-    GitRef,
-    Job,
-    JobRun,
-    JobStep,
-    PullRequest,
-    ReviewComment,
-    ReviewThread,
-)
+from skills.github.types import Job, JobStep
 from skills.github.utils import get_github_token
 
 __all__ = [
     "GitHubClient",
-    "GitRef",
     "Job",
-    "JobRun",
     "JobStep",
-    "PullRequest",
-    "ReviewComment",
-    "ReviewThread",
     "get_github_token",
 ]

--- a/.claude/skills/src/skills/github/client.py
+++ b/.claude/skills/src/skills/github/client.py
@@ -46,17 +46,6 @@ class GitHubClient:
         data = await self._get_json(f"/repos/{owner}/{repo}/pulls/{pr_number}")
         return PullRequest.model_validate(data)
 
-    async def graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
-        if self._session is None:
-            raise RuntimeError("GitHubClient must be used as async context manager")
-        payload = {"query": query, "variables": variables}
-        async with self._session.post(
-            "https://api.github.com/graphql",
-            json=payload,
-        ) as resp:
-            resp.raise_for_status()
-            return cast(dict[str, Any], await resp.json())
-
     async def get_raw(self, endpoint: str) -> aiohttp.ClientResponse:
         """Get raw response for streaming."""
         if self._session is None:
@@ -122,8 +111,3 @@ class GitHubClient:
         """Get a specific job."""
         data = await self._get_json(f"/repos/{owner}/{repo}/actions/jobs/{job_id}")
         return Job.model_validate(data)
-
-    async def get_job_run(self, owner: str, repo: str, run_id: int) -> JobRun:
-        """Get a specific workflow run."""
-        data = await self._get_json(f"/repos/{owner}/{repo}/actions/runs/{run_id}")
-        return JobRun.model_validate(data)

--- a/.claude/skills/src/skills/github/types.py
+++ b/.claude/skills/src/skills/github/types.py
@@ -12,21 +12,6 @@ class PullRequest(BaseModel):
     head: GitRef
 
 
-class ReviewComment(BaseModel):
-    id: int
-    body: str
-    author: str
-    createdAt: str
-
-
-class ReviewThread(BaseModel):
-    thread_id: str
-    line: int | None
-    startLine: int | None
-    diffHunk: str | None
-    comments: list[ReviewComment]
-
-
 class JobStep(BaseModel):
     name: str
     status: str


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25443

### What changes are proposed in this pull request?

Drop three unreferenced symbols in `.claude/skills/src/skills/github/`:

- `GitHubClient.graphql` and the `ReviewComment`/`ReviewThread` models were staged for a `fetch-unresolved-comments` command that no longer exists.
- `GitHubClient.get_job_run` never had a caller.

The `skills.github` re-exports are trimmed to the four names `fetch_logs` imports. `GitRef`, `PullRequest`, and `JobRun` stay in `types.py` since `get_pr` and `get_workflow_runs` still use them.

Verified with `vulture`, plus `ruff`, strict `mypy`, and the package's 187 tests.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release