### PR TITLE
Fix TLS URLs in `charts/templates/NOTES.txt`

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -122,6 +122,12 @@ jobs:
           kubectl port-forward svc/mlflow 5000:5000 &
           curl --retry 10 --retry-connrefused --retry-delay 3 --fail $CURL_FLAGS ${SCHEME}://localhost:5000/health
 
+      - name: Verify installation notes
+        env:
+          SCHEME: ${{ matrix.tls == true && 'https' || 'http' }}
+        run: |
+          helm get notes mlflow | grep -F "Then open: ${SCHEME}://127.0.0.1:5000"
+
       - name: Print container logs
         if: always()
         run: kubectl logs -l app.kubernetes.io/name=mlflow --tail=-1

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mlflow
 description: A production-ready Helm chart for deploying MLflow on Kubernetes
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "3.15.2"
 annotations:
   org.opencontainers.image.source: https://github.com/mlflow/mlflow

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- $scheme := ternary "https" "http" .Values.tls.enabled }}
 MLflow has been deployed successfully.
 
 Access the UI:
@@ -8,10 +9,10 @@ Access the UI:
 {{- else if eq .Values.service.type "NodePort" }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mlflow.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  http://$NODE_IP:$NODE_PORT
+  {{ $scheme }}://$NODE_IP:$NODE_PORT
 {{- else if eq .Values.service.type "LoadBalancer" }}
-  http://<EXTERNAL-IP>:{{ .Values.server.value_options.port }}
+  {{ $scheme }}://<EXTERNAL-IP>:{{ .Values.server.value_options.port }}
 {{- else }}
   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "mlflow.fullname" . }} {{ .Values.server.value_options.port }}:{{ .Values.server.value_options.port }}
-  # Then open: http://127.0.0.1:{{ .Values.server.value_options.port }}
+  # Then open: {{ $scheme }}://127.0.0.1:{{ .Values.server.value_options.port }}
 {{- end }}


### PR DESCRIPTION
### Related Issues/PRs

None

### What changes are proposed in this pull request?

When `tls.enabled=true`, the Helm chart configures the MLflow Service and container to use HTTPS. However, the non-Ingress branches in `charts/templates/NOTES.txt` always printed `http://` URLs for NodePort, LoadBalancer, and port-forward access. Following those installation instructions could therefore send users to the wrong protocol.

This change derives the scheme from `tls.enabled` for those three branches while preserving the existing Ingress behavior, which derives its public scheme from `ingress.tls`. The chart patch version is bumped from `0.1.1` to `0.1.2` so the corrected notes can be published.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added a Helm e2e assertion that checks the port-forward installation note against the TLS matrix. Locally verified the rendered notes for NodePort, LoadBalancer, and ClusterIP with TLS enabled and disabled, and verified that the Ingress branch remains HTTPS when `ingress.tls` is configured.

Also ran:

- `helm lint charts --set mlflow.backendStoreUri=sqlite:////tmp/mlflow.db`
- `helm template mlflow charts --set mlflow.backendStoreUri=sqlite:////tmp/mlflow.db`
- `helm package charts`
- `uv run --only-group lint pre-commit run --files .github/workflows/helm.yml charts/Chart.yaml charts/templates/NOTES.txt`

The full Kind-based e2e job was not run locally because a Docker daemon is unavailable.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Helm installation notes now print HTTPS URLs for NodePort, LoadBalancer, and port-forward access when `tls.enabled` is enabled.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, MLflow deployments, and model serving
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
