### PR TITLE
Add agent hints for GenAI anti-patterns

### DIFF
--- a/mlflow/agent/hint.py
+++ b/mlflow/agent/hint.py
@@ -1,4 +1,4 @@
-"""An agent-directed pointer to the MLflow tracing skill.
+"""Agent-directed pointers to the bundled MLflow skills.
 
 Emitted on ``import mlflow`` when a coding agent is driving. Whether the skill
 is already installed is deliberately not probed: skills end up in too many
@@ -61,6 +61,11 @@ _AGENT_ENV_VALUES_WITHOUT_TTY = {"TERM_PROGRAM": "kiro"}
 # Lives in https://github.com/mlflow/skills and is installed by `mlflow agent setup`.
 TRACING_SKILL = "instrumenting-with-mlflow-tracing"
 
+# All hints in this module are process-local. An agent only needs to see a
+# particular problem once to change course; repeating it on every span or row
+# makes the useful message indistinguishable from ordinary logs.
+_EMITTED_HINTS: set[str] = set()
+
 # Points at the copy shipped inside this MLflow install: no network, and the
 # revision always matches the installed code.
 #
@@ -115,3 +120,33 @@ def maybe_hint_tracing_skill() -> None:
     if (path := _bundled_skill_manifest()) is None:
         return
     _logger.info(_HINT.format(skill=TRACING_SKILL, path=path))
+
+
+def maybe_warn_agent(issue_id: str, issue: str) -> None:
+    """Warn a coding agent about an observed GenAI anti-pattern once per process.
+
+    The warning deliberately points at the bundled skills collection instead of
+    choosing a skill for the agent. Detectors describe only the concrete issue
+    they observed and leave routing to the installed skills.
+    """
+    if issue_id in _EMITTED_HINTS or MLFLOW_DISABLE_AGENT_HINT.get() or not _is_agent_driving():
+        return
+
+    try:
+        skills = resources.files("mlflow.assistant.skills")
+        readme = skills.joinpath("README.md")
+        if not readme.is_file():
+            return
+        skills_path = Path(str(readme)).parent
+    except Exception:
+        # Hints are advisory and must never affect the operation that detected
+        # the issue, including unusual import loaders and packaged installs.
+        return
+
+    _EMITTED_HINTS.add(issue_id)
+    _logger.warning(
+        "%s Review the MLflow skills bundled at %s before continuing. "
+        "Set MLFLOW_DISABLE_AGENT_HINT=1 to silence this.",
+        issue,
+        skills_path,
+    )

--- a/mlflow/agent/hint.py
+++ b/mlflow/agent/hint.py
@@ -150,3 +150,30 @@ def maybe_warn_agent(issue_id: str, issue: str) -> None:
         issue,
         skills_path,
     )
+
+
+def maybe_warn_local_tracking_for_databricks() -> None:
+    """Warn when a GenAI trace is going to local storage despite Databricks intent."""
+    if MLFLOW_DISABLE_AGENT_HINT.get() or not _is_agent_driving():
+        return
+
+    try:
+        from mlflow import get_tracking_uri
+        from mlflow.utils.databricks_utils import is_in_databricks_runtime
+        from mlflow.utils.uri import is_local_uri
+
+        has_databricks_intent = (
+            is_in_databricks_runtime()
+            or bool(os.environ.get("DATABRICKS_HOST"))
+            or bool(os.environ.get("DATABRICKS_CONFIG_PROFILE"))
+        )
+        tracking_uri = get_tracking_uri()
+        if has_databricks_intent and is_local_uri(tracking_uri):
+            maybe_warn_agent(
+                "databricks-intent-with-local-tracking",
+                f"A GenAI trace is being written to the local tracking URI {tracking_uri!r} even "
+                "though a Databricks environment or profile is configured.",
+            )
+    except Exception:
+        # This check is advisory and must never interfere with trace export.
+        return

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -1142,6 +1142,24 @@ class LiveSpan(Span):
             if self.status.status_code != SpanStatusCode.ERROR:
                 self.set_status(SpanStatus(SpanStatusCode.OK))
 
+            if self.span_type in (SpanType.LLM, SpanType.TOOL, SpanType.RETRIEVER):
+                # Import lazily: most MLflow users never create GenAI spans, and
+                # agent hints must not add work to their span lifecycle.
+                from mlflow.agent.hint import maybe_warn_agent
+
+                if self.inputs is None:
+                    maybe_warn_agent(
+                        "genai-span-missing-inputs",
+                        f"The successful {self.span_type} span {self.name!r} has no recorded "
+                        "inputs.",
+                    )
+                if self.outputs is None:
+                    maybe_warn_agent(
+                        "genai-span-missing-outputs",
+                        f"The successful {self.span_type} span {self.name!r} has no recorded "
+                        "outputs.",
+                    )
+
             if should_compute_cost_client_side():
                 set_span_cost_attribute(self)
 

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -1145,7 +1145,12 @@ class LiveSpan(Span):
             if self.span_type in (SpanType.LLM, SpanType.TOOL, SpanType.RETRIEVER):
                 # Import lazily: most MLflow users never create GenAI spans, and
                 # agent hints must not add work to their span lifecycle.
-                from mlflow.agent.hint import maybe_warn_agent
+                from mlflow.agent.hint import (
+                    maybe_warn_agent,
+                    maybe_warn_local_tracking_for_databricks,
+                )
+
+                maybe_warn_local_tracking_for_databricks()
 
                 if self.inputs is None:
                     maybe_warn_agent(

--- a/mlflow/genai/scorers/aggregation.py
+++ b/mlflow/genai/scorers/aggregation.py
@@ -83,6 +83,14 @@ def _cast_assessment_value_to_float(assessment: Feedback) -> float | None:
         and CategoricalRating(assessment.value.lower()) != CategoricalRating.UNKNOWN
     ):
         return float(assessment.value.lower() == CategoricalRating.YES)
+    elif isinstance(assessment.value, str):
+        from mlflow.agent.hint import maybe_warn_agent
+
+        maybe_warn_agent(
+            "non-aggregatable-scorer-string",
+            f"Scorer {assessment.name!r} returned {assessment.value!r}, which is not included in "
+            "aggregated metrics; return a boolean, number, or 'yes'/'no' instead.",
+        )
 
 
 def _compute_aggregations(

--- a/mlflow/genai/scorers/aggregation.py
+++ b/mlflow/genai/scorers/aggregation.py
@@ -83,11 +83,11 @@ def _cast_assessment_value_to_float(assessment: Feedback) -> float | None:
         and CategoricalRating(assessment.value.lower()) != CategoricalRating.UNKNOWN
     ):
         return float(assessment.value.lower() == CategoricalRating.YES)
-    elif isinstance(assessment.value, str):
+    elif assessment.value is not None:
         from mlflow.agent.hint import maybe_warn_agent
 
         maybe_warn_agent(
-            "non-aggregatable-scorer-string",
+            "non-aggregatable-scorer-output",
             f"Scorer {assessment.name!r} returned {assessment.value!r}, which is not included in "
             "aggregated metrics; return a boolean, number, or 'yes'/'no' instead.",
         )

--- a/mlflow/genai/utils/data_validation.py
+++ b/mlflow/genai/utils/data_validation.py
@@ -45,6 +45,7 @@ def _validate_function_and_input_compatibility(
     """
     params = inspect.signature(predict_fn).parameters
     if not params:
+        _warn_predict_fn_signature_mismatch()
         raise MlflowException.invalid_parameter_value(
             "`predict_fn` must accept at least one argument."
         ) from e
@@ -71,6 +72,8 @@ def _has_variable_positional_arguments(params: inspect.Signature) -> bool:
 def _validate_no_var_args(params: inspect.Signature, e: Exception):
     if not any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params.values()):
         return
+
+    _warn_predict_fn_signature_mismatch()
 
     """Raise an error for functions using *args which aren't supported."""
     code_sample = """```python
@@ -106,6 +109,8 @@ def _validate_input_keys_match_function_params(
 ):
     if _has_required_keyword_arguments(params, input_keys):
         return
+
+    _warn_predict_fn_signature_mismatch()
 
     """Raise an error when input keys don't match function parameters."""
     param_names = list(params.keys())
@@ -146,3 +151,13 @@ def _has_required_keyword_arguments(params: inspect.Signature, required_args: li
 
     # Required argument must be a subset of the function's arguments
     return set(required_args) <= set(func_args)
+
+
+def _warn_predict_fn_signature_mismatch() -> None:
+    from mlflow.agent.hint import maybe_warn_agent
+
+    maybe_warn_agent(
+        "genai-evaluate-predict-fn-signature-mismatch",
+        "The evaluation predict_fn signature does not match the dataset input keys; MLflow "
+        "unpacks each inputs dictionary as keyword arguments.",
+    )

--- a/mlflow/models/evaluation/deprecated.py
+++ b/mlflow/models/evaluation/deprecated.py
@@ -6,6 +6,21 @@ from mlflow.models.evaluation import evaluate as model_evaluate
 
 @functools.wraps(model_evaluate)
 def evaluate(*args, **kwargs):
+    model_type = kwargs.get("model_type")
+    if model_type in {
+        "question-answering",
+        "text-summarization",
+        "text",
+        "retriever",
+        "databricks-agent",
+    }:
+        from mlflow.agent.hint import maybe_warn_agent
+
+        maybe_warn_agent(
+            "legacy-genai-evaluate",
+            "The deprecated mlflow.evaluate API is being used for a GenAI model; "
+            "mlflow.genai.evaluate is the current API.",
+        )
     warnings.warn(
         "The `mlflow.evaluate` API has been deprecated as of MLflow 3.0.0. "
         "Please use these new alternatives:\n\n"

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -192,6 +192,16 @@ def deprecated(alternative: str | None = None, since: str | None = None, impact:
 
             @wraps(obj)
             def deprecated_func(*args, **kwargs):
+                if (
+                    impact and "genai/eval-monitor/legacy-llm-evaluation" in impact
+                ) or alternative == "mlflow.genai.make_judge":
+                    from mlflow.agent.hint import maybe_warn_agent
+
+                    maybe_warn_agent(
+                        "deprecated-genai-metric-or-judge",
+                        f"The deprecated GenAI API {qual_name} is being used; use current MLflow "
+                        "scorers or mlflow.genai.make_judge instead.",
+                    )
                 warnings.warn(notice, category=FutureWarning, stacklevel=2)
                 return obj(*args, **kwargs)
 

--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -462,7 +462,20 @@ def autologging_integration(name):
             ):
                 _check_and_log_warning_for_unsupported_package_versions(name)
 
-                return _autolog(*args, **kwargs)
+                try:
+                    return _autolog(*args, **kwargs)
+                except Exception:
+                    from mlflow.ml_package_versions import GENAI_FLAVOR_TO_MODULE_NAME
+
+                    if name in GENAI_FLAVOR_TO_MODULE_NAME:
+                        from mlflow.agent.hint import maybe_warn_agent
+
+                        maybe_warn_agent(
+                            "genai-autologging-initialization-failed",
+                            f"MLflow {name} autologging failed to initialize; enabling autologging "
+                            "after framework or client setup can prevent tracing.",
+                        )
+                    raise
 
         wrapped_autolog = update_wrapper_extended(autolog, _autolog)
         # Set the autologging integration name as a function attribute on the wrapped autologging

--- a/tests/agent/test_hint.py
+++ b/tests/agent/test_hint.py
@@ -22,6 +22,7 @@ def clean_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     ):
         monkeypatch.delenv(marker, raising=False)
     monkeypatch.delenv("MLFLOW_DISABLE_AGENT_HINT", raising=False)
+    hint._EMITTED_HINTS.clear()
 
     home = tmp_path / "home"
     home.mkdir()
@@ -145,3 +146,22 @@ def test_detects_agents_absent_from_the_setup_registry(
     assert "cursor" not in AGENTS
     monkeypatch.setenv("CURSOR_AGENT", "1")
     assert hint_message() is not None
+
+
+def test_antipattern_warning_names_issue_and_is_emitted_once(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("CLAUDECODE", "1")
+
+    with mock.patch.object(hint._logger, "warning") as warning:
+        hint.maybe_warn_agent("missing-inputs", "A tool span has no inputs.")
+        hint.maybe_warn_agent("missing-inputs", "A different instance has no inputs.")
+
+    warning.assert_called_once()
+    assert warning.call_args.args[1] == "A tool span has no inputs."
+    assert "different instance" not in str(warning.call_args)
+
+
+def test_antipattern_warning_is_silent_for_humans(clean_env: Path, caplog):
+    hint.maybe_warn_agent("missing-inputs", "A tool span has no inputs.")
+    assert not caplog.records

--- a/tests/agent/test_hint.py
+++ b/tests/agent/test_hint.py
@@ -165,3 +165,35 @@ def test_antipattern_warning_names_issue_and_is_emitted_once(
 def test_antipattern_warning_is_silent_for_humans(clean_env: Path, caplog):
     hint.maybe_warn_agent("missing-inputs", "A tool span has no inputs.")
     assert not caplog.records
+
+
+@pytest.mark.parametrize("intent_var", ["DATABRICKS_HOST", "DATABRICKS_CONFIG_PROFILE"])
+def test_local_tracking_warns_when_databricks_is_configured(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, intent_var: str
+):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv(intent_var, "configured")
+
+    with (
+        mock.patch("mlflow.get_tracking_uri", return_value="file:///tmp/mlruns"),
+        mock.patch("mlflow.agent.hint.maybe_warn_agent") as warn,
+    ):
+        hint.maybe_warn_local_tracking_for_databricks()
+
+    warn.assert_called_once_with(
+        "databricks-intent-with-local-tracking",
+        "A GenAI trace is being written to the local tracking URI 'file:///tmp/mlruns' even "
+        "though a Databricks environment or profile is configured.",
+    )
+
+
+def test_local_tracking_check_ignores_human_and_remote_tracking(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("DATABRICKS_HOST", "https://example.databricks.com")
+    with mock.patch("mlflow.agent.hint.maybe_warn_agent") as warn:
+        hint.maybe_warn_local_tracking_for_databricks()
+        monkeypatch.setenv("CLAUDECODE", "1")
+        with mock.patch("mlflow.get_tracking_uri", return_value="databricks"):
+            hint.maybe_warn_local_tracking_for_databricks()
+    warn.assert_not_called()

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -509,6 +509,28 @@ def test_autologging_integration_makes_expected_event_logging_calls():
     assert call.call_kwargs == {"biz": 82, "baz": "val", "disable": False, "silent": True}
 
 
+def test_failed_genai_autologging_warns_agent():
+    @autologging_integration("test_genai")
+    def autolog(disable=False, silent=False):
+        raise RuntimeError("patch failed")
+
+    with (
+        mock.patch.dict(
+            "mlflow.ml_package_versions.GENAI_FLAVOR_TO_MODULE_NAME",
+            {"test_genai": "test_genai"},
+        ),
+        mock.patch("mlflow.agent.hint.maybe_warn_agent") as warn,
+        pytest.raises(RuntimeError, match="patch failed"),
+    ):
+        autolog()
+
+    warn.assert_called_once_with(
+        "genai-autologging-initialization-failed",
+        "MLflow test_genai autologging failed to initialize; enabling autologging after framework "
+        "or client setup can prevent tracing.",
+    )
+
+
 @pytest.mark.usefixtures(test_mode_off.__name__)
 def test_autologging_integration_succeeds_when_event_logging_throws_in_standard_mode():
     @autologging_integration("test")

--- a/tests/evaluate/test_deprecated.py
+++ b/tests/evaluate/test_deprecated.py
@@ -21,6 +21,19 @@ def test_global_evaluate_warn_in_tracking_uri(tracking_uri):
             )
 
 
+def test_global_evaluate_hints_for_genai_model_type():
+    with (
+        patch("mlflow.agent.hint.maybe_warn_agent") as warn,
+        # Patch the implementation because this test only covers dispatch from
+        # the deprecated public entry point.
+        patch("mlflow.models.evaluation.deprecated.model_evaluate"),
+        pytest.warns(FutureWarning, match="The `mlflow.evaluate` API has been deprecated"),
+    ):
+        mlflow.evaluate(data=_TEST_DATA, model_type="question-answering")
+
+    warn.assert_called_once()
+
+
 @contextmanager
 def no_future_warning():
     with warnings.catch_warnings():

--- a/tests/genai/scorers/test_aggregation.py
+++ b/tests/genai/scorers/test_aggregation.py
@@ -122,14 +122,15 @@ def test_cast_numeric_values(value, expected_float):
     assert _cast_assessment_value_to_float(assessment) == expected_float
 
 
-def test_non_aggregatable_string_warns_agent():
-    assessment = Feedback(name="quality", value="pass")
+@pytest.mark.parametrize("value", ["pass", ["good", "safe"], {"rating": "good"}])
+def test_non_aggregatable_output_warns_agent(value):
+    assessment = Feedback(name="quality", value=value)
 
     with mock.patch("mlflow.agent.hint.maybe_warn_agent") as warn:
         assert _cast_assessment_value_to_float(assessment) is None
 
     warn.assert_called_once_with(
-        "non-aggregatable-scorer-string",
-        "Scorer 'quality' returned 'pass', which is not included in aggregated metrics; return a "
-        "boolean, number, or 'yes'/'no' instead.",
+        "non-aggregatable-scorer-output",
+        f"Scorer 'quality' returned {value!r}, which is not included in aggregated metrics; "
+        "return a boolean, number, or 'yes'/'no' instead.",
     )

--- a/tests/genai/scorers/test_aggregation.py
+++ b/tests/genai/scorers/test_aggregation.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from mlflow.entities.assessment import Feedback
@@ -118,3 +120,16 @@ def test_compute_aggregated_metrics_with_namespace():
 def test_cast_numeric_values(value, expected_float):
     assessment = Feedback(name="test", value=value)
     assert _cast_assessment_value_to_float(assessment) == expected_float
+
+
+def test_non_aggregatable_string_warns_agent():
+    assessment = Feedback(name="quality", value="pass")
+
+    with mock.patch("mlflow.agent.hint.maybe_warn_agent") as warn:
+        assert _cast_assessment_value_to_float(assessment) is None
+
+    warn.assert_called_once_with(
+        "non-aggregatable-scorer-string",
+        "Scorer 'quality' returned 'pass', which is not included in aggregated metrics; return a "
+        "boolean, number, or 'yes'/'no' instead.",
+    )

--- a/tests/genai/utils/test_data_validation.py
+++ b/tests/genai/utils/test_data_validation.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 import mlflow
@@ -156,6 +158,23 @@ data = [
 ]
 """
     assert _extract_code_example(e.value) == code_example
+
+
+def test_predict_fn_signature_mismatch_warns_agent():
+    def fn(question: str):
+        return "response"
+
+    with (
+        mock.patch("mlflow.agent.hint.maybe_warn_agent") as warn,
+        pytest.raises(MlflowException, match="parameter names"),
+    ):
+        check_model_prediction(fn, {"query": "What is MLflow?"})
+
+    warn.assert_called_once_with(
+        "genai-evaluate-predict-fn-signature-mismatch",
+        "The evaluation predict_fn signature does not match the dataset input keys; MLflow "
+        "unpacks each inputs dictionary as keyword arguments.",
+    )
 
 
 def test_check_model_prediction_unmatched_keys_with_many_args():

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -822,6 +822,23 @@ def test_start_span_context_manager(async_logging_enabled):
     assert child_span_2.start_time_ns <= child_span_2.end_time_ns - 0.1 * 1e6
 
 
+def test_successful_genai_span_without_inputs_or_outputs_warns_agent(async_logging_enabled):
+    with mock.patch("mlflow.agent.hint.maybe_warn_agent") as warn:
+        with mlflow.start_span(name="empty_tool", span_type=SpanType.TOOL):
+            pass
+
+    assert warn.call_args_list == [
+        mock.call(
+            "genai-span-missing-inputs",
+            "The successful TOOL span 'empty_tool' has no recorded inputs.",
+        ),
+        mock.call(
+            "genai-span-missing-outputs",
+            "The successful TOOL span 'empty_tool' has no recorded outputs.",
+        ),
+    ]
+
+
 @pytest.mark.skipif(
     IS_TRACING_SDK_ONLY, reason="Skipping test because mlflow or mlflow-skinny is not installed."
 )

--- a/tests/utils/test_annotations.py
+++ b/tests/utils/test_annotations.py
@@ -1,5 +1,6 @@
 import re
 from dataclasses import dataclass, fields
+from unittest import mock
 
 import pytest
 
@@ -122,6 +123,25 @@ def test_deprecated_function():
     docstring = function.__doc__
     assert docstring is not None
     assert msg in docstring
+
+
+def test_deprecated_genai_api_warns_agent():
+    @deprecated(alternative="mlflow.genai.make_judge")
+    def legacy_judge():
+        return "judge"
+
+    with (
+        mock.patch("mlflow.agent.hint.maybe_warn_agent") as warn,
+        pytest.warns(FutureWarning, match="legacy_judge.*deprecated"),
+    ):
+        assert legacy_judge() == "judge"
+
+    warn.assert_called_once_with(
+        "deprecated-genai-metric-or-judge",
+        "The deprecated GenAI API tests.utils.test_annotations."
+        "test_deprecated_genai_api_warns_agent.<locals>.legacy_judge is being used; use current "
+        "MLflow scorers or mlflow.genai.make_judge instead.",
+    )
 
 
 def test_empty_docstring():


### PR DESCRIPTION
### What changes are proposed in this pull request?

Extends the coding-agent hint infrastructure with once-per-process warnings for high-confidence GenAI anti-patterns:

- successful LLM, tool, or retriever spans that omit inputs or outputs
- scorer values that cannot be included in aggregated metrics
- deprecated `mlflow.evaluate` usage with a GenAI model type
- deprecated GenAI metrics and judges
- Databricks configuration or runtime intent combined with a local tracking URI
- failed GenAI autologging initialization, including failures caused by late framework or client setup
- evaluation `predict_fn` signatures that do not match dataset input keys

Warnings are emitted only when MLflow detects that a coding agent is driving the process. Each warning names the observed issue and points the agent to the MLflow skills bundled with the installed package. Human-driven processes remain silent, and `MLFLOW_DISABLE_AGENT_HINT=1` disables all hints.

### How is this PR tested?

- Added unit tests for agent detection, deduplication, human-process suppression, and each detector.
- Ran 88 dependency-light tests covering the hint infrastructure, scorer aggregation, prediction validation, and deprecation annotations.
- Ran the complete `tests/tracing/test_fluent.py` suite.
- Ran focused autologging tests; the full autologging file requires optional framework dependencies unavailable locally.
- Ran Ruff and Clint on all changed files.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the MLflow Skills repository?

- [x] No.

### Release Notes

When a coding agent uses certain problematic GenAI patterns, MLflow now emits a one-time warning describing the issue and pointing to the bundled MLflow skills. Human users are unaffected.
