### PR TITLE
Stop offering `WebSearch` to reviews on the gateway

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -103,8 +103,8 @@ the shallow boundary rather than reaching the commit that actually introduced a 
 errors, so don't trust them for pre-change history.
 
 Verify rather than infer. A `grep` through the installed package, a `uv run python -c '...'`, or a
-quick search and fetch of the upstream docs will settle most questions in seconds, and an unverified
-finding should be dropped rather than hedged. When the cheap checks don't settle it, escalate to the
+web fetch of the upstream docs will settle most questions in seconds, and an unverified finding
+should be dropped rather than hedged. When the cheap checks don't settle it, escalate to the
 expensive ones: build the docs site, build and boot the UI, start the backend.
 
 Node and `agent-browser` are on PATH for docs and UI changes. Capture to an absolute path named for

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -251,9 +251,9 @@ jobs:
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.
           EXIT_CODE=0
-          # Bedrock, the gateway's backend, does not serve Anthropic's server-side
-          # web_search tool. Denying the bare name drops it from Claude's context
-          # instead of leaving it to fail on use.
+          # The gateway does not serve Anthropic's server-side web_search tool.
+          # Denying the bare name drops it from Claude's context instead of
+          # leaving it to fail on use.
           timeout 30m claude \
             --model "$MODEL" \
             --effort "$EFFORT" \

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -251,6 +251,9 @@ jobs:
           # Both event paths run /pr-review end-to-end against the PR; on
           # pull_request (smoke), Post is gated off so no review is submitted.
           EXIT_CODE=0
+          # Bedrock, the gateway's backend, does not serve Anthropic's server-side
+          # web_search tool. Denying the bare name drops it from Claude's context
+          # instead of leaving it to fail on use.
           timeout 30m claude \
             --model "$MODEL" \
             --effort "$EFFORT" \
@@ -258,6 +261,7 @@ jobs:
             --permission-mode auto \
             --add-dir "$PR_CHECKOUT" \
             --allowed-tools "Bash(uv run --package skills skills:*)" \
+            --disallowed-tools WebSearch \
             --print \
             --verbose \
             --output-format stream-json \


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25451, where both smoke reviews hit this.

### What changes are proposed in this pull request?

Every `WebSearch` call from a review fails:

```
API Error: 400 {"message":"tool type 'web_search_20250305' is not supported for this model"}
```

The gateway does not serve Anthropic's server-side `web_search` tool. The error names the model, but no model choice helps: web search runs on Anthropic's own infrastructure rather than in the weights, so it is unavailable through the gateway regardless of which model the review picks.

Denying the bare tool name drops it from Claude's context, so the model never spends a turn discovering it is unavailable. A scoped rule would leave the tool visible and only block the call, which does not help here.

Same class as the `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` line above it: the CLI assumes first-party capabilities the gateway does not have.

The `pr-review` skill pointed reviewers at "a quick search and fetch of the upstream docs", which now names a tool they cannot call, so that line points at the web fetch alone.

`WebFetch` is unaffected. It runs client-side in the CLI, which is why the affected reviews still reached the docs they needed after the search failed.

### How is this PR tested?

- [x] Existing unit/integration tests

The `pull_request` smoke path runs a full review on this PR. Its transcript no longer lists `WebSearch` among the session's tools, while a run from before this change lists it; `WebFetch` is present in both. Across five earlier transcripts, `WebSearch` was attempted twice and failed both times.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


