### PR TITLE
Preserve non-ASCII text in a saved promptlab model's `parameters.yaml`

### DIFF
--- a/mlflow/prompt/promptlab_model.py
+++ b/mlflow/prompt/promptlab_model.py
@@ -84,7 +84,7 @@ def _load_pyfunc(path):
 
     pyfunc_flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=pyfunc.FLAVOR_NAME)
     parameters_path = os.path.join(path, pyfunc_flavor_conf["parameters_path"])
-    with open(parameters_path) as f:
+    with open(parameters_path, encoding="utf-8") as f:
         parameters = yaml.safe_load(f)
 
         prompt_parameters_as_params = [
@@ -158,8 +158,8 @@ def save_model(
         "model_parameters": {param.key: param.value for param in model_parameters},
         "model_route": model_route,
     }
-    with open(parameters_path, "w") as f:
-        yaml.safe_dump(parameters, stream=f, default_flow_style=False)
+    with open(parameters_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(parameters, stream=f, default_flow_style=False, allow_unicode=True)
 
     pyfunc.add_to_model(
         mlflow_model,

--- a/tests/prompt/test_promptlab_model.py
+++ b/tests/prompt/test_promptlab_model.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from mlflow.deployments import set_deployments_target
 from mlflow.entities.param import Param
-from mlflow.prompt.promptlab_model import _PromptlabModel
+from mlflow.prompt.promptlab_model import _load_pyfunc, _PromptlabModel, save_model
 
 set_deployments_target("http://localhost:5000")
 
@@ -97,3 +97,25 @@ def test_promptlab_works_with_completions_route():
         response = model.predict(pd.DataFrame(data=[{"thing": "books"}]))
 
         assert response == ["test"]
+
+
+def test_save_model_preserves_non_ascii_text(tmp_path):
+    prompt_template = "{{ object }}は何色ですか"
+    model_path = tmp_path / "model"
+
+    save_model(
+        path=str(model_path),
+        prompt_template=prompt_template,
+        prompt_parameters=[Param(key="object", value="空")],
+        model_parameters=[Param(key="temperature", value=0.5)],
+        model_route="completions",
+        pip_requirements=["mlflow"],
+    )
+
+    written = (model_path / "parameters.yaml").read_text(encoding="utf-8")
+    assert prompt_template in written
+    assert r"\u" not in written
+
+    loaded = _load_pyfunc(str(model_path))
+    assert loaded.prompt_template == prompt_template
+    assert [(p.key, p.value) for p in loaded.prompt_parameters] == [("object", "空")]


### PR DESCRIPTION
### Related Issues/PRs

Closes #14785

### What changes are proposed in this pull request?

`save_model` in `mlflow/prompt/promptlab_model.py` writes the prompt template and its parameters to `parameters.yaml` with `yaml.safe_dump`, which defaults to `allow_unicode=False`. A Japanese prompt template is therefore escaped to `\uXXXX` in the saved artifact. The file is still correct — `safe_load` gives the characters back — but anybody who opens the artifact sees escapes instead of their own language, which is what the issue reports.

This adds `allow_unicode=True`, as suggested by @serena-ruan in the issue thread.

It also pins both ends of that file to UTF-8, and that half is worth a sentence because it is not cosmetic. Today the write uses `open(parameters_path, "w")` and the matching read in `_load_pyfunc` uses `open(parameters_path)`, both of which take the platform default encoding. That is harmless right now *because* of the bug: the dump is pure ASCII, so any locale can round-trip it. The moment real non-ASCII text reaches the file, a machine whose default encoding is not UTF-8 raises `UnicodeEncodeError` on save or reads mojibake on load — and that is most likely on exactly the platforms whose users run into this in the first place. Adding the flag without the encoding would swap a cosmetic problem for a functional one, so the two go together.

Not changed, and I would rather ask than assume: `create_eval_results_json` in `mlflow/utils/promptlab_utils.py` calls `json.dumps` with the default `ensure_ascii=True`, so `eval_results_table.json` carries the same escapes. That decodes correctly in any JSON reader, so it may well be deliberate. Happy to include it here if you would like it changed.

### How is this PR tested?

- [x] New unit/integration tests

`test_save_model_preserves_non_ascii_text` round-trips a Japanese prompt template and a non-ASCII parameter value through `save_model` and `_load_pyfunc`, and asserts that the characters appear in `parameters.yaml` rather than as escapes. It fails without the `allow_unicode=True` half of the change.

`tests/prompt` and `tests/utils/test_promptlab_utils.py` are green: 6 passed, against a 5-passed baseline taken on the same commit before the change — exactly the one new test. `tests/server/auth/test_auth_workspace.py` and `tests/tracking/test_rest_tracking.py` also mention promptlab, but they exercise the run-creation handler and its permission validators through `promptlab_utils`, not the two functions touched here.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Prompt templates and parameters containing non-ASCII text are now stored as those characters in a saved promptlab model's `parameters.yaml`, instead of being escaped.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
