### PR TITLE
Give the sandbox its own copy of the reviewed tree

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -175,9 +175,12 @@ jobs:
       RESULT_BODY: /tmp/updated-comment.md
       PR_CHECKOUT: ${{ github.workspace }}/pr
       SANDBOX_IMAGE: ghcr.io/mlflow/sandbox:latest
-      # A copy, so a sandbox write cannot reach the `base` the runner later
-      # runs `skills` from with `UPLOAD_MEDIA_TOKEN` in scope.
+      # Copies, so nothing the sandbox writes reaches a tree the runner still
+      # uses. `base` needs it: the runner runs `skills` from there afterwards
+      # with `UPLOAD_MEDIA_TOKEN` in scope. Nothing reads `pr` after the
+      # container exits; copying keeps it that way by construction.
       SANDBOX_BASE: /tmp/base-sandbox
+      SANDBOX_PR: /tmp/pr-sandbox
     steps:
       - name: Resolve job URL
         env:
@@ -257,6 +260,7 @@ jobs:
           sudo systemctl restart docker
           docker run --rm --runtime=runsc "$SANDBOX_IMAGE" true
           cp -a base "$SANDBOX_BASE"
+          cp -a pr "$SANDBOX_PR"
           mkdir -p "$REVIEW_MEDIA"
 
       - name: Parse review arguments
@@ -396,7 +400,7 @@ jobs:
           timeout 45m docker run --rm --runtime=runsc \
             --add-host gw-proxy:host-gateway \
             --volume "$SANDBOX_BASE:$SANDBOX_BASE" \
-            --volume "$PR_CHECKOUT:$PR_CHECKOUT" \
+            --volume "$SANDBOX_PR:$SANDBOX_PR" \
             --volume "$REVIEW_OUT:$REVIEW_OUT" \
             --workdir "$SANDBOX_BASE" \
             --env GH_TOKEN \
@@ -413,13 +417,13 @@ jobs:
               --effort "$EFFORT" \
               --max-budget-usd 8 \
               --permission-mode auto \
-              --add-dir "$PR_CHECKOUT" \
+              --add-dir "$SANDBOX_PR" \
               --allowed-tools "Bash(uv run --directory $SANDBOX_BASE --package skills skills:*)" \
               --disallowed-tools WebSearch \
               --print \
               --verbose \
               --output-format stream-json \
-              "/pr-review $PR_URL $PR_CHECKOUT $REVIEW_PAYLOAD $REVIEW_MEDIA $SANDBOX_BASE" \
+              "/pr-review $PR_URL $SANDBOX_PR $REVIEW_PAYLOAD $REVIEW_MEDIA $SANDBOX_BASE" \
             | base/.claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 45 minutes"


### PR DESCRIPTION
### Related Issues/PRs

Stacked on #25467. Part of stack #25469.

### What changes are proposed in this pull request?

`base` is copied to `/tmp/base-sandbox` so a sandbox write cannot reach the tree the runner later runs `skills` from with `UPLOAD_MEDIA_TOKEN` in scope. `pr` was mounted directly, which is safe only because nothing on the runner reads it after the container exits.

That is true today — `$PR_CHECKOUT`'s last use is the head check before the review — but it holds by inspection, not by construction. A step added after `Review` that read the PR tree would silently be reading whatever the review left behind, with nothing to flag it. Copying makes the property structural, and brings `pr` to parity with `base`.

Mounting read-only is not the cheaper alternative here: `SKILL.md` expects a review to be able to build and run the code under review.

Costs a second `cp -a` and the disk for another copy of the tree.

### How is this PR tested?

- [x] Manual tests

The `pull_request` smoke run exercises `/pr-review` end to end against the copied tree.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
