### PR TITLE
feat(tracing): propagate OpenAI service_tier to LiteLLM cost calculation

### DIFF
--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -45,6 +45,11 @@ def set_span_chat_attributes(span: LiveSpan, inputs: dict[str, Any], output: Any
     if usage := _parse_usage(output):
         span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage)
 
+    # Extract service_tier from OpenAI response (e.g. "default", "priority", "flex").
+    # LiteLLM uses this to apply tier-specific pricing when computing cost.
+    if service_tier := _parse_service_tier(output):
+        span.set_attribute(SpanAttributeKey.OPENAI_SERVICE_TIER, service_tier)
+
 
 def _extract_tool_call_ids(output: Any) -> list[str]:
     tool_call_ids = []
@@ -228,4 +233,26 @@ def _parse_usage(output: Any) -> dict[str, Any] | None:
     except ImportError:
         pass
 
+    return None
+
+
+def _parse_service_tier(output: Any) -> str | None:
+    """Extract service_tier from an OpenAI ChatCompletion response.
+
+    The ``service_tier`` field on the OpenAI response object reflects which tier
+    the request was actually processed on (e.g. ``"default"``, ``"priority"``,
+    ``"flex"``).  LiteLLM's ``cost_per_token`` accepts a ``service_tier`` kwarg
+    to apply tier-specific pricing, so surfacing this value enables accurate cost
+    reporting when callers use non-default tiers.
+
+    Returns:
+        The service_tier string, or None if the output type does not carry one.
+    """
+    try:
+        from openai.types.chat import ChatCompletion
+
+        if isinstance(output, ChatCompletion) and (st := getattr(output, "service_tier", None)):
+            return st
+    except ImportError:
+        pass
     return None

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -114,6 +114,10 @@ class SpanAttributeKey:
     # This attribute stores cost information calculated from token usage and model pricing.
     # Stored in {"input_cost": float, "output_cost": float, "total_cost": float} format (USD).
     LLM_COST = "mlflow.llm.cost"
+    # This attribute stores the OpenAI service tier used for the request (e.g.
+    # "default", "priority", "flex"). When present, it is factored into cost
+    # estimation so that tier-specific pricing is used.
+    OPENAI_SERVICE_TIER = "mlflow.openai.service_tier"
     # This attribute stores the model name extracted from span inputs/attributes.
     MODEL = "mlflow.llm.model"
     MODEL_PROVIDER = "mlflow.llm.provider"

--- a/mlflow/tracing/otel/translation/__init__.py
+++ b/mlflow/tracing/otel/translation/__init__.py
@@ -135,8 +135,13 @@ def translate_span_when_storing(span: Span) -> dict[str, Any]:
                 if SpanAttributeKey.MODEL_PROVIDER in attributes
                 else None
             )
+            service_tier = (
+                json.loads(attributes[SpanAttributeKey.OPENAI_SERVICE_TIER])
+                if SpanAttributeKey.OPENAI_SERVICE_TIER in attributes
+                else None
+            )
             if cost := calculate_cost_by_model_and_token_usage(
-                model_name, token_usage, model_provider
+                model_name, token_usage, model_provider, service_tier
             ):
                 attributes[SpanAttributeKey.LLM_COST] = dump_span_attribute_value(cost)
         except Exception:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -342,7 +342,8 @@ def calculate_span_cost(span: LiveSpan) -> dict[str, float] | None:
     model_name = span.get_attribute(SpanAttributeKey.MODEL)
     usage = span.get_attribute(SpanAttributeKey.CHAT_USAGE)
     model_provider = span.get_attribute(SpanAttributeKey.MODEL_PROVIDER)
-    return calculate_cost_by_model_and_token_usage(model_name, usage, model_provider)
+    service_tier = span.get_attribute(SpanAttributeKey.OPENAI_SERVICE_TIER)
+    return calculate_cost_by_model_and_token_usage(model_name, usage, model_provider, service_tier)
 
 
 # Model URI prefixes that are internal routing identifiers (not real model names).
@@ -351,7 +352,10 @@ _SKIP_COST_PREFIXES = ("gateway:/", "endpoints:/")
 
 
 def calculate_cost_by_model_and_token_usage(
-    model_name: str | None, usage: dict[str, int] | None, model_provider: str | None = None
+    model_name: str | None,
+    usage: dict[str, int] | None,
+    model_provider: str | None = None,
+    service_tier: str | None = None,
 ) -> dict[str, float] | None:
     if not model_name or not usage:
         return None
@@ -398,6 +402,7 @@ def calculate_cost_by_model_and_token_usage(
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                     custom_llm_provider=model_provider.lower(),
+                    service_tier=service_tier,
                     **cache_kwargs,
                 )
             except Exception:
@@ -411,6 +416,7 @@ def calculate_cost_by_model_and_token_usage(
                     model=model_name,
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
+                    service_tier=service_tier,
                     **cache_kwargs,
                 )
             except Exception:

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -1292,3 +1292,107 @@ async def test_chat_completions_autolog_streaming_with_cached_tokens(client, moc
         TokenUsageKey.TOTAL_TOKENS: 70,
         TokenUsageKey.CACHE_READ_INPUT_TOKENS: 30,
     }
+
+
+def test_parse_service_tier_from_chat_completion():
+    """_parse_service_tier extracts the service_tier field from a ChatCompletion."""
+    from openai.types.chat import ChatCompletion
+    from openai.types.chat.chat_completion import Choice
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
+
+    from mlflow.openai.utils.chat_schema import _parse_service_tier
+
+    msg = ChatCompletionMessage(role="assistant", content="hi")
+    choice = Choice(index=0, message=msg, finish_reason="stop")
+    completion = ChatCompletion(
+        id="cmpl-1",
+        choices=[choice],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        service_tier="priority",
+    )
+    assert _parse_service_tier(completion) == "priority"
+
+
+def test_parse_service_tier_none_when_absent():
+    """_parse_service_tier returns None when service_tier is not set."""
+    from openai.types.chat import ChatCompletion
+    from openai.types.chat.chat_completion import Choice
+    from openai.types.chat.chat_completion_message import ChatCompletionMessage
+
+    from mlflow.openai.utils.chat_schema import _parse_service_tier
+
+    msg = ChatCompletionMessage(role="assistant", content="hi")
+    choice = Choice(index=0, message=msg, finish_reason="stop")
+    completion = ChatCompletion(
+        id="cmpl-2",
+        choices=[choice],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+    )
+    assert _parse_service_tier(completion) is None
+
+
+@pytest.mark.asyncio
+async def test_service_tier_stored_and_passed_to_cost_calculation(client, mock_litellm_cost):
+    """service_tier from the OpenAI response is stored on the span and forwarded to
+    litellm.cost_per_token so that tier-specific pricing is applied."""
+    if mock_litellm_cost is None:
+        pytest.skip("litellm not installed")
+
+    mlflow.openai.autolog()
+
+    mock_response = {
+        "id": "chatcmpl-svc-tier",
+        "object": "chat.completion",
+        "created": 1741688000,
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 9,
+            "completion_tokens": 12,
+            "total_tokens": 21,
+        },
+        "service_tier": "priority",
+    }
+
+    if client._is_async:
+        patch_target = "httpx.AsyncClient.send"
+
+        async def send_patch(self, request, *args, **kwargs):
+            return httpx.Response(status_code=200, request=request, json=mock_response)
+
+    else:
+        patch_target = "httpx.Client.send"
+
+        def send_patch(self, request, *args, **kwargs):
+            return httpx.Response(status_code=200, request=request, json=mock_response)
+
+    with mock.patch(patch_target, send_patch):
+        response = client.chat.completions.create(
+            messages=[{"role": "user", "content": "say hi"}],
+            model="gpt-4o-mini",
+        )
+        if client._is_async:
+            await response
+
+    traces = get_traces()
+    assert len(traces) == 1
+    span = traces[0].data.spans[0]
+
+    # service_tier must be stored as a span attribute
+    assert span.get_attribute(SpanAttributeKey.OPENAI_SERVICE_TIER) == "priority"
+
+    if not IS_TRACING_SDK_ONLY:
+        # litellm.cost_per_token must have been called with service_tier="priority"
+        assert mock_litellm_cost.called
+        call_kwargs = mock_litellm_cost.call_args
+        assert call_kwargs.kwargs.get("service_tier") == "priority"


### PR DESCRIPTION
## Summary

Closes #25175

OpenAI's chat completion responses include a `service_tier` field that indicates which processing tier handled the request (`"default"`, `"priority"`, `"flex"`). LiteLLM's `cost_per_token` already has a `service_tier` kwarg to apply tier-specific pricing, but MLflow was discarding this information — cost estimates always used default-tier rates even when the response indicated a priority or flex request.

- **`mlflow/tracing/constant.py`**: Add `SpanAttributeKey.OPENAI_SERVICE_TIER = "mlflow.openai.service_tier"` to carry the tier through the span.
- **`mlflow/openai/utils/chat_schema.py`**: Add `_parse_service_tier()` helper and call it from `set_span_chat_attributes` so the tier is stored on the span whenever the OpenAI response carries it.
- **`mlflow/tracing/utils/__init__.py`**: Thread `service_tier` through `calculate_span_cost` and `calculate_cost_by_model_and_token_usage`; forward it to `litellm.cost_per_token` so tier-specific rates are used.
- **`mlflow/tracing/otel/translation/__init__.py`**: Read `OPENAI_SERVICE_TIER` from span attributes in `translate_span_when_storing` and pass it to the cost calculation (for OTEL-ingested spans).
- **`tests/openai/test_openai_autolog.py`**: Unit tests for `_parse_service_tier` (with and without the field), plus an integration test that verifies the span attribute is set **and** `litellm.cost_per_token` is called with `service_tier="priority"`.

## How it works

```python
# Before: service_tier silently dropped, default pricing always used
result = cost_per_token(model=model_name, prompt_tokens=..., completion_tokens=...)

# After: service_tier forwarded — LiteLLM uses tier-specific rates
result = cost_per_token(model=model_name, prompt_tokens=..., completion_tokens=...,
                        service_tier="priority")
```

## Test plan

- [ ] `tests/openai/test_openai_autolog.py::test_parse_service_tier_from_chat_completion` — unit test that `_parse_service_tier` extracts the field from `ChatCompletion`
- [ ] `tests/openai/test_openai_autolog.py::test_parse_service_tier_none_when_absent` — unit test that returns `None` when field is absent
- [ ] `tests/openai/test_openai_autolog.py::test_service_tier_stored_and_passed_to_cost_calculation` — integration test: mock response with `service_tier="priority"`, assert span attribute set **and** `litellm.cost_per_token` called with `service_tier="priority"`
- [ ] Existing autolog tests continue to pass (no regression — `service_tier` defaults to `None`, matching prior behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)