### PR TITLE
Test the checked-out commit in `build-wheel.yml`

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -150,9 +150,10 @@ jobs:
       - name: Test installation from GitHub
         env:
           REPO: ${{ github.repository }}
-          REF: ${{ github.ref }}
           MATRIX_TYPE: ${{ matrix.type }}
         run: |
+          # Test the exact commit that was checked out and used to build the wheel.
+          REF=$(git rev-parse HEAD)
           if [ "$MATRIX_TYPE" == "skinny" ]; then
             URL="git+https://github.com/${REPO}.git@${REF}#subdirectory=libs/skinny"
           elif [ "$MATRIX_TYPE" == "tracing" ]; then


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The `build-wheel` workflow checks out the ref selected by the `workflow_dispatch` input, but the `Test installation from GitHub` step uses `${{ github.ref }}`. For a manual run started from `master` with a different ref selected, the wheel is built from the selected ref while the installation check fetches `master`, so the check does not validate the source revision used to build the wheel.

Derive `REF` from `git rev-parse HEAD` in the installation step so it always tests the exact commit checked out for the job. This also keeps push and pull-request triggers correct without relying on a dispatch-only input.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

- Ran a regression check that fails against the original workflow because the installation step uses `github.ref` instead of the checked-out commit.
- Verified the corrected step uses the checkout SHA for the dev, skinny, and tracing URL forms.
- Ran `uv run --only-group lint pre-commit run --files .github/workflows/build-wheel.yml`.
- Ran `git diff --check`.
- Verified the checked-out commit is available from GitHub.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
