### PR TITLE
Fix NaiLaOpus setup for stale PR branches

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -153,6 +153,8 @@ jobs:
       # PR head code. Safe only because the job gate limits this workflow to
       # maintainer-authored PRs.
       - uses: ./mlflow/.github/actions/setup-python
+        with:
+          python-version: "3.10"
 
       - name: Install ripgrep
         run: |


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25420

### What changes are proposed in this pull request?

Pass Python 3.10 explicitly to the NaiLaOpus workflow's checked-out `setup-python` action.

The default-branch workflow executes the action implementation from the PR checkout. PR branches created before #25420 therefore still use the old implementation, which looks for `.python-version` at the workspace root even though MLflow is checked out under `mlflow/`. Pinning the workflow input makes setup independent of the checked-out action version and fixes failures such as [this job](https://github.com/mlflow/mlflow/actions/runs/33356379717/job/99388249808).

### How is this PR tested?

- [x] Manual tests

Validated the workflow schema, parsed the updated YAML, and ran `dev/check_actions.py`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed for critical fixes.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
