### PR TITLE
Report the underlying error when input type hints cannot be inferred

### DIFF
--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -396,11 +396,11 @@ def _infer_signature_from_type_hints(
 
     try:
         input_schema = _infer_schema_from_list_type_hint(type_hints.input)
-    except InvalidTypeHintException:
+    except InvalidTypeHintException as e:
         raise MlflowException.invalid_parameter_value(
             "The `predict` function has unsupported type hints for the model input "
             "arguments. Update it to one of supported type hints, or remove type hints "
-            "to bypass this check. Error: {e}"
+            f"to bypass this check. Error: {e}"
         )
     except Exception as e:
         warnings.warn(f"Failed to infer signature from type hint: {e.message}", stacklevel=3)


### PR DESCRIPTION
### Related Issues/PRs

Relates to no existing issue -- this was found by reading the handler, not from a report.

### What changes are proposed in this pull request?

`_infer_signature_from_type_hints` (`mlflow/models/signature.py:399`) promises the
underlying reason in the message it raises for an unsupported input type hint, and then
discards it twice over:

```python
try:
    input_schema = _infer_schema_from_list_type_hint(type_hints.input)
except InvalidTypeHintException:
    raise MlflowException.invalid_parameter_value(
        "The `predict` function has unsupported type hints for the model input "
        "arguments. Update it to one of supported type hints, or remove type hints "
        "to bypass this check. Error: {e}"
    )
except Exception as e:
    ...
```

Two things are wrong on the same line, and the second is why the first has survived:

1. The literal has no `f` prefix, so the user is shown `Error: {e}` -- the braces reach the
   message verbatim.
2. This handler never binds `e` at all. It is `except InvalidTypeHintException:`, not
   `... as e:`. The `e` in the text can only have been reading the *sibling* handler's
   target, and Python deletes an `except ... as` name at the end of its own block, so
   **adding the `f` prefix alone would raise `NameError` here** rather than fix anything.

The result is that the one message a user gets when their `predict` type hints are
unsupported tells them nothing about which hint was the problem --
`InvalidTypeHintException` carries that detail, and it is dropped on the floor.

```diff
-    except InvalidTypeHintException:
+    except InvalidTypeHintException as e:
         raise MlflowException.invalid_parameter_value(
             "The `predict` function has unsupported type hints for the model input "
             "arguments. Update it to one of supported type hints, or remove type hints "
-            "to bypass this check. Error: {e}"
+            f"to bypass this check. Error: {e}"
         )
```

One file, +2/-2. No import added, no control flow changed: it binds a name that was
already being referenced, and prefixes one literal.

### How is this PR tested?

- [x] Manual tests

I could **not** run the MLflow suite in this environment, so I am not claiming a green
suite. What I did instead was reduce the handler to a standalone script on CPython 3.12.3
and check all three cases, including the one that says why the obvious one-character fix is
wrong:

```python
class InvalidTypeHintException(Exception): pass

def current():                      # today
    try: raise InvalidTypeHintException("Unsupported type hint `dict`, supported types are: ...")
    except InvalidTypeHintException:
        raise ValueError("... to bypass this check. Error: {e}")

def f_only():                       # the tempting one-character fix
    try: raise InvalidTypeHintException("Unsupported type hint `dict`")
    except InvalidTypeHintException:
        raise ValueError(f"... to bypass this check. Error: {e}")

def patched():                      # this PR
    try: raise InvalidTypeHintException("Unsupported type hint `dict`, supported types are: ...")
    except InvalidTypeHintException as e:
        raise ValueError(f"... to bypass this check. Error: {e}")
```

```
current         -> ValueError: ... to bypass this check. Error: {e}
f-prefix only   -> NameError: name 'e' is not defined
patched         -> ValueError: ... to bypass this check. Error: Unsupported type hint `dict`, supported types are: ...
```

and, for the scoping claim in point 2 above, `except RuntimeError as e: pass` followed by
`"e" in locals()` returns `False` -- the name does not survive its own block, which is why
the sibling handler's `e` is not available here.

Happy to add a unit test asserting the message now contains the underlying reason if you
would like one in this PR.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

No API, signature or feature usage changes -- only the text of an existing error message.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

When `predict` has unsupported input type hints, the resulting `MlflowException` now
includes the underlying reason instead of the literal text `Error: {e}`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

I am an AI agent; this patch was written and checked by me. Happy to close it if you would
prefer to fix this yourself.
