### PR TITLE
Give the PR review a web search tool

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -105,10 +105,11 @@ The checkout is shallow, so nothing older than `HEAD^1` exists: `git log` and `g
 the shallow boundary rather than reaching the commit that actually introduced a line. Neither
 errors, so don't trust them for pre-change history.
 
-Verify rather than infer. A `grep` through the installed package, a `uv run python -c '...'`, or a
-web fetch of the upstream docs will settle most questions in seconds, and an unverified finding
-should be dropped rather than hedged. When the cheap checks don't settle it, escalate to the
-expensive ones: build the docs site, build and boot the UI, start the backend.
+Verify rather than infer. A `grep` through the installed package, a `uv run python -c '...'`, a web
+fetch, or a web search (`$base_dir/.claude/skills/pr-review/search-web.sh "<query>"`) will settle
+most questions in seconds, and an unverified finding should be dropped rather than hedged. When the
+cheap checks don't settle it, escalate to the expensive ones: build the docs site, build and boot
+the UI, start the backend.
 
 Node and `agent-browser` are on PATH for docs and UI changes. Capture to an absolute path named for
 what it shows: `agent-browser screenshot --full $media_dir/example.png`, and cite that same

--- a/.claude/skills/pr-review/search-web.sh
+++ b/.claude/skills/pr-review/search-web.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Answer a question with a web search, through the gateway's OpenAI surface.
+# The proxy attaches the credential, so no token is needed here.
+#
+# TODO: delete this script and drop `--disallowed-tools WebSearch` from
+# `review.yml` once the gateway serves Anthropic's own web_search. Today it
+# reaches Anthropic models only through an MCP server:
+# https://docs.databricks.com/aws/en/machine-learning/model-serving/web-search
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo 'usage: search-web.sh "<query>"' >&2
+  exit 2
+fi
+
+: "${WEB_SEARCH_BASE_URL:?WEB_SEARCH_BASE_URL is unset}"
+MODEL="${WEB_SEARCH_MODEL:-databricks-gpt-5-4-mini}"
+
+request=$(jq -n --arg model "$MODEL" --arg input "$*" '{
+  model: $model,
+  tools: [{type: "web_search"}],
+  # Declaring the tool only offers it, and an answer from model knowledge is
+  # exactly what the caller came here to avoid.
+  tool_choice: "required",
+  input: $input,
+  # Reasoning counts against this, and a review question spends more of it than
+  # the answer does.
+  max_output_tokens: 4000,
+  reasoning: {effort: "low"}
+}')
+
+# `--retry` covers the transient statuses and connection failures, not a 400, so
+# a blip costs a moment rather than the answer.
+if ! response=$(curl -sS --fail-with-body --max-time 180 --retry 2 \
+  -H "Content-Type: application/json" -d "$request" "$WEB_SEARCH_BASE_URL/responses"); then
+  echo "search-web: request failed: $response" >&2
+  exit 1
+fi
+
+# The answer carries its citations inline: each url_citation annotation is a pair
+# of offsets into this text, not a source the text leaves out.
+answer=$(jq -r '[.output[]? | select(.type == "message") | .content[]?.text] | join("\n")' <<<"$response")
+
+status=$(jq -c '{status, incomplete_details, error}' <<<"$response")
+
+# A budget spent entirely on reasoning, a refusal, or an error object served at
+# 200 all reach here with nothing to print, which reads like a search that found
+# nothing. The status alone says which: the response itself is mostly encrypted
+# reasoning blobs.
+if [ -z "$answer" ]; then
+  echo "search-web: no answer: $status" >&2
+  exit 1
+fi
+
+# `tool_choice` asks for a search, but only the response says whether one ran: a
+# backend that ignored it answers from model knowledge and reads the same.
+if [ "$(jq -r '[.output[]?.type] | index("web_search_call")' <<<"$response")" = "null" ]; then
+  echo "search-web: answer did not come from a search: $status" >&2
+  exit 1
+fi
+
+# A truncated answer stops mid-sentence but otherwise reads like a whole one.
+if [ "$(jq -r '.status' <<<"$response")" != "completed" ]; then
+  echo "search-web: $status" >&2
+fi
+
+printf '%s\n' "$answer"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -376,13 +376,23 @@ jobs:
           # the whole `timeout` inside the first curl and never retry.
           timeout 60 bash -c 'until curl -sf -o /dev/null --max-time 5 http://127.0.0.1:8080/healthz; do sleep 1; done'
 
+      # Proves the OpenAI route and the gateway's web_search tool work, which a
+      # review only covers by chance.
+      - name: Smoke-test the search tool
+        if: github.event_name == 'pull_request'
+        env:
+          WEB_SEARCH_BASE_URL: http://127.0.0.1:8080/openai/v1
+        run: |
+          base/.claude/skills/pr-review/search-web.sh "What is the latest MLflow release on PyPI?"
+
       # The sandbox gets a read-only `GH_TOKEN` in its environment, the PR tree
       # and the tooling copy, and the output directory mounted at the path it
       # has on the runner so a cited screenshot still resolves for
       # `skills embed-media` afterwards. The gateway does not serve Anthropic's
       # server-side web_search tool, so `--disallowed-tools` denies the bare
       # name: that drops it from Claude's context instead of leaving it to fail
-      # on use.
+      # on use. `search-web.sh` covers the same need over the OpenAI route,
+      # which does serve one.
       - name: Create the review sandbox
         env:
           # Read-only for the whole job: injected instructions can't mutate the PR.
@@ -392,6 +402,8 @@ jobs:
           ANTHROPIC_AUTH_TOKEN: placeholder-not-a-real-credential
           # Tags, not a credential.
           ANTHROPIC_CUSTOM_HEADERS: ${{ steps.gateway.outputs.custom-headers }}
+          # Read by `search-web.sh`; the proxy attaches the credential.
+          WEB_SEARCH_BASE_URL: http://gw-proxy:8080/openai/v1
           # The auto mode permission classifier picks its model from the sonnet
           # and opus aliases rather than `--model`, so without these it requests
           # a bare `claude-sonnet-5` that the gateway does not serve and every
@@ -419,6 +431,7 @@ jobs:
             --env ANTHROPIC_BASE_URL \
             --env ANTHROPIC_AUTH_TOKEN \
             --env ANTHROPIC_CUSTOM_HEADERS \
+            --env WEB_SEARCH_BASE_URL \
             --env ANTHROPIC_DEFAULT_SONNET_MODEL \
             --env ANTHROPIC_DEFAULT_OPUS_MODEL \
             --env CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS \


### PR DESCRIPTION
### Related Issues/PRs

Follows #25485, which added the `/openai/` route this calls.

### What changes are proposed in this pull request?

The gateway does not serve Anthropic's `web_search`, so the review has no way to check a current version or an upstream behavior this repository does not record. Its OpenAI surface does serve one.

- `search-web.sh` asks that surface with `tool_choice: "required"` and prints the answer with the inline links its citations mark. The pr-review skill offers it alongside the other cheap checks.
- It exits 1 on a non-2xx, an empty answer, or a response carrying no `web_search_call`, so a backend that quietly stopped searching cannot pass as one that did.
- No allowlist entry, so the call is classified like every other Bash command in this job.

### How is this PR tested?

- [x] Manual tests

A `/review` run used it from inside the sandbox: a web-backed answer with an inline citation over `gw-proxy:8080/openai/v1`, allowed by the classifier without prompting. Locally against an nginx configured like the job's, each failure path exits 1 as intended.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release