### PR TITLE
Declare `optuna` as a test requirement

### DIFF
--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -46,6 +46,8 @@ polars>=1
 dspy
 # required for testing mlflow.genai.optimize.optimizers
 gepa
+# required for testing mlflow.optuna and mlflow.pyspark.optuna
+optuna
 # required for testing docker compose
 testcontainers
 # required for testing cost tracking


### PR DESCRIPTION
### Related Issues/PRs

Relates to the master CI failure in https://github.com/mlflow/mlflow/actions/runs/33237204870

### What changes are proposed in this pull request?

`tests/optuna` and `tests/pyspark/optuna` import `optuna` at module scope, but `optuna` was never declared in `requirements/`. It only came along as a transitive dependency of `dspy`: 2.6.27 required `optuna>=3.4.0` unconditionally, while 3.x moved it behind an `optuna` extra we don't request.

dspy 3.3.1 (uploaded 2026-08-21) cleared the 7-day package cooldown on 2026-08-28, so the next master run resolved `dspy 2.6.27 -> 3.3.1`, `optuna` fell out of the environment, and every `python` matrix group started failing at collection:

```
ERROR collecting tests/optuna/test_storage.py
E   ModuleNotFoundError: No module named 'optuna'
ERROR collecting tests/pyspark/optuna/test_study.py
E   ModuleNotFoundError: No module named 'optuna'
```

Requesting `optuna` directly makes the dependency explicit and independent of dspy's packaging choices.

### How is this PR tested?

- [x] Existing unit/integration tests

`uv pip compile` on `dspy` + `optuna` resolves `dspy==3.3.1` with `optuna==4.9.0`, the same optuna version present in the last green master run.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
