### PR TITLE
Pin the review's `skills` calls to the tooling checkout

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -2,8 +2,8 @@
 name: pr-review
 description: Review a pull request and emit a validated review payload.
 disable-model-invocation: true
-argument-hint: "<pr_url> <pr_checkout> <payload_path> <media_dir>"
-arguments: [pr_url, pr_checkout, payload_path, media_dir]
+argument-hint: "<pr_url> <pr_checkout> <payload_path> <media_dir> <base_dir>"
+arguments: [pr_url, pr_checkout, payload_path, media_dir, base_dir]
 ---
 
 # Review Pull Request
@@ -16,8 +16,8 @@ that payload is the whole job.
 The PR is checked out at `$pr_checkout`, not in the working directory:
 
 ```text
-<working directory>   # this skill and the `skills` CLI come from here, and
-                      # nothing you review does
+$base_dir             # the working directory: this skill and the `skills`
+                      # CLI come from here, and nothing you review does
 $pr_checkout          # the reviewed tree: the PR merged into its base
 ```
 
@@ -25,7 +25,11 @@ The working directory holds a checkout of the same repository, so it looks like 
 review and is not guaranteed to match it. Everything aimed at the PR needs the prefix:
 `git -C $pr_checkout ...`, `$pr_checkout/<path>` to open or grep a file, and
 `cd $pr_checkout && ...` for anything that builds or runs repository code. The
-`uv run --package skills` commands below are the exception, and run unprefixed.
+`uv run` commands below are the exception: `--directory $base_dir` pins each one to
+this checkout, so it keeps using this tree's `skills` package and rules even when the
+working directory has moved into `$pr_checkout`. uv resolves its workspace from the
+working directory, and so does the rule loader, so dropping the flag silently hands
+both to the code under review.
 
 ## Instructions
 
@@ -46,7 +50,7 @@ gh pr view <pr_url> --json title,body
 the PR diff:
 
 ```bash
-git -C $pr_checkout diff HEAD^1 HEAD | uv run --package skills skills annotate-diff
+git -C $pr_checkout diff HEAD^1 HEAD | uv run --directory $base_dir --package skills skills annotate-diff
 ```
 
 Each line comes back as `old_line new_line | <marker> content`, which gives you the `line` and
@@ -84,7 +88,7 @@ gh api graphql -F owner=<owner> -F repo=<repo> -F pr=<pr_number> \
 Load the repository style rules applicable to the changed files:
 
 ```bash
-git -C $pr_checkout diff --name-only HEAD^1 | uv run --package skills skills load-rules
+git -C $pr_checkout diff --name-only HEAD^1 | uv run --directory $base_dir --package skills skills load-rules
 ```
 
 ### 3. Analyze the change
@@ -173,9 +177,9 @@ Authoring rules not captured by the schema:
 Validate before finishing, then fix any errors and re-emit until both of these pass:
 
 ```bash
-uv run --package skills skills validate-review $payload_path
+uv run --directory $base_dir --package skills skills validate-review $payload_path
 # only when you wrote a file into $media_dir
-uv run --package skills skills embed-media --check --dir $media_dir --target $payload_path
+uv run --directory $base_dir --package skills skills embed-media --check --dir $media_dir --target $payload_path
 ```
 
 Do not post the review: no `gh pr review`, no review/comment APIs, no other skills. Stop

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -414,12 +414,12 @@ jobs:
               --max-budget-usd 8 \
               --permission-mode auto \
               --add-dir "$PR_CHECKOUT" \
-              --allowed-tools "Bash(uv run --package skills skills:*)" \
+              --allowed-tools "Bash(uv run --directory $SANDBOX_BASE --package skills skills:*)" \
               --disallowed-tools WebSearch \
               --print \
               --verbose \
               --output-format stream-json \
-              "/pr-review $PR_URL $PR_CHECKOUT $REVIEW_PAYLOAD $REVIEW_MEDIA" \
+              "/pr-review $PR_URL $PR_CHECKOUT $REVIEW_PAYLOAD $REVIEW_MEDIA $SANDBOX_BASE" \
             | base/.claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 45 minutes"


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #25462. Bottom of stack #25469.

### What changes are proposed in this pull request?

uv resolves its workspace from the working directory, and `skills`' rule loader resolves the repository root the same way (`git rev-parse --show-toplevel`). So a review that runs the CLI from `$pr_checkout` gets the reviewed tree's copy of both.

The last sandboxed run did exactly that. The agent used `cd $pr_checkout && ... | uv run --package skills ...` rather than the `git -C` form the skill specifies, and the transcript shows the consequence:

```
Creating virtual environment at: .venv
   Building skills @ file:///home/runner/work/mlflow/mlflow/pr/.claude/skills
```

Two effects. The review's own diff-annotation tool is built from the code under review, and `load-rules` reads `.claude/rules/*` out of the PR, so a PR can add a rules file and have its text pulled in as review guidance.

The fix passes the tooling checkout to the skill as `$base_dir` and pins each call with `--directory`, which sets the working directory for that invocation only. Both resolutions land in the tooling tree regardless of where the review has navigated, and `cd $pr_checkout && uv run ...` for reproducing a report is unaffected.

Predates the sandbox: before #25462 this ran PR-authored build hooks directly on the runner, next to the job's credentials.

### How is this PR tested?

- [x] Manual tests

The `pull_request` smoke run exercises `/pr-review` end to end, including all four pinned `skills` calls.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
