### PR TITLE
Read team review membership from the stats issue

### DIFF
--- a/.github/workflows/team-review.js
+++ b/.github/workflows/team-review.js
@@ -1,35 +1,25 @@
 const STATS_ISSUE_NUMBER = 19428;
-const MEMBERS = [
-  "B-Step62",
-  "harupy",
-  "kriscon-db",
-  "aaronteo-db",
-  "joshuawong-db",
-  "tanghaoji",
-  "mprahl",
-  "HumairAK",
-];
 const REVIEWER_BALANCE_RULES = [{ reviewers: ["mprahl", "HumairAK"], maxSelected: 1 }];
 
 async function loadStats(github, owner, repo) {
-  try {
-    const issue = await github.rest.issues.get({
-      owner,
-      repo,
-      issue_number: STATS_ISSUE_NUMBER,
-    });
-    const match = issue.data.body.match(/```json\n([\s\S]*?)\n```/);
-    if (match) {
-      return JSON.parse(match[1]);
-    }
-  } catch (err) {
-    console.warn(`Warning: Failed to load stats from issue: ${err.message}`);
+  const issue = await github.rest.issues.get({
+    owner,
+    repo,
+    issue_number: STATS_ISSUE_NUMBER,
+  });
+  const match = issue.data.body.match(/```json\n([\s\S]*?)\n```/);
+  if (!match) {
+    throw new Error(
+      `No JSON block found in https://github.com/${owner}/${repo}/issues/${STATS_ISSUE_NUMBER}`
+    );
   }
-  return { reviewCounts: {} };
+  return JSON.parse(match[1]);
 }
 
 async function saveStats(github, owner, repo, stats) {
-  const body = `This issue tracks reviewer assignment counts for fair distribution.
+  const body = `This issue is the source of truth for team review membership. Add or remove a
+reviewer by editing the JSON block below. Add new reviewers at roughly the current highest count,
+since the lowest counts are assigned first.
 
 \`\`\`json
 ${JSON.stringify(stats, null, 2)}
@@ -167,12 +157,10 @@ module.exports = async ({ github, context }) => {
   const approved = reviews.data.filter((r) => r.state === "APPROVED").map((r) => r.user.login);
   const requested = context.payload.pull_request.requested_reviewers.map((r) => r.login);
 
-  const eligibleReviewers = MEMBERS.filter(
+  const stats = await loadStats(github, owner, repo);
+  const eligibleReviewers = Object.keys(stats.reviewCounts || {}).filter(
     (m) => !approved.includes(m) && !requested.includes(m) && m !== author && m !== copilotInitiator
   );
-
-  // Load stats, select reviewers, and update stats
-  const stats = await loadStats(github, owner, repo);
   const selectedReviewers = selectReviewers(eligibleReviewers, stats);
 
   if (selectedReviewers.length > 0) {

--- a/.github/workflows/team-review.js
+++ b/.github/workflows/team-review.js
@@ -27,6 +27,19 @@ async function loadStats(github, owner, repo) {
   if (Object.keys(reviewCounts).length === 0) {
     throw new Error(`\`reviewCounts\` is empty in ${issueUrl}, so the roster has no members`);
   }
+
+  // A rule naming someone off the roster is inert rather than broken, so warn instead of throwing.
+  const staleRuleReviewers = [
+    ...new Set(
+      REVIEWER_BALANCE_RULES.flatMap((rule) => rule.reviewers.filter((r) => !(r in reviewCounts)))
+    ),
+  ];
+  if (staleRuleReviewers.length > 0) {
+    console.warn(
+      `Warning: REVIEWER_BALANCE_RULES names ${staleRuleReviewers.join(", ")}, ` +
+        `absent from ${issueUrl}. Affected rules have no effect.`
+    );
+  }
   return stats;
 }
 

--- a/.github/workflows/team-review.js
+++ b/.github/workflows/team-review.js
@@ -2,6 +2,7 @@ const STATS_ISSUE_NUMBER = 19428;
 const REVIEWER_BALANCE_RULES = [{ reviewers: ["mprahl", "HumairAK"], maxSelected: 1 }];
 
 async function loadStats(github, owner, repo) {
+  const issueUrl = `https://github.com/${owner}/${repo}/issues/${STATS_ISSUE_NUMBER}`;
   const issue = await github.rest.issues.get({
     owner,
     repo,
@@ -9,11 +10,24 @@ async function loadStats(github, owner, repo) {
   });
   const match = issue.data.body.match(/```json\n([\s\S]*?)\n```/);
   if (!match) {
-    throw new Error(
-      `No JSON block found in https://github.com/${owner}/${repo}/issues/${STATS_ISSUE_NUMBER}`
-    );
+    throw new Error(`No JSON block found in ${issueUrl}`);
   }
-  return JSON.parse(match[1]);
+
+  let stats;
+  try {
+    stats = JSON.parse(match[1]);
+  } catch (err) {
+    throw new Error(`Malformed JSON block in ${issueUrl}: ${err.message}`);
+  }
+
+  const { reviewCounts } = stats;
+  if (typeof reviewCounts !== "object" || reviewCounts === null || Array.isArray(reviewCounts)) {
+    throw new Error(`\`reviewCounts\` is missing or not an object in ${issueUrl}`);
+  }
+  if (Object.keys(reviewCounts).length === 0) {
+    throw new Error(`\`reviewCounts\` is empty in ${issueUrl}, so the roster has no members`);
+  }
+  return stats;
 }
 
 async function saveStats(github, owner, repo, stats) {
@@ -158,7 +172,7 @@ module.exports = async ({ github, context }) => {
   const requested = context.payload.pull_request.requested_reviewers.map((r) => r.login);
 
   const stats = await loadStats(github, owner, repo);
-  const eligibleReviewers = Object.keys(stats.reviewCounts || {}).filter(
+  const eligibleReviewers = Object.keys(stats.reviewCounts).filter(
     (m) => !approved.includes(m) && !requested.includes(m) && m !== author && m !== copilotInitiator
   );
   const selectedReviewers = selectReviewers(eligibleReviewers, stats);


### PR DESCRIPTION
### Related Issues/PRs

Relates to #19428

### What changes are proposed in this pull request?

The roster lived in two places: the hardcoded `MEMBERS` array and the keys of the stats issue's JSON block (#19428). Membership now comes from the issue alone, so adding or removing a reviewer is an issue edit rather than a PR.

`loadStats` no longer falls back to empty counts, and now validates the JSON block. That fallback was harmless when it only meant "treat everyone as unassigned", but with the issue as the roster an unreadable or misconfigured issue would silently assign nobody.

### How is this PR tested?

- [x] Manual tests

`team-review.yml` is `pull_request_target`, so it always runs master's copy of the script and this PR's version cannot execute until merge. Verified instead by driving the module against a stubbed `github` client: only reviewers present in the issue are selected, the saved body round-trips, and every bad-input path throws with the issue URL (no JSON block, malformed JSON, and a `reviewCounts` that is missing, null, an array, or empty), and over 700 runs with equal counts selection stays spread with the `mprahl`/`HumairAK` balance rule never violated.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
