### PR TITLE
Fix environment variable expansion in `docker/README.md`

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -112,7 +112,7 @@ volumes:
 
 Common environment variables for configuring MLflow:
 
-- `MLFLOW_BACKEND_STORE_URI` - Backend store URI (database connection string)
+- `MLFLOW_BACKEND_STORE_URI` - Backend store URI (database connection string). The `mlflow server` command reads this variable automatically, so `--backend-store-uri` is not required when it is set.
 - `MLFLOW_DEFAULT_ARTIFACT_ROOT` - Default location for storing artifacts
 - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` - AWS credentials for S3
 - `AZURE_STORAGE_CONNECTION_STRING` - Azure storage connection string

--- a/docker/README.md
+++ b/docker/README.md
@@ -43,7 +43,7 @@ Access the MLflow UI at http://localhost:5000
 docker run -p 5000:5000 \
   -e MLFLOW_BACKEND_STORE_URI=mysql+pymysql://user:password@mysql-host:3306/mlflow \
   mlflow:latest-full \
-  mlflow server --backend-store-uri $MLFLOW_BACKEND_STORE_URI --host 0.0.0.0
+  mlflow server --host 0.0.0.0
 ```
 
 ### With PostgreSQL Backend
@@ -52,7 +52,7 @@ docker run -p 5000:5000 \
 docker run -p 5000:5000 \
   -e MLFLOW_BACKEND_STORE_URI=postgresql://user:password@postgres-host:5432/mlflow \
   mlflow:latest-full \
-  mlflow server --backend-store-uri $MLFLOW_BACKEND_STORE_URI --host 0.0.0.0
+  mlflow server --host 0.0.0.0
 ```
 
 ### With S3 Artifact Storage
@@ -102,7 +102,7 @@ services:
       - "5000:5000"
     environment:
       MLFLOW_BACKEND_STORE_URI: mysql+pymysql://mlflow:mlflow@mysql:3306/mlflow
-    command: mlflow server --backend-store-uri $MLFLOW_BACKEND_STORE_URI --host 0.0.0.0
+    command: mlflow server --host 0.0.0.0
 
 volumes:
   mysql-data:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The Docker README passes `MLFLOW_BACKEND_STORE_URI` into the container, but the MySQL, PostgreSQL, and Docker Compose examples also reference `$MLFLOW_BACKEND_STORE_URI` in the command. The direct `docker run` command is expanded by the host shell, while Docker executes the resulting command arguments without a shell inside the container. Docker Compose also interpolates variables before the container starts, so the container environment is not used for this expansion. When `MLFLOW_BACKEND_STORE_URI` is unset in the host environment, the command becomes `mlflow server --backend-store-uri --host 0.0.0.0`; Click consumes `--host` as the value of `--backend-store-uri` and then fails with `Got unexpected extra argument (0.0.0.0)`. Removing the redundant option lets MLflow read `MLFLOW_BACKEND_STORE_URI` from the container environment directly.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

- Reproduced the host-shell argument expansion with an unset `MLFLOW_BACKEND_STORE_URI` and verified the corrected command arguments.
- Confirmed all affected README examples no longer use the host-expanded variable.
- Ran `npx --yes prettier@2.7.1 --check docker/README.md`.
- Ran `git diff --check`.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. The Docker README examples now correctly use the container's `MLFLOW_BACKEND_STORE_URI` environment variable.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow Model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM integrations
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing MLflow feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
