### PR TITLE
Copy the review sandbox trees in instead of bind-mounting them

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -168,8 +168,9 @@ jobs:
     # headroom than the unsandboxed job needed.
     timeout-minutes: 60
     env:
-      # Written in the sandbox, copied back here when it exits, so one
-      # `docker cp` retrieves both.
+      # Written in the sandbox, read back here, so both sit under one bind
+      # mount. gVisor overlays the container's root filesystem, so a write
+      # anywhere else would never reach the runner.
       REVIEW_OUT: /tmp/review-out
       REVIEW_PAYLOAD: /tmp/review-out/review-payload.json
       REVIEW_MEDIA: /tmp/review-out/media
@@ -349,8 +350,9 @@ jobs:
           }
           CONF
           # The sandbox runs as uid 1001, the runner's own uid, which is what
-          # makes the trees copied into it writable. Mode alone would therefore
-          # not keep the bearer from it if this file were ever copied in.
+          # makes the trees copied into it and the output mount writable. Mode
+          # alone would therefore not keep the bearer from it if this file were
+          # ever copied or mounted in.
           sudo chown root:root /tmp/nginx.conf
           docker run --detach --name gw-proxy --publish 8080:80 \
             --volume /tmp/nginx.conf:/etc/nginx/nginx.conf:ro \
@@ -359,9 +361,10 @@ jobs:
           # the whole `timeout` inside the first curl and never retry.
           timeout 60 bash -c 'until curl -sf -o /dev/null --max-time 5 http://127.0.0.1:8080/healthz; do sleep 1; done'
 
-      # The sandbox gets a read-only `GH_TOKEN` in its environment, plus the PR
-      # tree and the tooling copy, each at the path it has on the runner so a
-      # cited screenshot still resolves for `skills embed-media` afterwards.
+      # The sandbox gets a read-only `GH_TOKEN` in its environment, the PR tree
+      # and the tooling copy, and the output directory mounted at the path it
+      # has on the runner so a cited screenshot still resolves for
+      # `skills embed-media` afterwards.
       - name: Review
         id: review
         env:
@@ -392,15 +395,18 @@ jobs:
           # pull_request (smoke), the steps that mutate the PR are gated off so
           # no review is submitted.
           EXIT_CODE=0
-          # `--rm` is out: the output exists only in the container's layer until
-          # the collect step copies it back, so the container has to outlive the
-          # review process.
+          # The mount source has to exist first, or Docker creates it root-owned
+          # and the sandbox cannot write it.
+          mkdir -p "$REVIEW_MEDIA"
+          # `docker cp` needs a container to copy into, so the run is split and
+          # `--rm` gives way to the removal step below.
           #
           # The gateway does not serve Anthropic's server-side web_search tool.
           # Denying the bare name drops it from Claude's context instead of
           # leaving it to fail on use.
           docker create --name review-sandbox --runtime=runsc \
             --add-host gw-proxy:host-gateway \
+            --volume "$REVIEW_OUT:$REVIEW_OUT" \
             --workdir "$SANDBOX_BASE" \
             --env GH_TOKEN \
             --env ANTHROPIC_BASE_URL \
@@ -425,12 +431,13 @@ jobs:
               "/pr-review $PR_URL $SANDBOX_PR $REVIEW_PAYLOAD $REVIEW_MEDIA $SANDBOX_BASE" \
             > /dev/null
 
-          mkdir -p "$REVIEW_MEDIA"
-          # `-a` keeps the runner's uid on the copies, which is the uid the
-          # image runs as, so the sandbox can write what it was given.
-          docker cp -a base "review-sandbox:$SANDBOX_BASE"
+          # `docker create` pre-creates `--workdir`, so `$SANDBOX_BASE` already
+          # exists and takes the `SRC/.` form to land the tree there rather than
+          # nested under it; `$SANDBOX_PR` does not exist, so the plain form
+          # creates it. `-a` keeps the runner's uid, which the image runs as, so
+          # the sandbox can write what it was given.
+          docker cp -a base/. "review-sandbox:$SANDBOX_BASE"
           docker cp -a pr "review-sandbox:$SANDBOX_PR"
-          docker cp -a "$REVIEW_OUT" "review-sandbox:$REVIEW_OUT"
 
           timeout 45m docker start --attach review-sandbox \
             | base/.claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
@@ -442,19 +449,8 @@ jobs:
             exit $EXIT_CODE
           fi
 
-      # The container holds the only copy of what the review wrote, so this runs
-      # on every path and ahead of the removal below. `docker stop` first so a
-      # container the `timeout` detached from has finished writing.
-      - name: Collect the review output
-        if: always()
-        run: |
-          if ! docker inspect review-sandbox > /dev/null 2>&1; then
-            echo "No sandbox container was created; nothing to collect"
-            exit 0
-          fi
-          docker stop --time 30 review-sandbox > /dev/null
-          docker cp -a "review-sandbox:$REVIEW_OUT/." "$REVIEW_OUT"
-
+      # `--force` because a `timeout` only kills the client the container was
+      # attached to, leaving it running.
       - name: Remove the sandbox container
         if: always()
         run: |

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -367,7 +367,10 @@ jobs:
       # The sandbox gets a read-only `GH_TOKEN` in its environment, the PR tree
       # and the tooling copy, and the output directory mounted at the path it
       # has on the runner so a cited screenshot still resolves for
-      # `skills embed-media` afterwards.
+      # `skills embed-media` afterwards. The gateway does not serve Anthropic's
+      # server-side web_search tool, so `--disallowed-tools` denies the bare
+      # name: that drops it from Claude's context instead of leaving it to fail
+      # on use.
       - name: Review
         id: review
         env:
@@ -401,10 +404,6 @@ jobs:
           # `$REVIEW_OUT` is the mount source and has to exist first, or Docker
           # creates it root-owned and the sandbox cannot write it.
           mkdir -p "$REVIEW_MEDIA"
-          # The gateway does not serve Anthropic's server-side web_search tool.
-          # Denying the bare name drops it from Claude's context instead of
-          # leaving it to fail on use.
-
           # `docker cp` needs a container to copy into, so the run is split and
           # `--rm` gives way to the removal step below.
           docker create --name review-sandbox --runtime=runsc \
@@ -438,9 +437,10 @@ jobs:
           # carries the directory entry: `docker create` pre-creates `--workdir`
           # owned by root, and only extracting that entry resets it to the uid
           # the image runs as. `-a` carries the runner's uid, which is that uid.
-          # Each checkout directory name has to match its target's basename.
-          docker cp -a base "review-sandbox:${SANDBOX_BASE%/*}/"
-          docker cp -a pr "review-sandbox:${SANDBOX_PR%/*}/"
+          # Both halves come from the same variable, so retargeting one fails on
+          # a missing checkout rather than silently copying somewhere else.
+          docker cp -a "${SANDBOX_BASE##*/}" "review-sandbox:${SANDBOX_BASE%/*}/"
+          docker cp -a "${SANDBOX_PR##*/}" "review-sandbox:${SANDBOX_PR%/*}/"
 
           timeout 45m docker start --attach review-sandbox \
             | base/.claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -401,12 +401,12 @@ jobs:
           # `$REVIEW_OUT` is the mount source and has to exist first, or Docker
           # creates it root-owned and the sandbox cannot write it.
           mkdir -p "$REVIEW_MEDIA"
-          # `docker cp` needs a container to copy into, so the run is split and
-          # `--rm` gives way to the removal step below.
-
           # The gateway does not serve Anthropic's server-side web_search tool.
           # Denying the bare name drops it from Claude's context instead of
           # leaving it to fail on use.
+
+          # `docker cp` needs a container to copy into, so the run is split and
+          # `--rm` gives way to the removal step below.
           docker create --name review-sandbox --runtime=runsc \
             --add-host gw-proxy:host-gateway \
             --volume "$REVIEW_OUT:$REVIEW_OUT" \

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -168,17 +168,18 @@ jobs:
     # headroom than the unsandboxed job needed.
     timeout-minutes: 60
     env:
-      # Written in the sandbox, read back here, so both sit under one bind mount.
+      # Written in the sandbox, copied back here when it exits, so one
+      # `docker cp` retrieves both.
       REVIEW_OUT: /tmp/review-out
       REVIEW_PAYLOAD: /tmp/review-out/review-payload.json
       REVIEW_MEDIA: /tmp/review-out/media
       RESULT_BODY: /tmp/updated-comment.md
       PR_CHECKOUT: ${{ github.workspace }}/pr
       SANDBOX_IMAGE: ghcr.io/mlflow/sandbox:latest
-      # Copies, so nothing the sandbox writes reaches a tree the runner still
-      # uses. `base` needs it: the runner runs `skills` from there afterwards
-      # with `UPLOAD_MEDIA_TOKEN` in scope. Nothing reads `pr` after the
-      # container exits; copying keeps it that way by construction.
+      # Copied into the container rather than mounted, so nothing the sandbox
+      # writes reaches a tree the runner still uses. `base` needs that: the
+      # runner runs `skills` from its own copy afterwards with
+      # `UPLOAD_MEDIA_TOKEN` in scope.
       SANDBOX_BASE: /tmp/base-sandbox
       SANDBOX_PR: /tmp/pr-sandbox
     steps:
@@ -253,15 +254,12 @@ jobs:
             run: |
               docker pull "$SANDBOX_IMAGE"
 
-      - name: Stage the sandbox
+      - name: Enable the gVisor runtime
         run: |
           # Picks up the runtime `runsc install` registered. Restarting mid-pull
           # would have failed it, hence the split.
           sudo systemctl restart docker
           docker run --rm --runtime=runsc "$SANDBOX_IMAGE" true
-          cp -a base "$SANDBOX_BASE"
-          cp -a pr "$SANDBOX_PR"
-          mkdir -p "$REVIEW_MEDIA"
 
       - name: Parse review arguments
         id: prompt
@@ -350,9 +348,9 @@ jobs:
             }
           }
           CONF
-          # The sandbox runs as uid 1001 to keep its bind mounts writable, which
-          # is the runner's own uid, so mode alone would not keep the bearer from
-          # it if anything under /tmp were ever mounted in.
+          # The sandbox runs as uid 1001, the runner's own uid, which is what
+          # makes the trees copied into it writable. Mode alone would therefore
+          # not keep the bearer from it if this file were ever copied in.
           sudo chown root:root /tmp/nginx.conf
           docker run --detach --name gw-proxy --publish 8080:80 \
             --volume /tmp/nginx.conf:/etc/nginx/nginx.conf:ro \
@@ -362,7 +360,7 @@ jobs:
           timeout 60 bash -c 'until curl -sf -o /dev/null --max-time 5 http://127.0.0.1:8080/healthz; do sleep 1; done'
 
       # The sandbox gets the PR tree, the tooling copy and a read-only `GH_TOKEN`,
-      # each mounted at the path it has on the runner so a cited screenshot still
+      # each copied to the path it has on the runner so a cited screenshot still
       # resolves for `skills embed-media` afterwards.
       - name: Review
         id: review
@@ -394,14 +392,13 @@ jobs:
           # pull_request (smoke), the steps that mutate the PR are gated off so
           # no review is submitted.
           EXIT_CODE=0
+          # `--rm` is out: the output has to outlive the container that wrote it.
+          #
           # The gateway does not serve Anthropic's server-side web_search tool.
           # Denying the bare name drops it from Claude's context instead of
           # leaving it to fail on use.
-          timeout 45m docker run --rm --runtime=runsc \
+          docker create --name review-sandbox --runtime=runsc \
             --add-host gw-proxy:host-gateway \
-            --volume "$SANDBOX_BASE:$SANDBOX_BASE" \
-            --volume "$SANDBOX_PR:$SANDBOX_PR" \
-            --volume "$REVIEW_OUT:$REVIEW_OUT" \
             --workdir "$SANDBOX_BASE" \
             --env GH_TOKEN \
             --env ANTHROPIC_BASE_URL \
@@ -424,6 +421,16 @@ jobs:
               --verbose \
               --output-format stream-json \
               "/pr-review $PR_URL $SANDBOX_PR $REVIEW_PAYLOAD $REVIEW_MEDIA $SANDBOX_BASE" \
+            > /dev/null
+
+          mkdir -p "$REVIEW_MEDIA"
+          # `-a` keeps the runner's uid on the copies, which is the uid the
+          # image runs as, so the sandbox can write what it was given.
+          docker cp -a base "review-sandbox:$SANDBOX_BASE"
+          docker cp -a pr "review-sandbox:$SANDBOX_PR"
+          docker cp -a "$REVIEW_OUT" "review-sandbox:$REVIEW_OUT"
+
+          timeout 45m docker start --attach review-sandbox \
             | base/.claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 45 minutes"
@@ -432,6 +439,24 @@ jobs:
             cat "$OUTPUT_FILE"
             exit $EXIT_CODE
           fi
+
+      # The container holds the only copy of what the review wrote, so this runs
+      # on every path and ahead of the removal below. `docker stop` first so a
+      # container the `timeout` detached from has finished writing.
+      - name: Collect the review output
+        if: always()
+        run: |
+          if ! docker inspect review-sandbox > /dev/null 2>&1; then
+            echo "No sandbox container was created; nothing to collect"
+            exit 0
+          fi
+          docker stop --time 30 review-sandbox > /dev/null
+          docker cp -a "review-sandbox:$REVIEW_OUT/." "$REVIEW_OUT"
+
+      - name: Remove the sandbox container
+        if: always()
+        run: |
+          docker rm --force review-sandbox > /dev/null 2>&1 || true
 
       # A sandbox that cannot reach the proxy only reports a request timeout.
       - name: Gateway proxy log

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -359,9 +359,9 @@ jobs:
           # the whole `timeout` inside the first curl and never retry.
           timeout 60 bash -c 'until curl -sf -o /dev/null --max-time 5 http://127.0.0.1:8080/healthz; do sleep 1; done'
 
-      # The sandbox gets the PR tree, the tooling copy and a read-only `GH_TOKEN`,
-      # each copied to the path it has on the runner so a cited screenshot still
-      # resolves for `skills embed-media` afterwards.
+      # The sandbox gets a read-only `GH_TOKEN` in its environment, plus the PR
+      # tree and the tooling copy, each at the path it has on the runner so a
+      # cited screenshot still resolves for `skills embed-media` afterwards.
       - name: Review
         id: review
         env:
@@ -392,7 +392,9 @@ jobs:
           # pull_request (smoke), the steps that mutate the PR are gated off so
           # no review is submitted.
           EXIT_CODE=0
-          # `--rm` is out: the output has to outlive the container that wrote it.
+          # `--rm` is out: the output exists only in the container's layer until
+          # the collect step copies it back, so the container has to outlive the
+          # review process.
           #
           # The gateway does not serve Anthropic's server-side web_search tool.
           # Denying the bare name drops it from Claude's context instead of

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -398,8 +398,8 @@ jobs:
           # pull_request (smoke), the steps that mutate the PR are gated off so
           # no review is submitted.
           EXIT_CODE=0
-          # The mount source has to exist first, or Docker creates it root-owned
-          # and the sandbox cannot write it.
+          # `$REVIEW_OUT` is the mount source and has to exist first, or Docker
+          # creates it root-owned and the sandbox cannot write it.
           mkdir -p "$REVIEW_MEDIA"
           # `docker cp` needs a container to copy into, so the run is split and
           # `--rm` gives way to the removal step below.
@@ -438,8 +438,9 @@ jobs:
           # carries the directory entry: `docker create` pre-creates `--workdir`
           # owned by root, and only extracting that entry resets it to the uid
           # the image runs as. `-a` carries the runner's uid, which is that uid.
-          docker cp -a base "review-sandbox:/tmp/"
-          docker cp -a pr "review-sandbox:/tmp/"
+          # Each checkout directory name has to match its target's basename.
+          docker cp -a base "review-sandbox:${SANDBOX_BASE%/*}/"
+          docker cp -a pr "review-sandbox:${SANDBOX_PR%/*}/"
 
           timeout 45m docker start --attach review-sandbox \
             | base/.claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -181,8 +181,11 @@ jobs:
       # writes reaches a tree the runner still uses. `base` needs that: the
       # runner runs `skills` from its own copy afterwards with
       # `UPLOAD_MEDIA_TOKEN` in scope.
-      SANDBOX_BASE: /tmp/base-sandbox
-      SANDBOX_PR: /tmp/pr-sandbox
+      # Basenames match the checkout directories: the copy below sends each
+      # tree to `/tmp/`, so the directory entry in the archive is what names
+      # it and sets its ownership.
+      SANDBOX_BASE: /tmp/base
+      SANDBOX_PR: /tmp/pr
     steps:
       - name: Resolve job URL
         env:
@@ -431,13 +434,12 @@ jobs:
               "/pr-review $PR_URL $SANDBOX_PR $REVIEW_PAYLOAD $REVIEW_MEDIA $SANDBOX_BASE" \
             > /dev/null
 
-          # `docker create` pre-creates `--workdir`, so `$SANDBOX_BASE` already
-          # exists and takes the `SRC/.` form to land the tree there rather than
-          # nested under it; `$SANDBOX_PR` does not exist, so the plain form
-          # creates it. `-a` keeps the runner's uid, which the image runs as, so
-          # the sandbox can write what it was given.
-          docker cp -a base/. "review-sandbox:$SANDBOX_BASE"
-          docker cp -a pr "review-sandbox:$SANDBOX_PR"
+          # Copied to the parent rather than onto the path itself, so the archive
+          # carries the directory entry: `docker create` pre-creates `--workdir`
+          # owned by root, and only extracting that entry resets it to the uid
+          # the image runs as. `-a` carries the runner's uid, which is that uid.
+          docker cp -a base "review-sandbox:/tmp/"
+          docker cp -a pr "review-sandbox:/tmp/"
 
           timeout 45m docker start --attach review-sandbox \
             | base/.claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -403,7 +403,7 @@ jobs:
           mkdir -p "$REVIEW_MEDIA"
           # `docker cp` needs a container to copy into, so the run is split and
           # `--rm` gives way to the removal step below.
-          #
+
           # The gateway does not serve Anthropic's server-side web_search tool.
           # Denying the bare name drops it from Claude's context instead of
           # leaving it to fail on use.


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25296

### What changes are proposed in this pull request?

The sandbox's `base` and `pr` trees are copied into the container with `docker cp` instead of being bind-mounted, which drops the host-side `cp -a` staging. The output directory stays a bind mount.

- `docker run` splits into `docker create` / `docker cp` / `docker start --attach`, since `docker cp` needs a container to exist first. `--rm` gives way to an `always()` removal step.
- `$REVIEW_OUT` stays mounted. gVisor overlays the container's root filesystem by default (`--overlay2=root:self`), so anything written outside a mount is invisible to the runner once the container exits. Not optional: an earlier push here got it wrong, and the smoke run's review wrote and validated its payload inside the sandbox while the follow-up `docker cp` copied nothing and exited 0.
- Each tree is copied to its parent (`docker cp -a "${SANDBOX_BASE##*/}" …:"${SANDBOX_BASE%/*}/"`) rather than onto its own path. `docker create` pre-creates `--workdir` owned by root, and only extracting the archive's directory entry resets that ownership; copying onto the path left `/tmp/base` unwritable by uid 1001, which broke `uv` and, through git's dubious-ownership check, every `skills` subcommand. Expanding both halves from one variable means retargeting either fails loudly rather than misplacing the tree.
- The container is addressed by a fixed `--name`, matching how `gw-proxy` is already reached from a later step.
- `Stage the sandbox` becomes `Enable the gVisor runtime`, which is all it does now.

Net effect on isolation: the sandbox keeps no writable handle on a runner path except the output directory it is meant to write. The host-side copies previously provided that; this makes it structural.

### How is this PR tested?

- [x] Manual tests

The `pull_request` smoke run on this PR, which is why it is filed from an upstream branch. It is self-verifying: the review reads its own sandbox and reports what it finds. Successive runs caught the gVisor overlay problem and the workdir ownership problem, and the latest confirms from inside the container that `/tmp/base` and `/tmp/pr` are owned by `agent` (uid 1001) and that `/proc/mounts` shows `/tmp/review-out` as the only host-backed mount.

Locally, against `alpine` under `bash -eo pipefail` to match the Actions default shell: exit codes propagate through the `| stream.sh` pipeline; the container stays `Up` after the attach client is SIGTERM'd, which is why removal uses `--force`; and the `docker cp` destination and ownership semantics behind the fixes were reproduced directly, in both the broken and fixed forms. Plus `bash -n` on every modified `run` block.

Copy cost measured on a 9,559-file / 407M tree: `docker cp` 11.0s vs `cp -a` 3.2s, the former inflated by Docker Desktop's host-to-VM hop and lower on a Linux runner. Noise against this job either way.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release