### PR TITLE
fix(haystack): register the autologging config in `mlflow.haystack.autolog`

### DIFF
--- a/mlflow/haystack/__init__.py
+++ b/mlflow/haystack/__init__.py
@@ -19,6 +19,8 @@ def autolog(
         silent: If ``True``, suppress all event logs and warnings from MLflow during
             Haystack autologging. If ``False``, show all events and warnings.
     """
+    _autolog(log_traces=log_traces, disable=disable, silent=silent)
+
     if disable or not log_traces:
         teardown_haystack_tracing()
         return

--- a/tests/haystack/test_haystack_tracing.py
+++ b/tests/haystack/test_haystack_tracing.py
@@ -13,6 +13,7 @@ from mlflow.environment_variables import MLFLOW_USE_DEFAULT_TRACER_PROVIDER
 from mlflow.exceptions import MlflowException
 from mlflow.haystack.autolog import _get_opentelemetry_tracer_class
 from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
 from mlflow.version import IS_TRACING_SDK_ONLY
 
 from tests.tracing.helper import get_traces
@@ -148,6 +149,18 @@ def test_autolog_disable():
     pipe2.add_component("adder", Add())
     pipe2.run({"adder": {"a": 2, "b": 3}})
     assert len(get_traces()) == 1
+
+
+def test_autolog_records_integration_config():
+    # `mlflow.autolog()` checks AUTOLOGGING_INTEGRATIONS before re-enabling a flavor,
+    # so the config has to be recorded or an explicit opt-out is overridden.
+    mlflow.haystack.autolog(disable=True)
+
+    config = AUTOLOGGING_INTEGRATIONS["haystack"]
+    assert config["disable"] is True
+
+    mlflow.haystack.autolog()
+    assert AUTOLOGGING_INTEGRATIONS["haystack"]["disable"] is False
 
 
 def test_in_memory_retriever_component_traced():


### PR DESCRIPTION
### Related Issues/PRs

None — I did not find an existing issue for this.

### What changes are proposed in this pull request?

`mlflow/haystack/__init__.py` defines the `_autolog` shim that carries the `@autologging_integration` decorator, with a docstring stating it *"exists solely to attach the autologging_integration decorator"* — but `autolog()` never calls it.

Haystack is the only flavour in the tree in this state. Of the 25 flavour modules defining `autolog`, 21 apply the decorator directly to `autolog`, and the four using the shim — `ag2`, `agno`, `litellm`, `strands` — all call it:

```python
# mlflow/litellm/__init__.py
_autolog(log_traces=log_traces, disable=disable, silent=silent)
```

The effect is that `AUTOLOGGING_INTEGRATIONS["haystack"]` is never populated. The post-import hook in `tracking/fluent.py` uses it to decide whether the user has already configured a flavour:

```python
prev_config = AUTOLOGGING_INTEGRATIONS.get(autolog_fn.integration_name)
if prev_config and not prev_config.get(AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED, False):
    return
```

`{}` is falsy, so the early return never fires for Haystack and `mlflow.autolog()` re-enables tracing after an explicit opt-out:

```
before   prev_config = {}                                            guard falls through -> re-enabled
after    prev_config = {'log_traces': True, 'disable': True, ...}    guard returns -> opt-out respected
```

By comparison, `sklearn` records its full config on the same call.

`silent` also only reaches the integration through this call, so it currently has no effect for Haystack either.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_autolog_records_integration_config` in `tests/haystack/test_haystack_tracing.py`, asserting the config is recorded for both `disable=True` and the default. The existing tests only exercise enable/disable tracing cycles and never look at `AUTOLOGGING_INTEGRATIONS`, which is why this went unnoticed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.autolog()` no longer re-enables Haystack tracing after an explicit `mlflow.haystack.autolog(disable=True)`, and `silent` is now honoured for the Haystack integration.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
