### PR TITLE
fix(dspy): handle `CoT` output field order change in dspy 3.3.x

### DIFF
--- a/dev/flavors/src/flavors/_matrix.py
+++ b/dev/flavors/src/flavors/_matrix.py
@@ -497,13 +497,17 @@ async def expand_config(
             # Add tracing SDK test with the latest stable version
             if len(versions) > 0 and category == "autologging" and cfg.test_tracing_sdk:
                 version = max(versions)  # Test against the latest stable version
+                # Build install command for `version`, not the last loop iteration's version
+                tracing_reqs = [f"{package_info.pip_release}=={version}"]
+                tracing_reqs.extend(get_matched_requirements(cfg.requirements or {}, str(version)))
+                tracing_install = make_pip_install_command(tracing_reqs)
                 matrix.add(
                     MatrixItem(
                         name=f"{name}-tracing",
                         flavor=flavor,
                         category="tracing-sdk",
                         job_name=f"{name} / tracing-sdk / {version}",
-                        install=install,
+                        install=tracing_install,
                         # --import-mode=importlib is required for testing tracing SDK
                         # (mlflow-tracing) works properly, without being affected by environment.
                         run=run.replace("pytest", "pytest --import-mode=importlib"),

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -625,14 +625,14 @@ dspy:
       uv pip install --system git+https://github.com/stanfordnlp/dspy.git
   models:
     minimum: "3.0.0"
-    maximum: "3.2.1"
+    maximum: "3.3.1"
     requirements:
       ">= 0.0.0": ["openai"]
     run: |
       pytest tests/dspy --ignore tests/dspy/test_dspy_autolog.py
   autologging:
     minimum: "3.0.0"
-    maximum: "3.2.1"
+    maximum: "3.3.1"
     requirements:
       ">= 0.0.0": ["openai"]
     run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -635,6 +635,9 @@ dspy:
     maximum: "3.3.1"
     requirements:
       ">= 0.0.0": ["openai"]
+      # dspy >= 3.3.0 pulls in litellm>=1.98.0 which uses NotRequired from typing (Python 3.11+);
+      # cap it for Python 3.10 CI. litellm 1.97.0 is also excluded (see test-requirements.txt).
+      ">= 3.3.0": ["litellm!=1.97.0,<1.98.0"]
     run: |
       pytest tests/dspy/test_dspy_autolog.py
     test_tracing_sdk: true

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -928,8 +928,11 @@ crewai:
       uv pip install --system git+https://github.com/crewAIInc/crewAI#subdirectory=lib/crewai
   autologging:
     minimum: "0.152.0"
-    maximum: "1.15.5"
+    maximum: "1.15.17"
     requirements:
+      # crewai tests import litellm directly (ModelResponse, litellm.completion mock).
+      # The tracing-sdk install path skips test-requirements.txt, so litellm must be listed here.
+      ">= 0.0.0": ["litellm!=1.97.0,<1.98.0"]
     run: pytest tests/crewai
     test_tracing_sdk: true
     test_every_n_versions: 20

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -30,11 +30,11 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "3.0.0",
-            "maximum": "3.2.1"
+            "maximum": "3.3.1"
         },
         "autologging": {
             "minimum": "3.0.0",
-            "maximum": "3.2.1"
+            "maximum": "3.3.1"
         }
     },
     "langchain": {

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -123,7 +123,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.152.0",
-            "maximum": "1.15.5"
+            "maximum": "1.15.17"
         }
     },
     "agno": {

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -2,6 +2,3 @@ pytest==9.1.1
 # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility
 # https://xgboost.readthedocs.io/en/latest/changes/v3.1.0.html#multi-target-class-intercept
 xgboost<3.1.0
-# litellm 1.98.0 imports NotRequired from typing (requires Python 3.11+) rather than typing_extensions,
-# breaking imports on Python 3.10
-litellm<1.98.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -2,3 +2,6 @@ pytest==9.1.1
 # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility
 # https://xgboost.readthedocs.io/en/latest/changes/v3.1.0.html#multi-target-class-intercept
 xgboost<3.1.0
+# litellm 1.98.0 imports NotRequired from typing (requires Python 3.11+) rather than typing_extensions,
+# breaking imports on Python 3.10
+litellm<1.98.0

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -33,6 +33,9 @@ skip_if_2_6_23_or_older = pytest.mark.skipif(
 
 _REASONING_KEYWORD = "rationale" if _DSPY_UNDER_2_6 else "reasoning"
 
+# dspy 3.3.0 changed CoT's output field order: reasoning now precedes answer
+_DSPY_3_3_OR_NEWER = _DSPY_VERSION >= Version("3.3.0")
+
 
 @pytest.fixture
 def dummy_model():
@@ -450,10 +453,16 @@ def test_infer_signature_from_input_examples(dummy_model):
 
         loaded_model = Model.load(model_info.model_uri)
         assert loaded_model.signature.inputs == Schema([ColSpec("string")])
-        assert loaded_model.signature.outputs == Schema([
-            ColSpec(name="answer", type="string"),
-            ColSpec(name=_REASONING_KEYWORD, type="string"),
-        ])
+        if _DSPY_3_3_OR_NEWER:
+            assert loaded_model.signature.outputs == Schema([
+                ColSpec(name=_REASONING_KEYWORD, type="string"),
+                ColSpec(name="answer", type="string"),
+            ])
+        else:
+            assert loaded_model.signature.outputs == Schema([
+                ColSpec(name="answer", type="string"),
+                ColSpec(name=_REASONING_KEYWORD, type="string"),
+            ])
 
 
 @skip_if_2_6_23_or_older


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/dev/actions/runs/33254427210

### What changes are proposed in this pull request?

dspy 3.3.0 changed the output field order of the `CoT` module so that `reasoning` precedes `answer`. The cross-version test `test_infer_signature_from_input_examples` was failing on dspy 3.3.1 because the schema assertion expected the old order (`answer, reasoning`).

- Bump dspy `maximum` from `3.2.1` to `3.3.1` in `ml-package-versions.yml` for both `models` and `autologging` test runs
- Add `_DSPY_3_3_OR_NEWER` version gate in `tests/dspy/test_save.py` and branch the output schema assertion to match the field order for each version

### How is this PR tested?

- [x] Existing unit/integration tests (the fixed test covers this directly)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release