### PR TITLE
Pin the reviewed head commit in the `review` gate

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -175,8 +175,8 @@ jobs:
               # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
               fetch-depth: 2
       # HEAD^2 of the merge ref is the PR head. A mismatch means the branch moved
-      # between the gate and the checkout, leaving the review reading one commit
-      # and its comments anchored to another.
+      # between the gate and this checkout, so the run would review a different
+      # commit than the one it was started for.
       - name: Verify reviewed head commit
         env:
           EXPECTED_HEAD_SHA: ${{ needs.gate.outputs.head_sha }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -29,6 +29,8 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+    outputs:
+      head_sha: ${{ steps.head.outputs.head_sha }}
     # Cheap author_association prefilter so random users can't spawn workflow
     # runs. The gate step below does the authoritative admin/maintain role
     # check.
@@ -82,6 +84,23 @@ jobs:
           if [ "$EVENT_NAME" = "issue_comment" ]; then
             check_user "$COMMENTER" "User"
           fi
+
+      # Pinned here, before anything checks out or runs PR code. `issue_comment`
+      # is the only path that has to fetch: its payload describes the comment,
+      # not the pull request.
+      - name: Resolve reviewed head commit
+        id: head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          CONTEXT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          head_sha="$CONTEXT_HEAD_SHA"
+          if [ -z "$head_sha" ]; then
+            head_sha=$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq .head.sha)
+          fi
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
 
   review:
     needs: gate
@@ -155,12 +174,18 @@ jobs:
               # Depth 2 so HEAD^1 (the merge ref's base parent) is reachable, letting
               # the pr-review skill read pre-change content via `git show HEAD^1:<path>`.
               fetch-depth: 2
-      # HEAD^2 of the merge ref is the PR head. Resolved before the review step,
-      # which runs Bash against that tree.
-      - name: Pin reviewed head commit
+      # HEAD^2 of the merge ref is the PR head. A mismatch means the branch moved
+      # between the gate and the checkout, leaving the review reading one commit
+      # and its comments anchored to another.
+      - name: Verify reviewed head commit
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
         run: |
           PR_HEAD_SHA=$(git -C "$PR_CHECKOUT" rev-parse HEAD^2)
-          echo "PR_HEAD_SHA=$PR_HEAD_SHA" >> "$GITHUB_ENV"
+          if [ "$PR_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::error::PR head moved after the gate pinned $EXPECTED_HEAD_SHA (merge ref now has $PR_HEAD_SHA)"
+            exit 1
+          fi
       - parallel:
           - uses: ./base/.github/actions/setup-python
             with:
@@ -297,6 +322,8 @@ jobs:
       # at POST time. Injected before validation so the schema's SHA pattern
       # covers it.
       - name: Pin review to the reviewed commit
+        env:
+          PR_HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
         run: |
           if [ ! -f "$REVIEW_PAYLOAD" ]; then
             echo "::error::Claude did not produce $REVIEW_PAYLOAD"


### PR DESCRIPTION
### Related Issues/PRs

Extracted from the closed #25451, which bundled this with a job split.

### What changes are proposed in this pull request?

The `review` job derives the reviewed head from the tree it just checked out, and nothing checks that tree against the commit the gate admitted. Push to the branch between the gate and the checkout and the run reviews the new head without a word, having been started for the old one.

The `gate` now resolves the head SHA and exports it as a job output. `pull_request` already carries it; `issue_comment` fetches it, since that payload describes the comment rather than the pull request. `review` verifies rather than derives: `HEAD^2` of the merge ref has to equal what the gate pinned, and a mismatch fails the job. That check runs before any PR code does.

This is not a tamper boundary, and does not try to be. Everything after the `Review` step shares a machine with whatever that step ran, which can reach `$GITHUB_PATH` and `$BASH_ENV` and so shape any later shell regardless of where the SHA came from. Only a separate job fixes that, per #25451. What this buys is that an honest branch push is caught rather than silently reviewed, and that the SHA has one source instead of a `$GITHUB_ENV` round trip.

### How is this PR tested?

- [x] Existing unit/integration tests

The `pull_request` smoke path runs on this PR and both new steps pass: `Resolve reviewed head commit` in `gate`, and `Verify reviewed head commit` in `review`, which agreed with the context-supplied SHA.

The `gh api` fallback is not covered before merge. `issue_comment` reads the workflow from the default branch, so a `/review` here runs master's copy rather than this one; that path only exercises after this lands.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


