### PR TITLE
Gate the review on the commenter, not the PR author

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -53,8 +53,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
-          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type || github.event.issue.user.type }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
           COMMENTER: ${{ github.event.comment.user.login }}
         run: |
           check_user() {

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,8 +22,9 @@ permissions: {}
 
 jobs:
   # Auth gate: only users with admin or maintain role on the repo can trigger
-  # the review (plus the Copilot bot). For issue_comment, BOTH the PR author
-  # and the commenter are checked.
+  # the review (plus the Copilot bot). On `issue_comment` that is the commenter,
+  # so a maintainer can review a contributor's PR; `pull_request` has no
+  # commenter, so the author is checked instead.
   gate:
     runs-on: ubuntu-slim
     timeout-minutes: 5
@@ -43,10 +44,6 @@ jobs:
       ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
-       (
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association) ||
-        (github.event.issue.user.login == 'Copilot' && github.event.issue.user.type == 'Bot')
-       ) &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
        startsWith(github.event.comment.body, '/review') &&
        !startsWith(github.event.comment.body, '/review-'))
@@ -80,9 +77,10 @@ jobs:
                 ;;
             esac
           }
-          check_user "$PR_AUTHOR" "$PR_AUTHOR_TYPE"
           if [ "$EVENT_NAME" = "issue_comment" ]; then
             check_user "$COMMENTER" "User"
+          else
+            check_user "$PR_AUTHOR" "$PR_AUTHOR_TYPE"
           fi
 
       # Pinned here, before anything checks out or runs PR code. `issue_comment`


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25478

### What changes are proposed in this pull request?

`/review` on an `issue_comment` required *both* the PR author and the commenter to hold admin/maintain, so a maintainer could not review a contributor's PR. Only the commenter is checked now. Both layers move together: the cheap `author_association` prefilter in `if:` and the authoritative role check in the gate step.

The `pull_request` path is deliberately untouched and still requires `head.repo.full_name == github.repository`. That path checks the workflow out from the PR's own branch, so opening it to forks would execute author-controlled workflow code. On `issue_comment` the tooling comes from the default branch and only the reviewed tree comes from the PR.

Why this is the right boundary: the commenter is the one deciding to spend the run, so triggering stays maintainer-controlled. The `review` job already runs PR code by design, holds only `contents`/`packages`/`pull-requests: read`, keeps the write credential in a separate job on a separate VM, and never puts the gateway bearer inside the container.

Two residual risks are unchanged by this PR but become reachable by a wider set of PRs, and are worth tracking separately:

- Review-content integrity. A prompt injection in the diff can shape the payload that a later job posts under the app's identity. `skills validate-review` checks the schema, not the content.
- Sandbox egress is unrestricted. The only credential inside is a read-only `GITHUB_TOKEN`, which is low value on a public repo, but restricting the container to the gateway proxy and `api.github.com` would be the natural hardening.

### How is this PR tested?

- [x] Manual tests

The `pull_request` smoke run on this PR exercises the `pull_request` branch of the gate, which is the branch this PR does not change, so it confirms no regression there. The relaxed `issue_comment` branch is exercised by commenting `/review` on a contributor PR after merge.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release