### PR TITLE
Cap `litellm` below 1.98.0

### DIFF
--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -61,7 +61,10 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          uv pip install --system pytest pytest-asyncio pytest-timeout litellm
+          # litellm pinned as in `requirements/test-requirements.txt`, which
+          # this install path does not read.
+          # https://github.com/BerriAI/litellm/issues/38892
+          uv pip install --system pytest pytest-asyncio pytest-timeout 'litellm!=1.97.0,<1.98.0'
 
       - name: Run core tracing tests
         # NB: OTLP exporter includes large dependencies, so we want to test it in a separate job

--- a/requirements/extra-ml-requirements.txt
+++ b/requirements/extra-ml-requirements.txt
@@ -80,8 +80,10 @@ ag2<1
 dspy!=2.6.9
 # Required by mlflow.litellm
 # 1.97.0 ships a broken `Message` pydantic model (unresolved forward ref
-# `ChatCompletionReasoningSummaryTextBlock`), see BerriAI/litellm#36384
-litellm!=1.97.0
+# `ChatCompletionReasoningSummaryTextBlock`), see BerriAI/litellm#36384.
+# 1.98.0 onward does not import on the Python 3.10 we still support:
+# https://github.com/BerriAI/litellm/issues/38892
+litellm!=1.97.0,<1.98.0
 # Required by mlflow.gemini
 google-genai
 # Required by mlflow.groq

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -52,8 +52,10 @@ optuna
 testcontainers
 # required for testing cost tracking
 # 1.97.0 ships a broken `Message` pydantic model (unresolved forward ref
-# `ChatCompletionReasoningSummaryTextBlock`), see BerriAI/litellm#36384
-litellm!=1.97.0
+# `ChatCompletionReasoningSummaryTextBlock`), see BerriAI/litellm#36384.
+# 1.98.0 onward does not import on the Python 3.10 we still support:
+# https://github.com/BerriAI/litellm/issues/38892
+litellm!=1.97.0,<1.98.0
 # required for testing Redis budget tracker
 fakeredis[lua]
 # required for testing claude_code tracing


### PR DESCRIPTION
### Related Issues/PRs

https://github.com/BerriAI/litellm/issues/38892

### What changes are proposed in this pull request?

`core` and `genai` are failing on master. litellm 1.98.0 cleared the 7-day cooldown and no longer imports on the Python 3.10 we support.

A `!=1.98.0` would not hold, since the 1.99 release candidates are affected too, so this caps instead, to be lifted once upstream fixes it. 1.96.2 is the resulting resolution, since `!=1.97.0` is already excluded for an unrelated reason.

`core` installs litellm directly (`uv pip install --system pytest pytest-asyncio pytest-timeout litellm`) rather than from the requirements file, so it needs the same pin inline. `requirements/constraints.txt` cannot carry it: uv ignores `PIP_CONSTRAINT`, which is the only place that file is wired up.

### How is this PR tested?

- [x] Existing unit/integration tests

`core` and `genai` collect again.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
