### PR TITLE
Fix Custom Views in Traces V4

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
@@ -7,6 +7,8 @@ import { TracesV3Logs } from './TracesV3Logs';
 import { IntlProvider } from '@databricks/i18n';
 import { QueryClient, QueryClientProvider, type UseMutateAsyncFunction } from '@databricks/web-shared/query-client';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { shouldEnableModelTraceExplorerCustomTraceView } from '@databricks/web-shared/model-trace-explorer';
+import { CustomViewDefinitionProvider } from '@databricks/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext';
 import {
   useMlflowTracesTableMetadata,
   useSearchMlflowTraces,
@@ -31,6 +33,8 @@ import { GenericNetworkRequestError } from '@mlflow/mlflow/src/shared/web-shared
 import { TestRouter, testRoute, waitForRoutesToBeRendered } from '@mlflow/mlflow/src/common/utils/RoutingTestUtils';
 import * as useCountInfoModule from './hooks/useCountInfo';
 
+const mockExperimentCustomViewProvider = jest.fn(({ children }: { children: React.ReactNode }) => children);
+
 // Overriding default timeout for OSS tests
 // eslint-disable-next-line no-restricted-syntax
 jest.setTimeout(30000);
@@ -53,6 +57,17 @@ jest.mock('@databricks/web-shared/genai-traces-table', () => {
     shouldUseInfinitePaginatedTraces: jest.fn(),
   };
 });
+
+jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
+  ...jest.requireActual<typeof import('@databricks/web-shared/model-trace-explorer')>(
+    '@databricks/web-shared/model-trace-explorer',
+  ),
+  shouldEnableModelTraceExplorerCustomTraceView: jest.fn(),
+}));
+
+jest.mock('./ExperimentCustomViewProvider', () => ({
+  ExperimentCustomViewProvider: (props: { children: React.ReactNode }) => mockExperimentCustomViewProvider(props),
+}));
 
 jest.mock('./hooks/useAssessmentCountMetrics', () => ({
   useAssessmentCountMetrics: jest.fn(() => undefined),
@@ -108,7 +123,7 @@ jest.mock('../../../../pages/experiment-evaluation-datasets/components/ExportTra
   ExportTracesToDatasetModal: jest.fn(() => null),
 }));
 
-const renderComponent = (props = {}, initialEntries?: string[]) => {
+const renderComponent = (props = {}, initialEntries?: string[], withCustomViewProvider = false) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -124,7 +139,13 @@ const renderComponent = (props = {}, initialEntries?: string[]) => {
             <QueryClientProvider client={queryClient}>
               <DesignSystemProvider>
                 <GenAITracesTableProvider isGroupedBySession={false}>
-                  <TracesV3Logs experimentIds={['test-experiment']} endpointName="test-endpoint" {...props} />
+                  {withCustomViewProvider ? (
+                    <CustomViewDefinitionProvider views={[]} isLoaded>
+                      <TracesV3Logs experimentIds={['test-experiment']} endpointName="test-endpoint" {...props} />
+                    </CustomViewDefinitionProvider>
+                  ) : (
+                    <TracesV3Logs experimentIds={['test-experiment']} endpointName="test-endpoint" {...props} />
+                  )}
                 </GenAITracesTableProvider>
               </DesignSystemProvider>
             </QueryClientProvider>
@@ -139,6 +160,7 @@ describe('TracesV3Logs', () => {
   beforeEach(() => {
     // Default mock implementations
     jest.mocked(useMarkdownConverter).mockReturnValue((markdown?: string) => markdown || '');
+    jest.mocked(shouldEnableModelTraceExplorerCustomTraceView).mockReturnValue(false);
 
     jest.mocked(useSelectedColumns).mockReturnValue({
       selectedColumns: [
@@ -174,6 +196,33 @@ describe('TracesV3Logs', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('reuses an outer Custom View definition instead of mounting a nested experiment provider', async () => {
+    jest.mocked(shouldEnableModelTraceExplorerCustomTraceView).mockReturnValue(true);
+    jest.mocked(useMlflowTracesTableMetadata).mockReturnValue({
+      assessmentInfos: [],
+      allColumns: [],
+      totalCount: 0,
+      isLoading: false,
+      error: null,
+      isEmpty: true,
+      tableFilterOptions: { source: [] },
+      evaluatedTraces: [],
+      otherEvaluatedTraces: [],
+    });
+    jest.mocked(useSetInitialTimeFilter).mockReturnValue({ isInitialTimeFilterLoading: false });
+    jest.mocked(useSearchMlflowTraces).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      error: null,
+    } as any);
+
+    renderComponent({}, undefined, true);
+    await waitForRoutesToBeRendered();
+
+    expect(mockExperimentCustomViewProvider).not.toHaveBeenCalled();
   });
 
   /**

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -98,6 +98,7 @@ import { IssueDetectionModal } from './IssueDetectionModal';
 import { useCountInfo } from './hooks/useCountInfo';
 import { useAssessmentCountMetrics } from './hooks/useAssessmentCountMetrics';
 import { useScorerDescriptions } from '../../../../pages/experiment-scorers/hooks/useScorerDescriptions';
+import { useOptionalCustomViewDefinition } from '@databricks/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext';
 
 const JudgeContextProvider = ({
   children,
@@ -204,6 +205,7 @@ const TracesV3LogsImpl = React.memo(
     enableSavedViews?: boolean;
     drawerWidth?: string | number;
   }) => {
+    const existingCustomViewDefinition = useOptionalCustomViewDefinition();
     // When viewing a single experiment, pass its ID to enable experiment-specific
     // features (run name links, logged model links, session links, filter dropdowns).
     // When viewing multiple experiments, pass undefined to disable those features.
@@ -817,7 +819,11 @@ const TracesV3LogsImpl = React.memo(
     );
 
     let content = tableContent;
-    if (shouldEnableModelTraceExplorerCustomTraceView() && singleExperimentId) {
+    if (
+      shouldEnableModelTraceExplorerCustomTraceView() &&
+      singleExperimentId &&
+      existingCustomViewDefinition === undefined
+    ) {
       content = (
         <React.Suspense fallback={tableContent}>
           <LazyExperimentCustomViewProvider key={singleExperimentId} experimentId={singleExperimentId}>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/TracesV4Tab.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/TracesV4Tab.test.tsx
@@ -1,0 +1,62 @@
+import { act, render, screen } from '@testing-library/react';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { TracesV4Tab } from './TracesV4Tab';
+
+let mockProviderReady: boolean;
+let mockProviderPromise: Promise<void>;
+let mockResolveProvider: () => void;
+const mockPageMount = jest.fn();
+
+jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
+  shouldEnableModelTraceExplorerCustomTraceView: () => true,
+}));
+
+jest.mock('../traces-v3/ExperimentCustomViewProvider', () => ({
+  ExperimentCustomViewProvider: ({ children }: { children: React.ReactNode }) => {
+    if (!mockProviderReady) {
+      throw mockProviderPromise;
+    }
+    return children;
+  },
+}));
+
+jest.mock('./components/TracesV4PageContent', () => ({
+  TracesV4PageContent: () => {
+    const React = jest.requireActual<typeof import('react')>('react');
+    React.useEffect(() => {
+      mockPageMount();
+    }, []);
+    return <button>Interactive traces page</button>;
+  },
+}));
+
+describe('TracesV4Tab', () => {
+  beforeEach(() => {
+    mockProviderReady = false;
+    mockProviderPromise = new Promise<void>((resolve) => {
+      mockResolveProvider = resolve;
+    });
+    mockPageMount.mockClear();
+  });
+
+  test('does not mount the interactive page while the Custom View provider is loading', async () => {
+    render(
+      <DesignSystemProvider>
+        <TracesV4Tab experimentId="exp-1" />
+      </DesignSystemProvider>,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Interactive traces page' })).not.toBeInTheDocument();
+    expect(mockPageMount).not.toHaveBeenCalled();
+
+    await act(async () => {
+      mockProviderReady = true;
+      mockResolveProvider();
+      await mockProviderPromise;
+    });
+
+    expect(await screen.findByRole('button', { name: 'Interactive traces page' })).toBeInTheDocument();
+    expect(mockPageMount).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/TracesV4Tab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/TracesV4Tab.tsx
@@ -1,7 +1,18 @@
+import React from 'react';
 import { GenericSkeleton } from '@databricks/design-system';
+import { shouldEnableModelTraceExplorerCustomTraceView } from '@databricks/web-shared/model-trace-explorer';
 import { MonitoringConfigProvider } from '@mlflow/mlflow/src/experiment-tracking/hooks/useMonitoringConfig';
 import { TracesV4PageWrapper } from './components/TracesV4PageWrapper';
 import { TracesV4PageContent } from './components/TracesV4PageContent';
+
+// Custom View pulls in @a2ui (ESM-only) transitively via ExperimentCustomViewProvider.
+// Lazy-load it so consumers that don't need Custom View don't pull @a2ui onto their
+// static module graph (mirrors the V3 traces page).
+const LazyExperimentCustomViewProvider = React.lazy(() =>
+  import('../traces-v3/ExperimentCustomViewProvider').then((module) => ({
+    default: module.ExperimentCustomViewProvider,
+  })),
+);
 
 interface TracesV4TabProps {
   experimentId: string;
@@ -19,14 +30,21 @@ interface TracesV4TabProps {
  * the controller's clear-on-time-change effect wipes the bulk selection before the user can act.
  */
 export const TracesV4Tab = ({ experimentId, isLoadingExperiment }: TracesV4TabProps) => {
+  const pageContent = <TracesV4PageContent experimentId={experimentId} />;
+  const content = shouldEnableModelTraceExplorerCustomTraceView() ? (
+    <React.Suspense fallback={pageContent}>
+      <LazyExperimentCustomViewProvider key={experimentId} experimentId={experimentId}>
+        {pageContent}
+      </LazyExperimentCustomViewProvider>
+    </React.Suspense>
+  ) : (
+    pageContent
+  );
+
   return (
     <TracesV4PageWrapper resetKey={experimentId}>
       <MonitoringConfigProvider>
-        {isLoadingExperiment ? (
-          <GenericSkeleton css={{ flex: 1, margin: 16 }} />
-        ) : (
-          <TracesV4PageContent experimentId={experimentId} />
-        )}
+        {isLoadingExperiment ? <GenericSkeleton css={{ flex: 1, margin: 16 }} /> : content}
       </MonitoringConfigProvider>
     </TracesV4PageWrapper>
   );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/TracesV4Tab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/TracesV4Tab.tsx
@@ -32,7 +32,7 @@ interface TracesV4TabProps {
 export const TracesV4Tab = ({ experimentId, isLoadingExperiment }: TracesV4TabProps) => {
   const pageContent = <TracesV4PageContent experimentId={experimentId} />;
   const content = shouldEnableModelTraceExplorerCustomTraceView() ? (
-    <React.Suspense fallback={pageContent}>
+    <React.Suspense fallback={<GenericSkeleton css={{ flex: 1, margin: 16 }} />}>
       <LazyExperimentCustomViewProvider key={experimentId} experimentId={experimentId}>
         {pageContent}
       </LazyExperimentCustomViewProvider>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.test.tsx
@@ -14,6 +14,8 @@ import { COLUMN_SIZES_STORAGE_VERSION } from '../hooks/useTracesV4ColumnSizing';
 import { DENSITY_STORAGE_VERSION } from '../hooks/useTracesV4Density';
 import { setLocalStorageItem } from '@databricks/web-shared/hooks';
 import { slowlyTypeEachKey } from '@databricks/web-shared/test-utils/slowlyTypeEachKey';
+import { TracesV4Tab } from '../TracesV4Tab';
+import { renderTracesV4Page } from '../test-utils/renderTracesV4Page';
 import {
   renderPage,
   findTraceRow,
@@ -25,6 +27,7 @@ import {
   server,
   state,
   env,
+  history,
   EXPERIMENT_ID,
   URL,
   SEARCH_ENDPOINT,
@@ -373,6 +376,37 @@ describe('TracesV4PageContent', () => {
       expect(await within(drawer).findByRole('button', { name: '000' })).toBeInTheDocument();
       expect(within(drawer).queryByText('trace:/cat.sch/tr-000')).not.toBeInTheDocument();
     }, 20000); // heavy full-page userEvent render — bump off the flaky 5s default under parallel jsdom load
+
+    test('the production V4 tab provides Custom view controls in the trace drawer', async () => {
+      const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+      const trace = makeTaggedTrace('tr-000', {});
+      state.pages = { '': { traces: [trace], next_page_token: undefined } };
+      server.use(
+        rest.get('/ajax-api/2.0/mlflow/experiments/get', (_req, res, ctx) =>
+          res(ctx.json({ experiment: { experiment_id: EXPERIMENT_ID, tags: [] } })),
+        ),
+        rest.get('/ajax-api/3.0/mlflow/traces/:traceId', (_req, res, ctx) =>
+          res(ctx.json({ trace: { trace_info: trace, spans: [] } })),
+        ),
+      );
+      renderTracesV4Page({
+        initialUrl: URL,
+        routes: [
+          {
+            path: '/ml/experiments/:experimentId/traces',
+            element: <TracesV4Tab experimentId={EXPERIMENT_ID} />,
+          },
+        ],
+        history,
+        experimentId: EXPERIMENT_ID,
+      });
+
+      await user.click(await findTraceRow('tr-000'));
+
+      const drawer = await screen.findByRole('dialog');
+      await user.click(within(drawer).getByRole('button', { name: 'Default view' }));
+      expect(await screen.findByRole('menuitem', { name: 'Create custom view' })).toBeInTheDocument();
+    }, 20000);
   });
 
   describe('session column', () => {


### PR DESCRIPTION
### Related Issues/PRs

Relates to the reported Traces V4 Custom View regression.

### What changes are proposed in this pull request?

- Mount the experiment-scoped Custom View provider above the Traces V4 page when the feature is enabled.
- Show the existing skeleton while the lazy provider loads, so the interactive V4 page mounts only once beneath the provider.
- Reuse an existing Custom View definition in nested `TracesV3Logs` surfaces instead of mounting a second experiment provider.
- Add focused regressions for the Suspense lifecycle and nested-provider guard.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Automated verification:

- `TracesV4Tab.test.tsx`: the interactive page stays unmounted while the provider is suspended and mounts once when ready.
- `TracesV3Logs.test.tsx`: an outer Custom View definition prevents a nested experiment provider from mounting.
- Focused ESLint and Prettier checks.
- Frontend TypeScript type-check.

Browser verification on an unstubbed local development server:

1. Opened a V4 trace and created a Custom View.
2. Opened Detect Issues → Select Traces.
3. Closed both modals.
4. Reopened the trace and confirmed Create custom view still works.

Before:

<img width="1743" height="1304" alt="Traces V4 without Custom View controls" src="https://github.com/user-attachments/assets/1d153490-c054-477c-b936-5c204783c358" />

After:

<img width="2321" height="1334" alt="Custom View in the redesigned trace drawer" src="https://github.com/user-attachments/assets/2758c73f-d7a1-4f20-a078-a9526d25b94a" />

<img width="2311" height="1329" alt="Created Custom View in Traces V4" src="https://github.com/user-attachments/assets/0db5ae1b-8428-44bf-a15d-a809d6aab265" />

Nested Select Traces verification:

![Select Traces nested inside Issue Detection](https://github.com/user-attachments/assets/7e0b6ced-4c04-4bf5-8a04-a6345d168208)

Custom View still available after the nested modal unmounts:

![Custom View after closing Select Traces](https://github.com/user-attachments/assets/af4dcc33-5d61-4d2a-a9d8-7851d02a4636)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Restores saved Custom Views and Custom View authoring controls in the Traces V4 drawer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
