### PR TITLE
Build a sandbox image for agent workflows

### DIFF
--- a/.claude/sandbox/Dockerfile
+++ b/.claude/sandbox/Dockerfile
@@ -1,0 +1,85 @@
+# syntax=docker/dockerfile:1
+
+# Toolchain image for running agents in CI, under gVisor.
+# Built and published by `.github/workflows/sandbox-image.yml`.
+FROM ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+
+ARG NODE_VERSION=24.19.0
+# https://nodejs.org/dist/v24.19.0/SHASUMS256.txt
+ARG NODE_SHA256=f625d97cd707df4ff96254916fbc5ff014f09c09effe5a1e0ca8f6d41a8789d4
+# Matches `.github/actions/setup-node`.
+ARG NPM_VERSION=12.0.1
+# Launcher only; `mlflow/server/js/.yarnrc.yml` picks the real Yarn via `yarnPath`.
+ARG YARN_VERSION=1.22.22
+ARG GH_VERSION=2.98.0
+# gh_2.98.0_checksums.txt on the release.
+ARG GH_SHA256=3b8ac6b30336802fc1a858d7c084e11cdf24ac1a761ca90b68022d7d729208de
+# Both match `.claude/scripts/install-agent-browser.sh`.
+ARG AGENT_BROWSER_VERSION=0.34.0
+ARG AGENT_BROWSER_SHA256=69eadf5d8d6003a06a5cd2f914ebb261c7754fe1335a9190122c334e91909789
+
+# The uv `.github/actions/setup-python` pins.
+COPY --from=ghcr.io/astral-sh/uv:0.11.14 /uv /uvx /usr/local/bin/
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Ubuntu carries no fonts, so Chrome falls back to a face with no usable metrics
+# and screenshots come out with mangled spacing. Liberation supplies the
+# Arial/Helvetica/Times metrics; the emoji face avoids tofu boxes.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+       ca-certificates \
+       curl \
+       fontconfig \
+       fonts-dejavu-core \
+       fonts-liberation \
+       fonts-noto-color-emoji \
+       git \
+       jq \
+       sudo \
+  && rm -rf /var/lib/apt/lists/*
+
+# `.tar.gz` rather than `.tar.xz` to avoid pulling in xz-utils for one download.
+RUN curl -fsSL --retry 3 "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz" -o /tmp/node.tar.gz \
+  && echo "${NODE_SHA256}  /tmp/node.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/node.tar.gz -C /usr/local --strip-components=1 --no-same-owner \
+  && rm /tmp/node.tar.gz \
+  && npm install -g "npm@${NPM_VERSION}" "yarn@${YARN_VERSION}"
+
+RUN curl -fsSL --retry 3 "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz \
+  && echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/gh.tar.gz -C /usr/local --strip-components=1 --no-same-owner "gh_${GH_VERSION}_linux_amd64/bin/gh" \
+  && rm /tmp/gh.tar.gz
+
+# uid 1001 is `runner` on GitHub-hosted runners, so bind mounts stay writable
+# without a recursive chmod. sudo lets an agent install a package to reproduce a
+# report; root here is still only root inside the sandbox.
+RUN useradd --create-home --uid 1001 --shell /bin/bash agent \
+  && echo 'agent ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/agent \
+  && chmod 0440 /etc/sudoers.d/agent
+
+USER agent
+ENV HOME=/home/agent
+ENV PATH=/home/agent/.local/bin:$PATH
+
+# Mirrors `.github/actions/setup-python`.
+ENV UV_INDEX_STRATEGY=unsafe-first-match \
+    UV_NO_PROGRESS=1 \
+    UV_EXCLUDE_NEWER=P7D
+
+# Not npm: its allowScripts policy blocks the postinstall that puts the binary in
+# place. Unpinned, like `.claude/scripts/install-claude.sh`.
+RUN mkdir -p "$HOME/.local/bin" \
+  && CLAUDE_RELEASES=https://downloads.claude.ai/claude-code-releases \
+  && CLAUDE_VERSION="$(curl -fsSL --retry 3 "$CLAUDE_RELEASES/latest")" \
+  && CLAUDE_SHA256="$(curl -fsSL --retry 3 "$CLAUDE_RELEASES/$CLAUDE_VERSION/manifest.json" | jq -r '.platforms["linux-x64"].checksum')" \
+  && curl -fsSL --retry 3 "$CLAUDE_RELEASES/$CLAUDE_VERSION/linux-x64/claude" -o "$HOME/.local/bin/claude" \
+  && echo "$CLAUDE_SHA256  $HOME/.local/bin/claude" | sha256sum -c - \
+  && chmod +x "$HOME/.local/bin/claude"
+
+# Under the agent's home so `agent-browser install` can chmod its own binary.
+# `--with-deps` adds the shared libraries Chrome links against.
+RUN curl -fsSL --retry 3 "https://github.com/vercel-labs/agent-browser/releases/download/v${AGENT_BROWSER_VERSION}/agent-browser-linux-x64" -o "$HOME/.local/bin/agent-browser" \
+  && echo "${AGENT_BROWSER_SHA256}  $HOME/.local/bin/agent-browser" | sha256sum -c - \
+  && chmod +x "$HOME/.local/bin/agent-browser" \
+  && agent-browser install --with-deps

--- a/.claude/sandbox/Dockerfile.dockerignore
+++ b/.claude/sandbox/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+# Nothing is copied in; this keeps the repo out of the build context.
+*

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -1,0 +1,98 @@
+name: Sandbox Image
+
+# Publishing the toolchain here rather than installing it per run keeps agent
+# jobs' startup short, and builds it from a trusted ref.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .claude/sandbox/**
+      - .github/workflows/sandbox-image.yml
+  pull_request:
+    paths:
+      - .claude/sandbox/**
+      - .github/workflows/sandbox-image.yml
+  # Claude Code is unpinned, so a weekly rebuild keeps it current and picks up
+  # base image security updates.
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  IMAGE: ghcr.io/mlflow/sandbox
+
+jobs:
+  build:
+    if: github.repository == 'mlflow/mlflow'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The dockerignore empties the build context, so this is all that is read.
+          sparse-checkout: .claude/sandbox
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # Loaded, not pushed, so nothing is published until it verifies below.
+      # amd64 only: Chrome's dependencies do not cross-build under QEMU.
+      - name: Build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: .claude/sandbox/Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: ${{ env.IMAGE }}:latest
+
+      - name: Verify the toolchain
+        run: |
+          docker run --rm "$IMAGE:latest" bash -lc '
+            set -euo pipefail
+            uv --version
+            node --version
+            npm --version
+            yarn --version
+            gh --version | head -1
+            git --version
+            jq --version
+            claude --version
+            agent-browser --version
+          '
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # `latest` is what callers pull; the commit tag ties a past run to its image.
+      # `workflow_dispatch` accepts any ref, so a manual run off master builds and
+      # verifies but does not publish.
+      - name: Push
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          docker tag "$IMAGE:latest" "$IMAGE:$COMMIT_SHA"
+          docker push "$IMAGE:latest"
+          docker push "$IMAGE:$COMMIT_SHA"

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ CLAUDE.local.md
 !.claude/hooks/
 !.claude/rules/
 !.claude/scripts/
+!.claude/sandbox/
 !.claude/settings.json
 !.claude/statusline.sh
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25457

### What changes are proposed in this pull request?

First of a stack that moves the `/review` agent into a gVisor sandbox. Today `claude` runs directly on the runner, so anything a poisoned diff talks it into runs beside every secret the job holds. Nothing consumes this image yet, and it is kept general rather than review-specific so other workflows can run agents in it too.

- `.claude/Dockerfile` carries what a review actually uses: uv, Node/npm/yarn, `gh` (the `pr-review` skill reads the PR through `gh pr view` and `gh api graphql`), Chrome via `agent-browser`, and the fonts Chrome needs to render legible screenshots.
- `.github/workflows/sandbox-image.yml` builds it, runs a toolchain smoke test, and only then pushes to `ghcr.io/mlflow/sandbox`, so a broken image is never published. The weekly rebuild keeps Claude Code current, matching the install-per-run behaviour `review.yml` has today.
- The image runs as uid 1001 to match `runner`, so the bind mounts a later PR in the stack adds stay writable without a recursive `chmod`.

### How is this PR tested?

- [x] Manual tests

This PR's own run of `sandbox-image.yml` builds the image and verifies the toolchain. The image was also exercised end to end during prototyping: Claude booted the MLflow server and UI inside it under gVisor and produced a correct screenshot.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
