### PR TITLE
Add willingness-to-contribute question to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.yaml
@@ -193,7 +193,7 @@ body:
     id: contribution
     attributes:
       label: Willingness to contribute
-      description: The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix for this bug to the MLflow code base?
+      description: The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix for this bug to the MLflow code base? The "No" option is perfectly valid — this question helps maintainers prioritize and find volunteer contributors, not to block submissions.
       options:
         - Yes. I can contribute a fix for this bug independently.
         - Yes. I would be willing to contribute a fix for this bug with guidance from the MLflow community.

--- a/.github/ISSUE_TEMPLATE/bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.yaml
@@ -189,6 +189,17 @@ body:
 
     validations:
       required: false
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Willingness to contribute
+      description: The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix for this bug to the MLflow code base?
+      options:
+        - Yes. I can contribute a fix for this bug independently.
+        - Yes. I would be willing to contribute a fix for this bug with guidance from the MLflow community.
+        - No. I cannot contribute a bug fix at this time.
+    validations:
+      required: true
   - type: checkboxes
     id: component
     attributes:

--- a/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/ui_bug_report_template.yaml
@@ -96,6 +96,17 @@ body:
           at Tl (react-dom.production.min.js:250:347)
         ```
 
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Willingness to contribute
+      description: The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix for this bug to the MLflow code base? The "No" option is perfectly valid — this question helps maintainers prioritize and find volunteer contributors, not to block submissions.
+      options:
+        - Yes. I can contribute a fix for this bug independently.
+        - Yes. I would be willing to contribute a fix for this bug with guidance from the MLflow community.
+        - No. I cannot contribute a bug fix at this time.
+    validations:
+      required: true
   - type: textarea
     validations:
       required: true


### PR DESCRIPTION
### Related Issues/PRs

Relates to #issue_number

### What changes are proposed in this pull request?

Adds a **Willingness to contribute** dropdown to the bug report issue template, mirroring the identical field already present in the feature request template.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Template YAML change only; verified by inspecting the rendered form locally.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release