### PR TITLE
Fix `IndexError` in `merge_records` after `to_dict`/`to_df` on empty `EvaluationDataset`

### DIFF
--- a/mlflow/entities/evaluation_dataset.py
+++ b/mlflow/entities/evaluation_dataset.py
@@ -415,7 +415,7 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
             DatasetGranularity based on existing records, or UNKNOWN if empty/unparseable
         """
         if self._schema is None:
-            if self.has_records():
+            if self.has_records() and self.records:
                 return self._classify_input_fields(set(self.records[0].inputs.keys()))
             return DatasetGranularity.UNKNOWN
         try:

--- a/mlflow/entities/evaluation_dataset.py
+++ b/mlflow/entities/evaluation_dataset.py
@@ -415,8 +415,8 @@ class EvaluationDataset(_MlflowObject, Dataset, PyFuncConvertibleDatasetMixin):
             DatasetGranularity based on existing records, or UNKNOWN if empty/unparseable
         """
         if self._schema is None:
-            if self.has_records() and self.records:
-                return self._classify_input_fields(set(self.records[0].inputs.keys()))
+            if self._records:
+                return self._classify_input_fields(set(self._records[0].inputs.keys()))
             return DatasetGranularity.UNKNOWN
         try:
             schema = json.loads(self._schema)

--- a/tests/entities/test_evaluation_dataset.py
+++ b/tests/entities/test_evaluation_dataset.py
@@ -770,6 +770,8 @@ def test_validate_schema_with_empty_records_after_to_dict():
 
     mock_store = Mock()
     mock_store.upsert_dataset_records.return_value = None
+    # schema=None forces _get_existing_granularity into the _records branch under test
+    mock_store.get_dataset.return_value.schema = None
 
     with patch("mlflow.tracking._tracking_service.utils._get_store", return_value=mock_store):
         dataset.merge_records([new_record])

--- a/tests/entities/test_evaluation_dataset.py
+++ b/tests/entities/test_evaluation_dataset.py
@@ -744,3 +744,34 @@ def test_delete_records():
     )
     # Verify cache was cleared
     assert dataset._records is None
+
+
+def test_validate_schema_with_empty_records_after_to_dict():
+    """Regression test for https://github.com/mlflow/mlflow/issues/25490.
+
+    to_dict()/to_df() sets _records=[] on an empty dataset. A subsequent
+    merge_records() call must not raise IndexError in _get_existing_granularity().
+    """
+    dataset = EvaluationDataset(
+        dataset_id="dataset123",
+        name="test_dataset",
+        digest="digest123",
+        created_time=123456789,
+        last_update_time=123456789,
+    )
+
+    # Simulate the state after to_dict()/to_df() on an empty dataset
+    dataset._records = []
+
+    new_record = {
+        "inputs": {"question": "What is the capital of France?"},
+        "expectations": {"name": "expected_answer", "value": "Paris"},
+    }
+
+    mock_store = Mock()
+    mock_store.upsert_dataset_records.return_value = None
+
+    with patch("mlflow.tracking._tracking_service.utils._get_store", return_value=mock_store):
+        dataset.merge_records([new_record])
+
+    mock_store.upsert_dataset_records.assert_called_once()


### PR DESCRIPTION
### Related Issues/PRs

Closes #25490

### What changes are proposed in this pull request?

`_get_existing_granularity()` uses `has_records()` to decide whether to inspect `self.records[0]` for granularity classification. `has_records()` is intentionally documented as "records are loaded (not `None`)" — it returns `True` for an empty list `[]`, since an empty-but-loaded state is a valid and distinct state from unloaded (`None`). The bug is that `_get_existing_granularity()` treated `has_records()` as a proxy for "there is at least one record to read," then unconditionally accessed `records[0]`, crashing with `IndexError` when the list was empty.

The empty-list state is reached by calling `to_dict()` or `to_df()` on a dataset that has no records: both methods eagerly populate `_records = []` from the store. A subsequent `merge_records()` call then hits the crash.

Fix: add a truthiness check on `self.records` alongside `has_records()` in `_get_existing_granularity()`, so an empty loaded list falls through to `DatasetGranularity.UNKNOWN` as intended.

- `mlflow/entities/evaluation_dataset.py`: change `if self.has_records():` to `if self.has_records() and self.records:` in `_get_existing_granularity()`
- `tests/entities/test_evaluation_dataset.py`: add regression test reproducing the exact scenario from the issue (`_records = []` → `merge_records([new_record])` must not raise)

### How is this PR tested?

- [x] New unit/integration tests
- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `IndexError: list index out of range` raised by `EvaluationDataset.merge_records()` after `to_dict()` or `to_df()` had been called on an empty dataset.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release