### PR TITLE
Isolate the PR write credentials from the `review` job

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,8 +2,8 @@
 name: pr-review
 description: Review a pull request and emit a validated review payload.
 disable-model-invocation: true
-argument-hint: "<pr_url> <pr_checkout> <payload_path> <media_dir>"
-arguments: [pr_url, pr_checkout, payload_path, media_dir]
+argument-hint: "<pr_url> <pr_checkout> <payload_path>"
+arguments: [pr_url, pr_checkout, payload_path]
 ---
 
 # Review Pull Request
@@ -107,9 +107,10 @@ quick search and fetch of the upstream docs will settle most questions in second
 finding should be dropped rather than hedged. When the cheap checks don't settle it, escalate to the
 expensive ones: build the docs site, build and boot the UI, start the backend.
 
-Node and `agent-browser` are on PATH for docs and UI changes. Capture to an absolute path named for
-what it shows: `agent-browser screenshot --full $media_dir/example.png`, and cite that same
-path in a finding.
+Node and `agent-browser` are on PATH for docs and UI changes. A capture is something you look at,
+not something you attach: screenshot to an absolute path under `/tmp`, read it back, and write what
+it showed you in prose. A review posts text only, so a citation naming a local file resolves to
+nothing.
 
 Evaluate the changed code across these dimensions:
 
@@ -161,22 +162,13 @@ Authoring rules not captured by the schema:
   suggestion block already shows.
 - Use suggestion blocks for simple fixes: fence with ` ```suggestion ` and preserve original
   indentation.
-- To attach an image or video (a diagram, a chart, a captured repro), write the file into
-  `$media_dir` and cite it by the absolute path you wrote it to:
-  `![desc]($media_dir/name.png)` to embed, or `[desc]($media_dir/name.png)`
-  to link. A later workflow step uploads it and rewrites the reference to a URL. Do not
-  upload anything yourself. Skip this unless a visual genuinely beats prose; most reviews
-  need none.
-- Put a video reference (`.mp4`, `.mov`, `.webm`) on a line of its own. GitHub renders a
-  player only for a bare URL in its own paragraph, so a video cited mid-sentence falls back
-  to a plain link.
+- Nothing you write to disk reaches the PR. Do not link or embed a local path; describe what
+  the capture showed instead.
 
-Validate before finishing, then fix any errors and re-emit until both of these pass:
+Validate before finishing, then fix any errors and re-emit until it passes:
 
 ```bash
 uv run --package skills skills validate-review $payload_path
-# only when you wrote a file into $media_dir
-uv run --package skills skills embed-media --check --dir $media_dir --target $payload_path
 ```
 
 Do not post the review: no `gh pr review`, no review/comment APIs, no other skills. Stop

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -121,7 +121,7 @@ jobs:
   link:
     needs: gate
     runs-on: ubuntu-slim
-    timeout-minutes: 10
+    timeout-minutes: 1
     permissions:
       actions: read
       pull-requests: write
@@ -137,7 +137,7 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          for _ in $(seq 60); do
+          for _ in $(seq 8); do
             url=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
                     --jq '.jobs[] | select(.name == "review") | .html_url')
             if [ -n "$url" ]; then

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -120,35 +120,48 @@ jobs:
   # it: a job's URL exists only once the job does. Cosmetic; nothing depends on it.
   link:
     needs: gate
-    if: github.event_name == 'issue_comment'
     runs-on: ubuntu-slim
     timeout-minutes: 10
     permissions:
       actions: read
       pull-requests: write
     steps:
-      - name: Deep-link the running review job
+      # Runs on both events so the pull_request smoke path covers the polling,
+      # the `actions: read` scope, and the job-name filter. Only the comment
+      # edit below is issue_comment-only.
+      - name: Wait for the review job URL
+        id: job
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           for _ in $(seq 60); do
             url=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
                     --jq '.jobs[] | select(.name == "review") | .html_url')
             if [ -n "$url" ]; then
-              printf '%s\n\n---\n\n🚀 [Review running...](%s?pr=%s)' \
-                "$COMMENT_BODY" "$url" "$PR_NUMBER" \
-                | gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@-
+              echo "url=$url" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             sleep 2
           done
           echo "::warning::review job never became visible; the comment keeps the run-level link"
+
+      - name: Deep-link the comment
+        if: github.event_name == 'issue_comment' && steps.job.outputs.url
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          JOB_URL: ${{ steps.job.outputs.url }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          printf '%s\n\n---\n\n🚀 [Review running...](%s?pr=%s)' \
+            "$COMMENT_BODY" "$JOB_URL" "$PR_NUMBER" \
+            | gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@-
 
   review:
     needs: gate

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -441,10 +441,12 @@ jobs:
           if-no-files-found: ignore
 
   # Separate job so PR-write credentials never share a machine with the code the
-  # review executes. Jobs get their own VM; steps do not.
+  # review executes. Jobs get their own VM; steps do not. Runs on both events so
+  # the smoke path covers the artifact handoff, the pin, and validation; only the
+  # steps that mutate the PR are issue_comment-only.
   post:
     needs: [gate, review]
-    if: "!cancelled() && needs.gate.result == 'success' && github.event_name == 'issue_comment'"
+    if: "!cancelled() && needs.gate.result == 'success'"
     runs-on: ubuntu-latest
     # The app token below is the only credential here, so a bare `gh` call fails closed.
     permissions: {}
@@ -480,7 +482,7 @@ jobs:
       # Attaching media is a nicety; losing the whole review over it is not. Any
       # fault here must not take the job down before Post review.
       - name: Upload review media
-        if: needs.review.result == 'success'
+        if: needs.review.result == 'success' && github.event_name == 'issue_comment'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
@@ -518,7 +520,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Post review
-        if: needs.review.result == 'success'
+        if: needs.review.result == 'success' && github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
@@ -527,7 +529,7 @@ jobs:
           gh api --method POST repos/"$REPO"/pulls/"$PR_NUMBER"/reviews --input "$REVIEW_PAYLOAD"
 
       - name: Report review results
-        if: "!cancelled()"
+        if: "!cancelled() && github.event_name == 'issue_comment'"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -521,10 +521,16 @@ jobs:
           COMMENT_ID: ${{ github.event.comment.id }}
           COMMENT_BODY: ${{ github.event.comment.body }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          POST_STATUS: ${{ job.status }}
         run: |
-          # Missing only when the review job died before building it.
-          if [ ! -f "$RESULT_BODY" ]; then
-            mkdir -p "$(dirname "$RESULT_BODY")"
+          mkdir -p "$(dirname "$RESULT_BODY")"
+          # The review job renders this before this job runs, so it reports the
+          # review's own outcome and knows nothing about pinning, validation, or
+          # the POST. A failure in any of those must not leave a success message.
+          if [ "$POST_STATUS" != "success" ]; then
+            printf '%s\n\n---\n\n❌ [Review](%s) ran but could not be posted.' \
+              "$COMMENT_BODY" "$RUN_URL" > "$RESULT_BODY"
+          elif [ ! -f "$RESULT_BODY" ]; then
             printf '%s\n\n---\n\n❌ [Review](%s) failed before it could report a result.' \
               "$COMMENT_BODY" "$RUN_URL" > "$RESULT_BODY"
           fi

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -174,7 +174,6 @@ jobs:
     timeout-minutes: 45
     env:
       REVIEW_PAYLOAD: /tmp/review-payload.json
-      REVIEW_MEDIA: /tmp/review-media
       PR_CHECKOUT: ${{ github.workspace }}/pr
     steps:
       - name: Resolve job URL
@@ -299,7 +298,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url || github.event.issue.html_url }}
           MODEL: ${{ steps.prompt.outputs.model }}
           EFFORT: ${{ steps.prompt.outputs.effort }}
-          AGENT_BROWSER_SCREENSHOT_DIR: ${{ env.REVIEW_MEDIA }}
+          AGENT_BROWSER_SCREENSHOT_DIR: /tmp/screenshots
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"
           mkdir -p "$AGENT_BROWSER_SCREENSHOT_DIR"
@@ -317,7 +316,7 @@ jobs:
             --print \
             --verbose \
             --output-format stream-json \
-            "/pr-review $PR_URL $PR_CHECKOUT $REVIEW_PAYLOAD $REVIEW_MEDIA" \
+            "/pr-review $PR_URL $PR_CHECKOUT $REVIEW_PAYLOAD" \
             | .claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 30 minutes"
@@ -327,8 +326,22 @@ jobs:
             exit $EXIT_CODE
           fi
 
-      # Fails the review job fast, next to the payload it produced. Not the gate on
-      # posting: `post` revalidates what it downloads on its own side.
+      # Without commit_id, GitHub anchors the comments to whatever head is current
+      # at POST time. The SHA comes from the gate, not from this job. Injected
+      # before validation so the schema's SHA pattern covers it.
+      - name: Pin review to the reviewed commit
+        env:
+          PR_HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+        run: |
+          if [ ! -f "$REVIEW_PAYLOAD" ]; then
+            echo "::error::Claude did not produce $REVIEW_PAYLOAD"
+            exit 1
+          fi
+          jq --arg sha "$PR_HEAD_SHA" '.commit_id = $sha' "$REVIEW_PAYLOAD" > /tmp/pinned-payload.json
+          mv /tmp/pinned-payload.json "$REVIEW_PAYLOAD"
+
+      # The last check before the payload becomes an artifact. `post` runs no
+      # repository code, so this is the only validation there is.
       - name: Validate review payload
         working-directory: base
         run: |
@@ -426,7 +439,7 @@ jobs:
           JS
 
       # Absolute paths share /tmp as their common ancestor, so this unpacks as
-      # review-payload.json, review-media/, and updated-comment.md.
+      # review-payload.json and updated-comment.md.
       # Keyed on run_id, not run_attempt: re-running only `post` leaves the
       # successful `review` job (and its attempt-1 artifact) untouched, so `post`
       # must look under a name that does not change across attempts. overwrite so
@@ -440,15 +453,16 @@ jobs:
           overwrite: true
           path: |
             /tmp/review-payload.json
-            /tmp/review-media
             /tmp/updated-comment.md
           retention-days: 1
           if-no-files-found: ignore
 
   # Separate job so PR-write credentials never share a machine with the code the
-  # review executes. Jobs get their own VM; steps do not. Runs on both events so
-  # the smoke path covers the artifact handoff, the pin, and validation; only the
-  # steps that mutate the PR are issue_comment-only.
+  # review executes. Jobs get their own VM; steps do not. It posts what the review
+  # job already pinned and validated, and runs no repository code of its own: no
+  # checkout, no toolchain, nothing between the artifact and the API call. Runs on
+  # both events so the smoke path covers the artifact handoff; only the steps that
+  # mutate the PR are issue_comment-only.
   post:
     needs: [gate, review]
     if: "!cancelled() && needs.gate.result == 'success'"
@@ -456,11 +470,9 @@ jobs:
     # permissions: {} grants no GITHUB_TOKEN, so a bare `gh` call that forgets its token fails closed.
     permissions: {}
     timeout-minutes: 10
-    # Same paths the review job used: the payload cites media by absolute path,
-    # and `embed-media` matches those citations against the files it finds.
+    # The paths the review job uploaded from, which is how the artifact unpacks.
     env:
       REVIEW_PAYLOAD: /tmp/review-payload.json
-      REVIEW_MEDIA: /tmp/review-media
       RESULT_BODY: /tmp/updated-comment.md
     steps:
       # Needed only here: GitHub refuses approving reviews from GITHUB_TOKEN, and
@@ -472,64 +484,12 @@ jobs:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-pull-requests: write
-      # Not sparse: `uv run --package skills` resolves the whole workspace, so a
-      # subset would have to track `[tool.uv.workspace].members`.
-      # Pinned to the base: with no `ref` this resolves to the PR's merge ref on
-      # pull_request, which would run PR-authored code in the job that holds the
-      # app token.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
-      - uses: ./.github/actions/setup-python
-        with:
-          pin-micro-version: false
       # Absent when the review job died before uploading, so the steps below check.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           name: review-output-${{ github.run_id }}
           path: /tmp
-
-      # Attaching media is a nicety; losing the whole review over it is not. Any
-      # fault here must not take the job down before Post review.
-      - name: Upload review media
-        if: needs.review.result == 'success' && github.event_name == 'issue_comment'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
-          REPO_ID: ${{ github.event.repository.id }}
-        run: |
-          # Empty directories aren't uploaded, so review-media/ may be missing.
-          mkdir -p "$REVIEW_MEDIA"
-          uv run --package skills skills embed-media \
-            --dir "$REVIEW_MEDIA" \
-            --target "$REVIEW_PAYLOAD" \
-            --repository-id "$REPO_ID"
-
-      # Without commit_id, GitHub anchors the comments to whatever head is current
-      # at POST time. The SHA comes from the gate, not the review job. Injected
-      # before validation so the schema's SHA pattern covers it.
-      - name: Pin review to the reviewed commit
-        if: needs.review.result == 'success'
-        env:
-          PR_HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
-        run: |
-          if [ ! -f "$REVIEW_PAYLOAD" ]; then
-            echo "::error::Claude did not produce $REVIEW_PAYLOAD"
-            exit 1
-          fi
-          jq --arg sha "$PR_HEAD_SHA" '.commit_id = $sha' "$REVIEW_PAYLOAD" > /tmp/pinned-payload.json
-          mv /tmp/pinned-payload.json "$REVIEW_PAYLOAD"
-
-      # Authored on a machine that ran PR code, so it's checked on this side.
-      - name: Validate review payload
-        if: needs.review.result == 'success'
-        run: |
-          uv run --package skills skills validate-review "$REVIEW_PAYLOAD"
-          echo "::group::Review payload"
-          jq . "$REVIEW_PAYLOAD"
-          echo "::endgroup::"
 
       - name: Post review
         if: needs.review.result == 'success' && github.event_name == 'issue_comment'
@@ -538,6 +498,10 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
+          if [ ! -f "$REVIEW_PAYLOAD" ]; then
+            echo "::error::the review job uploaded no $REVIEW_PAYLOAD"
+            exit 1
+          fi
           gh api --method POST repos/"$REPO"/pulls/"$PR_NUMBER"/reviews --input "$REVIEW_PAYLOAD"
 
       - name: Report review results
@@ -552,8 +516,8 @@ jobs:
         run: |
           mkdir -p "$(dirname "$RESULT_BODY")"
           # The review job renders this before this job runs, so it reports the
-          # review's own outcome and knows nothing about pinning, validation, or
-          # the POST. A failure in any of those must not leave a success message.
+          # review's own outcome and knows nothing about the POST. A failure there
+          # must not leave a success message.
           if [ "$POST_STATUS" != "success" ]; then
             printf '%s\n\n---\n\n❌ [Review](%s) ran but could not be posted.' \
               "$COMMENT_BODY" "$RUN_URL" > "$RESULT_BODY"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -29,6 +29,9 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+      pull-requests: write
+    outputs:
+      head_sha: ${{ steps.head.outputs.head_sha }}
     # Cheap author_association prefilter so random users can't spawn workflow
     # runs. The gate step below does the authoritative admin/maintain role
     # check.
@@ -83,52 +86,89 @@ jobs:
             check_user "$COMMENTER" "User"
           fi
 
+      # Pinned before any PR code runs, so `post` anchors the review to a commit
+      # the review job can't influence. `issue_comment` payloads carry no head SHA.
+      - name: Resolve reviewed head commit
+        id: head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          head_sha="$CONTEXT_HEAD_SHA"
+          if [ -z "$head_sha" ]; then
+            head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)
+          fi
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+      # `github.run_id` exists before any job starts, so this lands without waiting
+      # for the review job's runner. `link` swaps in the job-level URL later.
+      - name: Acknowledge the comment
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          printf '%s\n\n---\n\n🚀 [Review running...](%s)' "$COMMENT_BODY" "$RUN_URL" \
+            | gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@-
+
+  # Deep-links the comment to the review job. Runs alongside `review`, not before
+  # it: a job's URL exists only once the job does. Cosmetic; nothing depends on it.
+  link:
+    needs: gate
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Deep-link the running review job
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          for _ in $(seq 60); do
+            url=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
+                    --jq '.jobs[] | select(.name == "review") | .html_url')
+            if [ -n "$url" ]; then
+              printf '%s\n\n---\n\n🚀 [Review running...](%s?pr=%s)' \
+                "$COMMENT_BODY" "$url" "$PR_NUMBER" \
+                | gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@-
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::warning::review job never became visible; the comment keeps the run-level link"
+
   review:
     needs: gate
     runs-on: ubuntu-latest
-    # GITHUB_TOKEN is unused — all GitHub API calls go through the app tokens
-    # minted below. Grant nothing so any future accidental use of GITHUB_TOKEN
-    # fails closed.
-    permissions: {}
+    # Runs PR code by design (builds, tests, the dev server), so it holds no app
+    # credentials: the private key here would let a poisoned diff mint a write token.
+    permissions:
+      contents: read
+      pull-requests: read
     timeout-minutes: 45
     env:
       REVIEW_PAYLOAD: /tmp/review-payload.json
       REVIEW_MEDIA: /tmp/review-media
       PR_CHECKOUT: ${{ github.workspace }}/pr
     steps:
-      # Two app tokens with split scopes:
-      # - app-token-read (read-only): used by the Claude step so prompt-injection
-      #   in a diff can't trigger comments, approvals, or any PR mutation.
-      # - app-token-write (write): used by React/Post/Report (code we control).
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token-read
-        with:
-          client-id: ${{ secrets.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-contents: read
-          permission-pull-requests: read
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        if: github.event_name == 'issue_comment'
-        id: app-token-write
-        with:
-          client-id: ${{ secrets.APP_CLIENT_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          permission-pull-requests: write
       - name: Resolve job URL
         env:
           JOB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ job.check_run_id }}?pr=${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           echo "JOB_RUN_URL=$JOB_RUN_URL" >> "$GITHUB_ENV"
-      - name: React to comment
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
-          REPO: ${{ github.repository }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          printf '%s\n\n---\n\n🚀 [Review running...](%s)' "$COMMENT_BODY" "$JOB_RUN_URL" \
-            | gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@-
       # Each checkout owns a subdirectory, so neither cleans the other and the
       # two can run together.
       - parallel:
@@ -142,25 +182,28 @@ jobs:
           - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
             with:
               persist-credentials: false
-              token: ${{ steps.app-token-read.outputs.token }}
               path: base
           # The reviewed tree, passed to the review as a path. Nothing the job
           # itself runs comes from here.
           - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
             with:
               persist-credentials: false
-              token: ${{ steps.app-token-read.outputs.token }}
               ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/merge
               path: pr
               # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
               # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
               fetch-depth: 2
-      # HEAD^2 of the merge ref is the PR head. Resolved before the review step,
-      # which runs Bash against that tree.
-      - name: Pin reviewed head commit
+      # HEAD^2 of the merge ref is the PR head. A mismatch means the branch moved,
+      # so the review and `post` would target different commits.
+      - name: Verify reviewed head commit
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
         run: |
           PR_HEAD_SHA=$(git -C "$PR_CHECKOUT" rev-parse HEAD^2)
-          echo "PR_HEAD_SHA=$PR_HEAD_SHA" >> "$GITHUB_ENV"
+          if [ "$PR_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::error::PR head moved after the gate pinned $EXPECTED_HEAD_SHA (merge ref now has $PR_HEAD_SHA)"
+            exit 1
+          fi
       - parallel:
           - uses: ./base/.github/actions/setup-python
             with:
@@ -226,8 +269,8 @@ jobs:
         id: review
         working-directory: base
         env:
-          # Read-only token: Claude can fetch PR/diff/comments but cannot post anything.
-          GH_TOKEN: ${{ steps.app-token-read.outputs.token }}
+          # Read-only for the whole job: injected instructions can't mutate the PR.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_BASE_URL: ${{ steps.gateway.outputs.base-url }}
           ANTHROPIC_AUTH_TOKEN: ${{ steps.gateway.outputs.token }}
           ANTHROPIC_CUSTOM_HEADERS: ${{ steps.gateway.outputs.custom-headers }}
@@ -249,7 +292,7 @@ jobs:
           mkdir -p "$AGENT_BROWSER_SCREENSHOT_DIR"
 
           # Both event paths run /pr-review end-to-end against the PR; on
-          # pull_request (smoke), Post is gated off so no review is submitted.
+          # pull_request (smoke), `post` never runs so no review is submitted.
           EXIT_CODE=0
           timeout 30m claude \
             --model "$MODEL" \
@@ -271,36 +314,8 @@ jobs:
             exit $EXIT_CODE
           fi
 
-      # Kept out of the Claude step, which holds only the read-only app token, so a
-      # poisoned diff can't reach this PAT. Gated like Post so the pull_request
-      # smoke path stays non-mutating.
-      - name: Upload review media
-        if: github.event_name == 'issue_comment'
-        working-directory: base
-        # Attaching media is a nicety; losing the whole review over it is not. Any
-        # fault here must not take the job down before Post review.
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
-          REPO_ID: ${{ github.event.repository.id }}
-        run: |
-          uv run --package skills skills embed-media \
-            --dir "$REVIEW_MEDIA" \
-            --target "$REVIEW_PAYLOAD" \
-            --repository-id "$REPO_ID"
-
-      # Without commit_id, GitHub anchors the comments to whatever head is current
-      # at POST time. Injected before validation so the schema's SHA pattern
-      # covers it.
-      - name: Pin review to the reviewed commit
-        run: |
-          if [ ! -f "$REVIEW_PAYLOAD" ]; then
-            echo "::error::Claude did not produce $REVIEW_PAYLOAD"
-            exit 1
-          fi
-          jq --arg sha "$PR_HEAD_SHA" '.commit_id = $sha' "$REVIEW_PAYLOAD" > /tmp/pinned-payload.json
-          mv /tmp/pinned-payload.json "$REVIEW_PAYLOAD"
-
+      # The only payload check the pull_request smoke path gets. Not the gate on
+      # posting: `post` revalidates what it downloads.
       - name: Validate review payload
         working-directory: base
         run: |
@@ -309,20 +324,10 @@ jobs:
           jq . "$REVIEW_PAYLOAD"
           echo "::endgroup::"
 
-      - name: Post review
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          gh api --method POST repos/"$REPO"/pulls/"$PR_NUMBER"/reviews --input "$REVIEW_PAYLOAD"
-
       - name: Redact secrets from transcript
         if: always()
         env:
-          GH_TOKEN_READ: ${{ steps.app-token-read.outputs.token }}
-          GH_TOKEN_WRITE: ${{ steps.app-token-write.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GATEWAY_TOKEN: ${{ steps.gateway.outputs.token }}
         run: |
           python <<'PY'
@@ -334,7 +339,7 @@ jobs:
           if not path.exists():
               sys.exit(0)
           data = path.read_text()
-          for name in ("GH_TOKEN_READ", "GH_TOKEN_WRITE", "GATEWAY_TOKEN"):
+          for name in ("GH_TOKEN", "GATEWAY_TOKEN"):
               if val := os.environ.get(name):
                   data = data.replace(val, "***")
           path.write_text(data)
@@ -407,11 +412,120 @@ jobs:
           fs.writeFileSync('/tmp/updated-comment.md', `${process.env.COMMENT_BODY}\n\n---\n\n${resultLine}`);
           JS
 
-      - name: Report review results
-        if: always() && github.event_name == 'issue_comment'
+      # Absolute paths share /tmp as their common ancestor, so this unpacks as
+      # review-payload.json, review-media/, and updated-comment.md.
+      - name: Upload review output
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: review-output-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            /tmp/review-payload.json
+            /tmp/review-media
+            /tmp/updated-comment.md
+          retention-days: 1
+          if-no-files-found: ignore
+
+  # Separate job so PR-write credentials never share a machine with the code the
+  # review executes. Jobs get their own VM; steps do not.
+  post:
+    needs: [gate, review]
+    if: "!cancelled() && needs.gate.result == 'success' && github.event_name == 'issue_comment'"
+    runs-on: ubuntu-latest
+    # The app token below is the only credential here, so a bare `gh` call fails closed.
+    permissions: {}
+    timeout-minutes: 10
+    env:
+      REVIEW_PAYLOAD: ${{ github.workspace }}/review-output/review-payload.json
+      REVIEW_MEDIA: ${{ github.workspace }}/review-output/review-media
+      RESULT_BODY: ${{ github.workspace }}/review-output/updated-comment.md
+    steps:
+      # Needed only here: GitHub refuses approving reviews from GITHUB_TOKEN, and
+      # the payload's `event` can be APPROVE.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+      # Not sparse: `uv run --package skills` resolves the whole workspace, so a
+      # subset would have to track `[tool.uv.workspace].members`.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-python
+        with:
+          pin-micro-version: false
+      # Absent when the review job died before uploading, so the steps below check.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: review-output-${{ github.run_id }}-${{ github.run_attempt }}
+          path: review-output
+
+      # Attaching media is a nicety; losing the whole review over it is not. Any
+      # fault here must not take the job down before Post review.
+      - name: Upload review media
+        if: needs.review.result == 'success'
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.app-token-write.outputs.token }}
+          GH_TOKEN: ${{ secrets.UPLOAD_MEDIA_TOKEN }}
+          REPO_ID: ${{ github.event.repository.id }}
+        run: |
+          # Empty directories aren't uploaded, so review-media/ may be missing.
+          mkdir -p "$REVIEW_MEDIA"
+          uv run --package skills skills embed-media \
+            --dir "$REVIEW_MEDIA" \
+            --target "$REVIEW_PAYLOAD" \
+            --repository-id "$REPO_ID"
+
+      # Without commit_id, GitHub anchors the comments to whatever head is current
+      # at POST time. The SHA comes from the gate, not the review job. Injected
+      # before validation so the schema's SHA pattern covers it.
+      - name: Pin review to the reviewed commit
+        if: needs.review.result == 'success'
+        env:
+          PR_HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+        run: |
+          if [ ! -f "$REVIEW_PAYLOAD" ]; then
+            echo "::error::Claude did not produce $REVIEW_PAYLOAD"
+            exit 1
+          fi
+          jq --arg sha "$PR_HEAD_SHA" '.commit_id = $sha' "$REVIEW_PAYLOAD" > /tmp/pinned-payload.json
+          mv /tmp/pinned-payload.json "$REVIEW_PAYLOAD"
+
+      # Authored on a machine that ran PR code, so it's checked on this side.
+      - name: Validate review payload
+        if: needs.review.result == 'success'
+        run: |
+          uv run --package skills skills validate-review "$REVIEW_PAYLOAD"
+          echo "::group::Review payload"
+          jq . "$REVIEW_PAYLOAD"
+          echo "::endgroup::"
+
+      - name: Post review
+        if: needs.review.result == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh api --method POST repos/"$REPO"/pulls/"$PR_NUMBER"/reviews --input "$REVIEW_PAYLOAD"
+
+      - name: Report review results
+        if: "!cancelled()"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@/tmp/updated-comment.md
+          # Missing only when the review job died before building it.
+          if [ ! -f "$RESULT_BODY" ]; then
+            mkdir -p "$(dirname "$RESULT_BODY")"
+            printf '%s\n\n---\n\n❌ [Review](%s) failed before it could report a result.' \
+              "$COMMENT_BODY" "$RUN_URL" > "$RESULT_BODY"
+          fi
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID" -X PATCH -F body=@"$RESULT_BODY"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -327,8 +327,8 @@ jobs:
             exit $EXIT_CODE
           fi
 
-      # The only payload check the pull_request smoke path gets. Not the gate on
-      # posting: `post` revalidates what it downloads.
+      # Fails the review job fast, next to the payload it produced. Not the gate on
+      # posting: `post` revalidates what it downloads on its own side.
       - name: Validate review payload
         working-directory: base
         run: |
@@ -427,12 +427,17 @@ jobs:
 
       # Absolute paths share /tmp as their common ancestor, so this unpacks as
       # review-payload.json, review-media/, and updated-comment.md.
+      # Keyed on run_id, not run_attempt: re-running only `post` leaves the
+      # successful `review` job (and its attempt-1 artifact) untouched, so `post`
+      # must look under a name that does not change across attempts. overwrite so
+      # a full re-run replaces it cleanly.
       - name: Upload review output
         if: always()
         continue-on-error: true
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: review-output-${{ github.run_id }}-${{ github.run_attempt }}
+          name: review-output-${{ github.run_id }}
+          overwrite: true
           path: |
             /tmp/review-payload.json
             /tmp/review-media
@@ -483,7 +488,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
-          name: review-output-${{ github.run_id }}-${{ github.run_attempt }}
+          name: review-output-${{ github.run_id }}
           path: /tmp
 
       # Attaching media is a nicety; losing the whole review over it is not. Any

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -144,7 +144,7 @@ jobs:
               echo "url=$url" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            sleep 2
+            sleep 5
           done
           echo "::warning::review job never became visible; the comment keeps the run-level link"
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           for _ in $(seq 6); do
             url=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
-                    --jq '.jobs[] | select(.name == "review") | .html_url')
+                    --jq '.jobs[] | select(.name == "review") | .html_url') || true
             if [ -n "$url" ]; then
               echo "url=$url" >> "$GITHUB_OUTPUT"
               exit 0
@@ -453,7 +453,7 @@ jobs:
     needs: [gate, review]
     if: "!cancelled() && needs.gate.result == 'success'"
     runs-on: ubuntu-latest
-    # The app token below is the only credential here, so a bare `gh` call fails closed.
+    # permissions: {} grants no GITHUB_TOKEN, so a bare `gh` call that forgets its token fails closed.
     permissions: {}
     timeout-minutes: 10
     # Same paths the review job used: the payload cites media by absolute path,
@@ -480,7 +480,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha || github.ref }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -137,7 +137,7 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          for _ in $(seq 8); do
+          for _ in $(seq 6); do
             url=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate \
                     --jq '.jobs[] | select(.name == "review") | .html_url')
             if [ -n "$url" ]; then
@@ -451,14 +451,17 @@ jobs:
     # The app token below is the only credential here, so a bare `gh` call fails closed.
     permissions: {}
     timeout-minutes: 10
+    # Same paths the review job used: the payload cites media by absolute path,
+    # and `embed-media` matches those citations against the files it finds.
     env:
-      REVIEW_PAYLOAD: ${{ github.workspace }}/review-output/review-payload.json
-      REVIEW_MEDIA: ${{ github.workspace }}/review-output/review-media
-      RESULT_BODY: ${{ github.workspace }}/review-output/updated-comment.md
+      REVIEW_PAYLOAD: /tmp/review-payload.json
+      REVIEW_MEDIA: /tmp/review-media
+      RESULT_BODY: /tmp/updated-comment.md
     steps:
       # Needed only here: GitHub refuses approving reviews from GITHUB_TOKEN, and
       # the payload's `event` can be APPROVE.
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        if: github.event_name == 'issue_comment'
         id: app-token
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
@@ -466,9 +469,13 @@ jobs:
           permission-pull-requests: write
       # Not sparse: `uv run --package skills` resolves the whole workspace, so a
       # subset would have to track `[tool.uv.workspace].members`.
+      # Pinned to the base: with no `ref` this resolves to the PR's merge ref on
+      # pull_request, which would run PR-authored code in the job that holds the
+      # app token.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha || github.ref }}
       - uses: ./.github/actions/setup-python
         with:
           pin-micro-version: false
@@ -477,7 +484,7 @@ jobs:
         continue-on-error: true
         with:
           name: review-output-${{ github.run_id }}-${{ github.run_attempt }}
-          path: review-output
+          path: /tmp
 
       # Attaching media is a nicety; losing the whole review over it is not. Any
       # fault here must not take the job down before Post review.


### PR DESCRIPTION
### Related Issues/PRs

Relates to the read/write token split in `.github/workflows/review.yml`, which this PR moves from steps to jobs.

### What changes are proposed in this pull request?

The `review` job runs code from the PR by design (it builds the UI, boots the backend, and runs tests to verify findings) while holding both app tokens, the app private key, and `UPLOAD_MEDIA_TOKEN`. A step is not an isolation boundary: the runner user has passwordless `sudo`, the runner worker holds the job's secrets for the job's lifetime, and a process started during the review outlives the step that spawned it. Jobs are the boundary, since each gets its own VM.

Split into four:

- `gate` pins the reviewed head SHA before any PR code runs, so `post` anchors the review to a commit the review job cannot influence. It also acknowledges the comment as soon as `github.run_id` exists, which is earlier than today's `React to comment` since that waits for the review job's runner.
- `review` drops to a per-job `GITHUB_TOKEN` with `contents: read` and `pull-requests: read`, and hands its payload to `post` as an artifact.
- `post` holds the only `create-github-app-token` call, needed because GitHub refuses approving reviews from `GITHUB_TOKEN` and the payload's `event` can be `APPROVE`. It does nothing else: no checkout, no toolchain, no repository code between the artifact and the API call. The payload arrives already pinned and validated, so the job that holds the write credential only writes.
- `link` deep-links the comment to the review job while it runs.

That leaves no room for the media upload, which needed a checkout, a toolchain and a second credential in `post`. Attaching media is dropped rather than moved: `UPLOAD_MEDIA_TOKEN` beside PR code would be a worse trade, and keeping the citations without the upload would post local paths that resolve to nothing. The `pr-review` skill loses `media_dir` accordingly. Screenshots still work for the review's own analysis; a capture is now something it looks at and describes.

### How is this PR tested?

- [x] Existing unit/integration tests

The `pull_request` smoke path on this PR exercises `gate` and `review`, including the new head-SHA verification, the credential-free checkouts, and the pin and validation the payload now carries out of that job. `link` runs on both events; `post`'s mutating steps are `issue_comment`-only, so the first `/review` comment is what covers those.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
