### PR TITLE
Rename the `/review` trigger to `/rv`

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -34,7 +34,8 @@ jobs:
       head_sha: ${{ steps.head.outputs.head_sha }}
     # Cheap author_association prefilter so random users can't spawn workflow
     # runs. The gate step below does the authoritative admin/maintain role
-    # check.
+    # check. The command is matched exactly or with a trailing space, so a
+    # future `/rv-*` command is not swallowed by this one.
     if: >
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository &&
@@ -45,8 +46,8 @@ jobs:
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
-       startsWith(github.event.comment.body, '/review') &&
-       !startsWith(github.event.comment.body, '/review-'))
+       (github.event.comment.body == '/rv' ||
+        startsWith(github.event.comment.body, '/rv ')))
     steps:
       - name: Check user permission
         env:
@@ -287,7 +288,7 @@ jobs:
           big = bool(labels & {"size/M", "size/L", "size/XL"})
           default_model = "claude-opus-5" if big else "claude-sonnet-5"
 
-          body = sys.stdin.read().removeprefix("/review")
+          body = sys.stdin.read().removeprefix("/rv")
 
           parser = argparse.ArgumentParser(add_help=False)
           parser.add_argument("-m", "--model", choices=MODEL_CHOICES, default=default_model)
@@ -568,7 +569,7 @@ jobs:
         env:
           JOB_STATUS: ${{ job.status }}
           MODEL: ${{ steps.prompt.outputs.model }}
-          COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '/review' }}
+          COMMENT_BODY: ${{ github.event_name == 'issue_comment' && github.event.comment.body || '/rv' }}
         run: |
           node <<'JS'
           const fs = require('fs');


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25486

### What changes are proposed in this pull request?

Renames the PR review trigger comment from `/review` to `/rv`, matching the terse style `/cvt` already uses. Arguments are unchanged: `/rv -m opus -e max`.

The command is now matched exactly or with a trailing space rather than by prefix, so a future `/rv-*` command cannot be swallowed by this one. That also replaces the `!startsWith('/review-')` exclusion, which existed only to keep this workflow off `nailaopus.yml`'s `/review-v2`.

`ui-review.yml` has a comment referring to "the /review command" that is now stale. Left alone to keep this to one file.

### How is this PR tested?

- [x] Manual tests

The `pull_request` trigger on this workflow smoke-tests itself, so this PR runs the renamed gate end-to-end. Locally: the YAML parses, the gate expression's parentheses balance, and the arg parser returns the right model/effort for `/rv`, `/rv -e max`, `/rv --model opus -e low`, the `size/L` opus default, and the empty body the smoke path feeds it.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release