### PR TITLE
Split the `Review` step into create and run

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -175,8 +175,6 @@ jobs:
       RESULT_BODY: /tmp/updated-comment.md
       PR_CHECKOUT: ${{ github.workspace }}/pr
       SANDBOX_IMAGE: ghcr.io/mlflow/sandbox:latest
-      # A fixed name rather than the id `docker create` prints, so the run and
-      # removal steps can reach the container without passing it between them.
       SANDBOX_CONTAINER: review-sandbox
       # Copied into the container rather than mounted, so nothing the sandbox
       # writes reaches a tree the runner still uses. `base` needs that: the

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -175,6 +175,9 @@ jobs:
       RESULT_BODY: /tmp/updated-comment.md
       PR_CHECKOUT: ${{ github.workspace }}/pr
       SANDBOX_IMAGE: ghcr.io/mlflow/sandbox:latest
+      # A fixed name rather than the id `docker create` prints, so the run and
+      # removal steps can reach the container without passing it between them.
+      SANDBOX_CONTAINER: review-sandbox
       # Copied into the container rather than mounted, so nothing the sandbox
       # writes reaches a tree the runner still uses. `base` needs that: the
       # runner runs `skills` from its own copy afterwards with
@@ -397,7 +400,7 @@ jobs:
           mkdir -p "$REVIEW_MEDIA"
           # `docker cp` needs a container to copy into, which is why creating it
           # is a step of its own and `--rm` gives way to the removal step below.
-          docker create --name review-sandbox --runtime=runsc \
+          docker create --name "$SANDBOX_CONTAINER" --runtime=runsc \
             --add-host gw-proxy:host-gateway \
             --volume "$REVIEW_OUT:$REVIEW_OUT" \
             --workdir "$SANDBOX_BASE" \
@@ -430,8 +433,8 @@ jobs:
           # the image runs as. `-a` carries the runner's uid, which is that uid.
           # Both halves come from the same variable, so retargeting one fails on
           # a missing checkout rather than silently copying somewhere else.
-          docker cp -a "${SANDBOX_BASE##*/}" "review-sandbox:${SANDBOX_BASE%/*}/"
-          docker cp -a "${SANDBOX_PR##*/}" "review-sandbox:${SANDBOX_PR%/*}/"
+          docker cp -a "${SANDBOX_BASE##*/}" "$SANDBOX_CONTAINER:${SANDBOX_BASE%/*}/"
+          docker cp -a "${SANDBOX_PR##*/}" "$SANDBOX_CONTAINER:${SANDBOX_PR%/*}/"
 
       # Both event paths run /pr-review end-to-end against the PR; on
       # pull_request (smoke), the steps that mutate the PR are gated off so no
@@ -441,7 +444,7 @@ jobs:
         run: |
           OUTPUT_FILE="/tmp/output.jsonl"
           EXIT_CODE=0
-          timeout 45m docker start --attach review-sandbox \
+          timeout 45m docker start --attach "$SANDBOX_CONTAINER" \
             | base/.claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then
             echo "Warning: Claude command timed out after 45 minutes"
@@ -456,7 +459,7 @@ jobs:
       - name: Remove the sandbox container
         if: always()
         run: |
-          docker rm --force review-sandbox > /dev/null 2>&1 || true
+          docker rm --force "$SANDBOX_CONTAINER" > /dev/null 2>&1 || true
 
       # A sandbox that cannot reach the proxy only reports a request timeout.
       - name: Gateway proxy log

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -369,8 +369,7 @@ jobs:
       # server-side web_search tool, so `--disallowed-tools` denies the bare
       # name: that drops it from Claude's context instead of leaving it to fail
       # on use.
-      - name: Review
-        id: review
+      - name: Create the review sandbox
         env:
           # Read-only for the whole job: injected instructions can't mutate the PR.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -393,17 +392,11 @@ jobs:
           EFFORT: ${{ steps.prompt.outputs.effort }}
           AGENT_BROWSER_SCREENSHOT_DIR: ${{ env.REVIEW_MEDIA }}
         run: |
-          OUTPUT_FILE="/tmp/output.jsonl"
-
-          # Both event paths run /pr-review end-to-end against the PR; on
-          # pull_request (smoke), the steps that mutate the PR are gated off so
-          # no review is submitted.
-          EXIT_CODE=0
           # `$REVIEW_OUT` is the mount source and has to exist first, or Docker
           # creates it root-owned and the sandbox cannot write it.
           mkdir -p "$REVIEW_MEDIA"
-          # `docker cp` needs a container to copy into, so the run is split and
-          # `--rm` gives way to the removal step below.
+          # `docker cp` needs a container to copy into, which is why creating it
+          # is a step of its own and `--rm` gives way to the removal step below.
           docker create --name review-sandbox --runtime=runsc \
             --add-host gw-proxy:host-gateway \
             --volume "$REVIEW_OUT:$REVIEW_OUT" \
@@ -440,6 +433,14 @@ jobs:
           docker cp -a "${SANDBOX_BASE##*/}" "review-sandbox:${SANDBOX_BASE%/*}/"
           docker cp -a "${SANDBOX_PR##*/}" "review-sandbox:${SANDBOX_PR%/*}/"
 
+      # Both event paths run /pr-review end-to-end against the PR; on
+      # pull_request (smoke), the steps that mutate the PR are gated off so no
+      # review is submitted.
+      - name: Review
+        id: review
+        run: |
+          OUTPUT_FILE="/tmp/output.jsonl"
+          EXIT_CODE=0
           timeout 45m docker start --attach review-sandbox \
             | base/.claude/scripts/stream.sh "$OUTPUT_FILE" || EXIT_CODE=$?
           if [ "${EXIT_CODE:-0}" -eq 124 ]; then


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25478

### What changes are proposed in this pull request?

The `Review` step had grown to build the container, populate it, run the review and interpret the exit code. Split into `Create the review sandbox` and `Review`.

The seam is where the environment stops being needed: all eleven variables are consumed at `docker create` time, either passed through with `--env` or interpolated into the argv, so the run step needs none of them. That makes the env block sit entirely on one side rather than spanning both concerns.

Behaviour is unchanged apart from failure reporting: a failed create now skips the run instead of surfacing as one opaque step failure, and the `always()` removal step still cleans up either way. `steps.review` is referenced nowhere, and `/tmp/output.jsonl` is hardcoded in the downstream steps, so nothing else moves.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

The `pull_request` smoke run on this PR exercises the split end to end, which is why it is filed from an upstream branch. Locally, `bash -n` on both new `run` blocks and a check that the parsed workflow puts every env key on the create step and none on the run step.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release