### PR TITLE
fix: Handle numpy string types in type checking (closes #5474)

### DIFF
--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -19,12 +19,13 @@ def strip_suffix(original: str, suffix: str) -> str:
 
 
 def is_string_type(item: Any) -> bool:
-    return isinstance(item, str)
+    # numpy.str_ is a subclass of str, but bytes is not; include bytes for safety.
+    return isinstance(item, (str, bytes))
 
 
 def generate_feature_name_if_not_string(s: Any) -> str:
-    if isinstance(s, str):
-        return s
+    if isinstance(s, (str, bytes)):
+        return str(s)
 
     return f"feature_{s}"
 


### PR DESCRIPTION
## What
When deploying models to SageMaker, MLflow's string type checking failed for certain string representations (e.g., numpy.str_ or bytes) leading to a ModelError during prediction. The `is_string_type()` and `generate_feature_name_if_not_string()` functions only checked for `str`, missing `bytes` and potentially other string-like types.

## Fix
Updated `is_string_type()` to also accept `bytes` (and numpy.str_ is already a subclass of str). In `generate_feature_name_if_not_string()`, we now convert bytes to str before using, ensuring consistent feature names. This improves robustness of signature validation and feature naming.

Closes #5474