### PR TITLE
fix: prevent duplicate table creation when upgrading from 3.7.0 (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -86,7 +86,14 @@ def _is_empty_database(engine):
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
     InitialBase.metadata.create_all(engine)
-    _upgrade_db(engine)
+    # After creating all tables, stamp the latest revision to mark the schema as current.
+    # Do not run migrations because they would attempt to create the tables again.
+    config = _get_alembic_config(engine.url)
+    script = ScriptDirectory.from_config(config)
+    head = script.get_current_head()
+    with engine.begin() as connection:
+        context = MigrationContext.configure(connection)
+        context.stamp(script, head)
 
 
 def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
@@ -104,6 +111,21 @@ def _safe_initialize_tables(engine: sqlalchemy.engine.Engine) -> None:
     with ExclusiveFileLock(f"{tempfile.gettempdir()}/db_init_lock-{url_hash}"):
         if not _all_tables_exist(engine):
             _initialize_tables(engine)
+        else:
+            # If all tables exist but Alembic revision is not recorded (e.g., from a failed upgrade),
+            # stamp the latest revision to prevent future migration attempts.
+            try:
+                with engine.connect() as connection:
+                    context = MigrationContext.configure(connection)
+                    if context.get_current_revision() is None:
+                        config = _get_alembic_config(engine.url)
+                        script = ScriptDirectory.from_config(config)
+                        head = script.get_current_head()
+                        with engine.begin() as connection:
+                            context = MigrationContext.configure(connection)
+                            context.stamp(script, head)
+            except Exception:
+                _logger.warning("Failed to stamp Alembic revision; will retry during upgrade.", exc_info=True)
 
 
 def _get_latest_schema_revision():


### PR DESCRIPTION
## What

When running `mlflow db upgrade` after updating from 3.7.0 to 3.8.x, the command fails with a `Table 'secrets' already exists` error. This happens because the `_initialize_tables` function creates all tables using `InitialBase.metadata.create_all` and then always calls `_upgrade_db`, which runs Alembic migrations that include creating the same tables (like `secrets`) again. For an existing database, this causes a duplicate table creation error.

The previous logic checked if the database was empty before initializing, but a failed upgrade or partial migration can leave tables present, causing `_is_empty_database` to return False and leading the upgrade path to run migrations that attempt to recreate existing tables.

## Fix

- Modify `_initialize_tables` to stamp the Alembic revision to the latest head after creating tables, instead of running migrations that would duplicate the table creation.
- In `_safe_initialize_tables`, after confirming all tables exist, stamp the latest Alembic revision if no revision is recorded (e.g., after a failed upgrade).
- This ensures that `mlflow db upgrade` on an existing database either finds the schema is current or stamps the correct revision without re-running table-creation migrations.

Closes #19943