### PR TITLE
Route the review proxy by gateway surface

### DIFF
--- a/.github/actions/setup-gateway/action.yml
+++ b/.github/actions/setup-gateway/action.yml
@@ -1,5 +1,5 @@
 name: "setup-gateway"
-description: "Mint a Databricks AI Gateway bearer and emit the Claude CLI env values as outputs"
+description: "Mint a Databricks AI Gateway bearer and emit its base URLs as outputs"
 inputs:
   task:
     description: "Names the automation spending the tokens, e.g. pr-review. Tags the requests for cost attribution."
@@ -15,13 +15,13 @@ inputs:
     required: true
 outputs:
   base-url:
-    description: "Value for ANTHROPIC_BASE_URL"
+    description: "Base URL of the gateway. The provider surface goes after it."
     value: ${{ steps.gateway.outputs.base-url }}
   token:
-    description: "Value for ANTHROPIC_AUTH_TOKEN. Short-lived, and masked in logs."
+    description: "Bearer for the gateway. Short-lived, and masked in logs."
     value: ${{ steps.gateway.outputs.token }}
   custom-headers:
-    description: "Value for ANTHROPIC_CUSTOM_HEADERS, carrying the request tags"
+    description: "Request tags for cost attribution, as an HTTP header line"
     value: ${{ steps.gateway.outputs.custom-headers }}
 runs:
   using: "composite"
@@ -49,6 +49,6 @@ runs:
         echo "::add-mask::$TOKEN"
         echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
         # `%/` so a trailing slash on the input can't produce a `//` path.
-        echo "base-url=${DATABRICKS_HOST%/}/ai-gateway/anthropic" >> "$GITHUB_OUTPUT"
+        echo "base-url=${DATABRICKS_HOST%/}/ai-gateway" >> "$GITHUB_OUTPUT"
         TAGS=$(jq -cn --arg repository "$GITHUB_REPOSITORY" --arg task "$TASK" '{$repository, $task}')
         echo "custom-headers=Databricks-Ai-Gateway-Request-Tags: $TAGS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -327,26 +327,39 @@ jobs:
             client_max_body_size 0;
             server {
               listen 80;
+              # Every route reaches the same gateway with the same bearer, so
+              # only the upstream path differs.
+              proxy_set_header Authorization "Bearer ${GATEWAY_TOKEN}";
+              proxy_http_version 1.1;
+              # Streamed responses, and the default 60s read timeout is short
+              # for a review turn.
+              proxy_buffering off;
+              proxy_request_buffering off;
+              proxy_read_timeout 600s;
+              # This hop is what attaches the credential, so it verifies the
+              # gateway rather than trusting whatever answers.
+              proxy_ssl_server_name on;
+              proxy_ssl_verify on;
+              proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
               # Answered by nginx itself, so the probe below cannot be held up by
               # the gateway.
               location = /healthz {
                 access_log off;
                 return 200;
               }
+              # One route per gateway surface, named after it, so
+              # /anthropic/v1/messages and /openai/v1/responses land on the
+              # paths the gateway serves.
+              location /anthropic/ {
+                proxy_pass ${GATEWAY_URL}/anthropic/;
+              }
+              location /openai/ {
+                proxy_pass ${GATEWAY_URL}/openai/;
+              }
+              # Nothing else is a gateway path, and forwarding it would spend the
+              # bearer on a request we did not mean to make.
               location / {
-                proxy_pass ${GATEWAY_URL}/;
-                proxy_set_header Authorization "Bearer ${GATEWAY_TOKEN}";
-                proxy_http_version 1.1;
-                # Streamed responses, and the default 60s read timeout is short
-                # for a review turn.
-                proxy_buffering off;
-                proxy_request_buffering off;
-                proxy_read_timeout 600s;
-                # This hop is what attaches the credential, so it verifies the
-                # gateway rather than trusting whatever answers.
-                proxy_ssl_server_name on;
-                proxy_ssl_verify on;
-                proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+                return 404;
               }
             }
           }
@@ -374,7 +387,7 @@ jobs:
         env:
           # Read-only for the whole job: injected instructions can't mutate the PR.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANTHROPIC_BASE_URL: http://gw-proxy:8080
+          ANTHROPIC_BASE_URL: http://gw-proxy:8080/anthropic
           # The CLI refuses to start without a credential, so not simply empty.
           ANTHROPIC_AUTH_TOKEN: placeholder-not-a-real-credential
           # Tags, not a credential.


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The review job's nginx proxy forwarded everything to the gateway's Anthropic path, so reaching another surface on the same gateway meant standing up a second proxy.

- One route per surface: `/anthropic/` and `/openai/`, so `/anthropic/v1/messages` and `/openai/v1/responses` land where the gateway serves them.
- `setup-gateway` emits the gateway base URL rather than one surface's, and each route appends its own.
- Shared `proxy_*` settings hoisted to the server block, since every route uses the same gateway and the same bearer.
- Anything unrouted answers 404 rather than being forwarded with the bearer attached.

No behavior change for the review itself: `ANTHROPIC_BASE_URL` carries the `/anthropic` prefix, so the CLI's `/v1/messages` lands where it did before. The `/openai/` route has no caller yet; the stacked PR adds one.

### How is this PR tested?

- [x] Manual tests

Rendered the heredoc and ran `nginx -t` (syntax ok), then ran the rendered config against an upstream that echoes back the request URI:

| request | upstream received | status |
| --- | --- | --- |
| `/anthropic/v1/messages` | `/anthropic/v1/messages` | 200 |
| `/openai/v1/responses` | `/openai/v1/responses` | 200 |
| `/v1/messages` | not forwarded | 404 from nginx |

Also ran it with the two surfaces pointed at the real APIs, which answered 401 `authentication_error` and 401 `invalid_api_key` respectively. This PR's own `pull_request` smoke run exercises the Anthropic route end to end.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release