### PR TITLE
Catch a capture cited from outside `--dir` in `embed-media`

### DIFF
--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -96,9 +96,12 @@ def is_local_media(raw: str) -> bool:
 
     Claude cites a capture by the absolute path it wrote it to, so one that matches no
     collected file is a typo or a --dir that points somewhere else. GitHub resolves it
-    against the repository, where it is a 404 either way.
+    against the repository, where it is a 404 either way. A leading // is a
+    scheme-relative URL, which GitHub serves like any other.
     """
-    return raw.startswith("/") and Path(raw).suffix.lower() in MIME_TYPES
+    return (
+        raw.startswith("/") and not raw.startswith("//") and Path(raw).suffix.lower() in MIME_TYPES
+    )
 
 
 @dataclass
@@ -141,9 +144,9 @@ def check_media(directory: Path, texts: list[str]) -> CheckReport:
             path = by_name.get(name)
             if path and raw == str(path):
                 cited.add(name)
-            # A basename alone can only be meant as a capture; the same basename under
-            # some other relative path is an ordinary link that happens to collide.
-            elif path and "/" not in raw.removeprefix("./"):
+            # A basename alone, or a local path, can only be meant as a capture; the same
+            # basename under some other relative path is a link that happens to collide.
+            elif path and ("/" not in raw.removeprefix("./") or is_local_media(raw)):
                 cited.add(name)
                 report.errors.append(f"({raw}): cite the capture as {path}")
             elif raw.startswith(f"{directory}/"):

--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -91,6 +91,16 @@ def rewrite_payload(
 LINK = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)\)")
 
 
+def is_local_media(raw: str) -> bool:
+    """Whether a citation names media on this machine rather than something GitHub serves.
+
+    Claude cites a capture by the absolute path it wrote it to, so one that matches no
+    collected file is a typo or a --dir that points somewhere else. GitHub resolves it
+    against the repository, where it is a 404 either way.
+    """
+    return raw.startswith("/") and Path(raw).suffix.lower() in MIME_TYPES
+
+
 @dataclass
 class CheckReport:
     errors: list[str] = field(default_factory=list)
@@ -132,7 +142,7 @@ def check_media(directory: Path, texts: list[str]) -> CheckReport:
             if path and raw == str(path):
                 cited.add(name)
             # A basename alone can only be meant as a capture; the same basename under
-            # some other directory is an ordinary link that happens to collide.
+            # some other relative path is an ordinary link that happens to collide.
             elif path and "/" not in raw.removeprefix("./"):
                 cited.add(name)
                 report.errors.append(f"({raw}): cite the capture as {path}")
@@ -140,6 +150,11 @@ def check_media(directory: Path, texts: list[str]) -> CheckReport:
                 report.errors.append(
                     f"({raw}): no such file, so the citation is stripped and the finding "
                     "degrades to prose"
+                )
+            elif is_local_media(raw):
+                report.errors.append(
+                    f"({raw}): not a capture in {directory}, so the citation is stripped "
+                    "and the finding degrades to prose"
                 )
 
     for name in sorted(cited):
@@ -244,7 +259,9 @@ def run(args: argparse.Namespace) -> None:
         raw
         for raw in dict.fromkeys(LINK.findall(target_text))
         if raw not in resolvable
-        and (raw.startswith(f"{args.dir}/") or raw.removeprefix("./") in names)
+        and (
+            raw.startswith(f"{args.dir}/") or raw.removeprefix("./") in names or is_local_media(raw)
+        )
     ]
     for raw in stray:
         print(f"  no such capture, stripping: {raw}", file=sys.stderr)

--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -263,8 +263,10 @@ def run(args: argparse.Namespace) -> None:
             raw.startswith(f"{args.dir}/") or raw.removeprefix("./") in names or is_local_media(raw)
         )
     ]
-    for raw in stray:
-        print(f"  no such capture, stripping: {raw}", file=sys.stderr)
+    if stray:
+        # The workflow step is continue-on-error, so a non-zero exit here would change
+        # nothing, and stderr is buried in the log. An annotation is what reaches a human.
+        print(f"::warning::citations naming no capture, stripped: {', '.join(stray)}")
     if not referenced and not stray:
         print(f"No media referenced by {args.target}")
         return

--- a/.claude/skills/src/skills/commands/embed_media.py
+++ b/.claude/skills/src/skills/commands/embed_media.py
@@ -91,6 +91,12 @@ def rewrite_payload(
 LINK = re.compile(r"!?\[[^\]]*\]\(([^)\s]+)\)")
 
 
+# Wider than MIME_TYPES, which is an uploadability allowlist that deliberately leaves out
+# formats GitHub may not render. A capture the uploader would refuse is still a capture,
+# and citing it from the wrong directory is still the mistake below.
+CAPTURE_SUFFIXES = MIME_TYPES.keys() | {".svg"}
+
+
 def is_local_media(raw: str) -> bool:
     """Whether a citation names media on this machine rather than something GitHub serves.
 
@@ -100,7 +106,9 @@ def is_local_media(raw: str) -> bool:
     scheme-relative URL, which GitHub serves like any other.
     """
     return (
-        raw.startswith("/") and not raw.startswith("//") and Path(raw).suffix.lower() in MIME_TYPES
+        raw.startswith("/")
+        and not raw.startswith("//")
+        and Path(raw).suffix.lower() in CAPTURE_SUFFIXES
     )
 
 

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -402,10 +402,13 @@ def test_check_points_a_capture_cited_from_another_directory_at_the_path_written
     assert report.warnings == []
 
 
-def test_check_rejects_a_local_citation_matching_no_capture(tmp_path: Path) -> None:
-    report = check(tmp_path, "[the bug](/tmp/other/absent.png)")
+# The svg is a format MIME_TYPES leaves out, so it only reaches this branch if the
+# citation gate is wider than the uploader's allowlist.
+@pytest.mark.parametrize("cite", ["/tmp/other/absent.png", "/tmp/other/diagram.svg"])
+def test_check_rejects_a_local_citation_matching_no_capture(tmp_path: Path, cite: str) -> None:
+    report = check(tmp_path, f"[the bug]({cite})")
     assert report.errors == [
-        f"(/tmp/other/absent.png): not a capture in {tmp_path / 'media'}, so the citation is "
+        f"({cite}): not a capture in {tmp_path / 'media'}, so the citation is "
         "stripped and the finding degrades to prose"
     ]
 
@@ -581,12 +584,13 @@ def test_cli_strips_a_bare_filename_citation(
     assert target.read_text() == "evidence: the bug"
 
 
+@pytest.mark.parametrize("cite", ["/tmp/other/shot.png", "/tmp/other/diagram.svg"])
 def test_cli_strips_a_capture_cited_from_outside_the_media_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], cite: str
 ) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
-    target.write_text("evidence: ![the bug](/tmp/other/shot.png)")
+    target.write_text(f"evidence: ![the bug]({cite})")
 
     monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)
@@ -595,10 +599,7 @@ def test_cli_strips_a_capture_cited_from_outside_the_media_directory(
 
     uploader.assert_not_called()
     assert target.read_text() == "evidence: the bug"
-    assert (
-        "::warning::citations naming no capture, stripped: /tmp/other/shot.png"
-        in capsys.readouterr().out
-    )
+    assert f"::warning::citations naming no capture, stripped: {cite}" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize(

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -365,6 +365,7 @@ def test_check_rejects_a_citation_that_is_not_the_path_written(tmp_path: Path, b
         "[upstream](https://example.com/diagram.png)",
         "the `logo.png` in the diff",
         "[the module](mlflow/utils.py)",
+        "[the run log](/tmp/other/output.jsonl)",
     ],
 )
 def test_check_leaves_references_that_are_not_captures_alone(tmp_path: Path, body: str) -> None:
@@ -378,7 +379,6 @@ def test_check_leaves_references_that_are_not_captures_alone(tmp_path: Path, bod
     [
         "[the docs icon](docs/static/img/shot.png)",
         "[upstream](https://example.com/shot.png)",
-        "[a capture from another run](/tmp/other/shot.png)",
     ],
 )
 def test_check_leaves_a_link_whose_basename_collides_with_a_capture_alone(
@@ -387,6 +387,18 @@ def test_check_leaves_a_link_whose_basename_collides_with_a_capture_alone(
     # The capture is named shot.png, so every one of these shares its basename.
     report = check(tmp_path, body)
     assert report.errors == []
+
+
+@pytest.mark.parametrize("cite", ["/tmp/other/shot.png", "/tmp/other/absent.png"])
+def test_check_rejects_a_capture_cited_from_outside_the_media_directory(
+    tmp_path: Path, cite: str
+) -> None:
+    # The shape of a --dir pointing somewhere other than where the capture was written.
+    report = check(tmp_path, f"[the bug]({cite})")
+    assert report.errors == [
+        f"({cite}): not a capture in {tmp_path / 'media'}, so the citation is stripped "
+        "and the finding degrades to prose"
+    ]
 
 
 def test_check_warns_about_a_capture_nothing_cites(tmp_path: Path) -> None:
@@ -550,6 +562,22 @@ def test_cli_strips_a_bare_filename_citation(
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
     target.write_text(f"evidence: ![the bug]({cite})")
+
+    monkeypatch.setenv("GH_TOKEN", "t")
+    args = build_args(media, target)
+    with mock.patch.object(embed_media, "upload_asset") as uploader:
+        args.func(args)
+
+    uploader.assert_not_called()
+    assert target.read_text() == "evidence: the bug"
+
+
+def test_cli_strips_a_capture_cited_from_outside_the_media_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    media = make_media(tmp_path)
+    target = tmp_path / "body.md"
+    target.write_text("evidence: ![the bug](/tmp/other/shot.png)")
 
     monkeypatch.setenv("GH_TOKEN", "t")
     args = build_args(media, target)

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -599,7 +599,10 @@ def test_cli_strips_a_capture_cited_from_outside_the_media_directory(
 
     uploader.assert_not_called()
     assert target.read_text() == "evidence: the bug"
-    assert f"::warning::citations naming no capture, stripped: {cite}" in capsys.readouterr().out
+    # One annotation for the run, however many citations it stripped.
+    out = capsys.readouterr().out
+    assert f"::warning::citations naming no capture, stripped: {cite}" in out
+    assert out.count("::warning::") == 1
 
 
 @pytest.mark.parametrize(

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -379,6 +379,7 @@ def test_check_leaves_references_that_are_not_captures_alone(tmp_path: Path, bod
     [
         "[the docs icon](docs/static/img/shot.png)",
         "[upstream](https://example.com/shot.png)",
+        "[the cdn](//cdn.example.com/shot.png)",
     ],
 )
 def test_check_leaves_a_link_whose_basename_collides_with_a_capture_alone(
@@ -389,15 +390,23 @@ def test_check_leaves_a_link_whose_basename_collides_with_a_capture_alone(
     assert report.errors == []
 
 
-@pytest.mark.parametrize("cite", ["/tmp/other/shot.png", "/tmp/other/absent.png"])
-def test_check_rejects_a_capture_cited_from_outside_the_media_directory(
-    tmp_path: Path, cite: str
+def test_check_points_a_capture_cited_from_another_directory_at_the_path_written(
+    tmp_path: Path,
 ) -> None:
     # The shape of a --dir pointing somewhere other than where the capture was written.
-    report = check(tmp_path, f"[the bug]({cite})")
+    report = check(tmp_path, "[the bug](/tmp/other/shot.png)")
     assert report.errors == [
-        f"({cite}): not a capture in {tmp_path / 'media'}, so the citation is stripped "
-        "and the finding degrades to prose"
+        f"(/tmp/other/shot.png): cite the capture as {tmp_path / 'media' / 'shot.png'}"
+    ]
+    # The capture is cited, just under the wrong directory, so it is not also uncited.
+    assert report.warnings == []
+
+
+def test_check_rejects_a_local_citation_matching_no_capture(tmp_path: Path) -> None:
+    report = check(tmp_path, "[the bug](/tmp/other/absent.png)")
+    assert report.errors == [
+        f"(/tmp/other/absent.png): not a capture in {tmp_path / 'media'}, so the citation is "
+        "stripped and the finding degrades to prose"
     ]
 
 
@@ -592,12 +601,15 @@ def test_cli_strips_a_capture_cited_from_outside_the_media_directory(
     )
 
 
+@pytest.mark.parametrize(
+    "body",
+    ["see [the icon](docs/static/img/shot.png)", "see [the cdn](//cdn.example.com/shot.png)"],
+)
 def test_cli_leaves_a_link_outside_the_media_directory_alone(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, body: str
 ) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
-    body = "see [the icon](docs/static/img/shot.png)"
     target.write_text(body)
 
     monkeypatch.setenv("GH_TOKEN", "t")

--- a/.claude/skills/tests/test_embed_media.py
+++ b/.claude/skills/tests/test_embed_media.py
@@ -573,7 +573,7 @@ def test_cli_strips_a_bare_filename_citation(
 
 
 def test_cli_strips_a_capture_cited_from_outside_the_media_directory(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     media = make_media(tmp_path)
     target = tmp_path / "body.md"
@@ -586,6 +586,10 @@ def test_cli_strips_a_capture_cited_from_outside_the_media_directory(
 
     uploader.assert_not_called()
     assert target.read_text() == "evidence: the bug"
+    assert (
+        "::warning::citations naming no capture, stripped: /tmp/other/shot.png"
+        in capsys.readouterr().out
+    )
 
 
 def test_cli_leaves_a_link_outside_the_media_directory_alone(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25451, where this blind spot produced the bug described below.

### What changes are proposed in this pull request?

A review payload that cites `/tmp/review-media/shot.png` while `--dir` points somewhere else matched nothing, and neither mode of `embed-media` said so:

- `--check` exited 0 with `OK: 0 media reference(s) resolve` and a `cited by nothing` warning.
- The upload path posted the citation verbatim, so the review shipped a link to a path that exists on no machine GitHub can reach.

That is exactly the shape review found on #25451, where the artifact download landed the media somewhere other than where `--dir` pointed. `--check` would not have caught it.

An absolute path with a media extension is never an ordinary link: GitHub resolves it against the repository and 404s. So `--check` now reports it, and the upload path strips it the way it already strips a typo under `--dir`.

The strip itself stays non-fatal: the workflow step is `continue-on-error` precisely so a missing capture cannot cost the whole review, and it degrades the finding to prose. But it only printed to stderr, which is where the original bug hid. It now emits a `::warning::` annotation, matching what a fatal upload failure already does.

This reverses one previously blessed case. `test_check_leaves_a_link_whose_basename_collides_with_a_capture_alone` treated `/tmp/other/shot.png` as an ordinary link colliding on basename; it renders as a broken link either way, so it moves to the rejecting test. Relative paths (`docs/static/img/shot.png`) and URLs are untouched, and so is an absolute path that is not media.

### How is this PR tested?

- [x] New unit/integration tests

Four cases: `--check` rejects the citation whether or not the basename exists under `--dir`, the upload path strips it, a non-media absolute path stays an ordinary link, and the strip annotates.  Re-running the original failure by hand now exits 1 with `not a capture in /tmp/emtest2/media` where it used to print `OK`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
