### PR TITLE
fix: Prevent Table 'secrets' already exists during DB upgrade (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -70,11 +70,24 @@ def _all_tables_exist(engine):
     # Using issubset() instead of equality so that additional tables added by migrations
     # don't cause this check to fail. This prevents unnecessary calls to _initialize_tables
     # which can cause migration errors like "Can't locate revision identified by 'xxx'".
+    #
+    # However, if the DB already has tables but its schema is out of date (e.g., the
+    # 'secrets' table exists from an older migration), we must not skip initialization.
+    # Compare the current Alembic head to the latest revision. If they differ,
+    # the tables are present but stale, so return False to force migration.
     expected_tables = set(Base.metadata.tables)
     actual_tables = {
         t for t in sqlalchemy.inspect(engine).get_table_names() if not t.startswith("alembic_")
     }
-    return expected_tables.issubset(actual_tables)
+    if not expected_tables.issubset(actual_tables):
+        return False
+    try:
+        current_rev = _get_current_schema_revision(engine)
+        latest_rev = _get_latest_schema_revision()
+        return current_rev == latest_rev
+    except Exception as e:
+        _logger.warning("Failed to compare schema revisions, assuming tables are stale: %s", e)
+        return False
 
 
 def _is_empty_database(engine):


### PR DESCRIPTION
## What

Running `mlflow db upgrade` after upgrading from 3.7.0 to 3.8.x fails on MySQL with `(1050, "Table 'secrets' already exists")`. This happens because `_all_tables_exist()` only checks that all ORM tables are physically present, ignoring the database schema version. Since the `secrets` table already exists from previous migrations, `_initialize_tables()` is skipped, and then Alembic runs a migration that tries to create it again.

## Fix

Make `_all_tables_exist()` schema-aware. After confirming all expected tables are physically present, it now compares the database's current Alembic schema revision against the latest revision packaged with MLflow. If they differ, the function returns `False`, forcing `_initialize_tables()` to run the proper migration path. This prevents the duplicate table creation error and ensures upgrades proceed correctly.

## Changes

- In `mlflow/store/db/utils.py`, update `_all_tables_exist()` to compare `_get_current_schema_revision(engine)` with `_get_latest_schema_revision()`.
- Add a safety fallback: if revision comparison fails, assume the schema is stale to avoid skipping necessary migrations.

Closes #19943