### PR TITLE
feat(typescript): keep Responses API streaming spans open until consumption

### DIFF
--- a/libs/typescript/integrations/helpers/openaiTestHelper.ts
+++ b/libs/typescript/integrations/helpers/openaiTestHelper.ts
@@ -138,6 +138,24 @@ export const openAIMockHandlers = [
   }),
   http.post('https://api.openai.com/v1/responses', async ({ request }) => {
     const body = (await request.json()) as ResponseCreateParams;
+    if ('stream' in body && body.stream) {
+      return new HttpResponse(
+        [
+          'data: {"type":"response.created","sequence_number":0,"response":{"id":"responses-stream","object":"response","created_at":123,"status":"in_progress","model":"gpt-4o","output":[]}}\n\n',
+          'data: {"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"id":"msg_123","type":"message","status":"in_progress","role":"assistant","content":[]}}\n\n',
+          'data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"msg_123","output_index":0,"content_index":0,"delta":"Test "}\n\n',
+          'data: {"type":"response.output_text.delta","sequence_number":3,"item_id":"msg_123","output_index":0,"content_index":0,"delta":"response"}\n\n',
+          'data: {"type":"response.output_item.done","sequence_number":4,"output_index":0,"item":{"id":"msg_123","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Test response","annotations":[]}]}}\n\n',
+          'data: {"type":"response.output_item.added","sequence_number":5,"output_index":1,"item":{"id":"fc_123","type":"function_call","status":"in_progress","call_id":"call_123","name":"get_weather","arguments":""}}\n\n',
+          'data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_123","output_index":1,"delta":"{\\"city\\":"}\n\n',
+          'data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_123","output_index":1,"delta":"\\"Paris\\"}"}\n\n',
+          'data: {"type":"response.output_item.done","sequence_number":8,"output_index":1,"item":{"id":"fc_123","type":"function_call","status":"completed","call_id":"call_123","name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}}\n\n',
+          'data: {"type":"response.completed","sequence_number":9,"response":{"id":"responses-stream","object":"response","created_at":123,"status":"completed","model":"gpt-4o","output":[{"id":"msg_123","type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Test response","annotations":[]}]},{"id":"fc_123","type":"function_call","status":"completed","call_id":"call_123","name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}],"usage":{"input_tokens":10,"output_tokens":20,"total_tokens":30,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}},"output_text":"Test response"}}\n\n',
+          'data: [DONE]\n\n',
+        ].join(''),
+        { headers: { 'Content-Type': 'text/event-stream' } },
+      );
+    }
     return HttpResponse.json(createResponsesResponse(body));
   }),
   http.post('https://api.openai.com/v1/embeddings', async ({ request }) => {

--- a/libs/typescript/integrations/openai/src/index.ts
+++ b/libs/typescript/integrations/openai/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { CompletionUsage } from 'openai/resources/index';
-import { ResponseUsage } from 'openai/resources/responses/responses';
+import { ResponseStreamEvent, ResponseUsage } from 'openai/resources/responses/responses';
 import { ChatCompletionChunk } from 'openai/resources/chat/completions';
 import { Stream } from 'openai/streaming';
 import {
@@ -26,7 +26,7 @@ const MAX_ACCUMULATED_LENGTH = 10000;
 const TRUNCATION_SUFFIX = '...[truncated]';
 
 type StreamInternals<Item> = { iterator: () => AsyncIterator<Item> };
-type StreamState = {
+type ChatCompletionStreamState = {
   span: LiveSpan;
   choices: Map<number, AccumulatedChoice>;
   usage?: TokenUsage;
@@ -45,6 +45,15 @@ type AccumulatedChoice = {
     }>;
   };
   finish_reason?: string | null;
+};
+type ResponsesStreamState = {
+  span: LiveSpan;
+  outputItems: Map<number, Record<string, unknown>>;
+  outputText: string;
+  completedResponse?: Record<string, unknown>;
+  usage?: TokenUsage;
+  consumed: boolean;
+  ended: boolean;
 };
 
 /**
@@ -128,8 +137,11 @@ function wrapWithTracing(fn: Function, moduleName: string): Function {
       return fn.apply(this, args);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (moduleName === 'Completions' && args[0]?.stream === true) {
+    if (
+      (moduleName === 'Completions' || moduleName === 'Responses') &&
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      args[0]?.stream === true
+    ) {
       const parentSpan = getCurrentActiveSpan();
       const span = startSpan({ name, spanType, parent: parentSpan ?? undefined });
       span.setInputs(args[0]);
@@ -138,7 +150,11 @@ function wrapWithTracing(fn: Function, moduleName: string): Function {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return Promise.resolve()
         .then(() => fn.apply(this, args) as unknown)
-        .then((stream) => wrapChatCompletionStream(stream, span))
+        .then((stream) =>
+          moduleName === 'Responses'
+            ? wrapResponsesStream(stream, span)
+            : wrapChatCompletionStream(stream, span),
+        )
         .catch((error: unknown) => {
           const err = error instanceof Error ? error : new Error(String(error));
           span.setStatus(SpanStatusCode.ERROR, err.message);
@@ -155,7 +171,6 @@ function wrapWithTracing(fn: Function, moduleName: string): Function {
 
         const result = await fn.apply(this, args);
 
-        // TODO: Handle Responses API streaming responses
         span.setOutputs(result);
 
         // Add token usage
@@ -180,7 +195,12 @@ function wrapWithTracing(fn: Function, moduleName: string): Function {
 
 function wrapChatCompletionStream(stream: unknown, span: LiveSpan): Stream<ChatCompletionChunk> {
   const targetStream = stream as Stream<ChatCompletionChunk>;
-  const state: StreamState = { span, choices: new Map(), consumed: false, ended: false };
+  const state: ChatCompletionStreamState = {
+    span,
+    choices: new Map(),
+    consumed: false,
+    ended: false,
+  };
 
   // A consumer may abandon the stream without ever iterating it, in which case
   // no iterator runs and the span would stay open forever. Aborting the request
@@ -192,7 +212,7 @@ function wrapChatCompletionStream(stream: unknown, span: LiveSpan): Stream<ChatC
     'abort',
     () => {
       if (!state.consumed) {
-        endStreamSpan(state);
+        endChatCompletionStreamSpan(state);
       }
     },
     { once: true },
@@ -226,13 +246,53 @@ function wrapChatCompletionStream(stream: unknown, span: LiveSpan): Stream<ChatC
   });
 }
 
-function recordStreamError(state: StreamState, error: unknown): void {
+function wrapResponsesStream(stream: unknown, span: LiveSpan): Stream<ResponseStreamEvent> {
+  const targetStream = stream as Stream<ResponseStreamEvent>;
+  const state: ResponsesStreamState = {
+    span,
+    outputItems: new Map(),
+    outputText: '',
+    consumed: false,
+    ended: false,
+  };
+
+  targetStream.controller?.signal?.addEventListener(
+    'abort',
+    () => {
+      if (!state.consumed) {
+        endResponsesStreamSpan(state);
+      }
+    },
+    { once: true },
+  );
+
+  const internals = targetStream as unknown as StreamInternals<ResponseStreamEvent>;
+  const wrapsInternalIterator = typeof internals.iterator === 'function';
+
+  return new Proxy(targetStream, {
+    get(target, prop, receiver) {
+      if (wrapsInternalIterator ? prop === 'iterator' : prop === Symbol.asyncIterator) {
+        return () => {
+          state.consumed = true;
+          const iterator = wrapsInternalIterator
+            ? internals.iterator()
+            : (target as AsyncIterable<ResponseStreamEvent>)[Symbol.asyncIterator]();
+          return wrapResponsesIterator(iterator, state);
+        };
+      }
+
+      return Reflect.get(target, prop, receiver) as unknown;
+    },
+  });
+}
+
+function recordStreamError(state: { span: LiveSpan }, error: unknown): void {
   const err = error instanceof Error ? error : new Error(String(error));
   state.span.setStatus(SpanStatusCode.ERROR, err.message);
   state.span.recordException(err);
 }
 
-function endStreamSpan(state: StreamState): void {
+function endChatCompletionStreamSpan(state: ChatCompletionStreamState): void {
   if (state.ended) {
     return;
   }
@@ -244,9 +304,21 @@ function endStreamSpan(state: StreamState): void {
   state.span.end();
 }
 
+function endResponsesStreamSpan(state: ResponsesStreamState): void {
+  if (state.ended) {
+    return;
+  }
+  state.ended = true;
+  state.span.setOutputs(buildResponsesStreamOutputs(state));
+  if (state.usage) {
+    state.span.setAttribute(SpanAttributeKey.TOKEN_USAGE, state.usage);
+  }
+  state.span.end();
+}
+
 async function* wrapChatCompletionIterator(
   iterator: AsyncIterator<ChatCompletionChunk>,
-  state: StreamState,
+  state: ChatCompletionStreamState,
 ): AsyncGenerator<ChatCompletionChunk> {
   const { choices } = state;
   let completed = false;
@@ -318,8 +390,177 @@ async function* wrapChatCompletionIterator(
         recordStreamError(state, error);
       }
     }
-    endStreamSpan(state);
+    endChatCompletionStreamSpan(state);
   }
+}
+
+async function* wrapResponsesIterator(
+  iterator: AsyncIterator<ResponseStreamEvent>,
+  state: ResponsesStreamState,
+): AsyncGenerator<ResponseStreamEvent> {
+  let completed = false;
+
+  try {
+    while (true) {
+      const { value, done } = await iterator.next();
+      if (done) {
+        completed = true;
+        break;
+      }
+
+      accumulateResponsesEvent(state, value);
+      yield value;
+    }
+  } catch (error) {
+    recordStreamError(state, error);
+    throw error;
+  } finally {
+    if (!completed) {
+      try {
+        await iterator.return?.();
+      } catch (error) {
+        recordStreamError(state, error);
+      }
+    }
+    endResponsesStreamSpan(state);
+  }
+}
+
+function accumulateResponsesEvent(state: ResponsesStreamState, event: ResponseStreamEvent): void {
+  switch (event.type) {
+    case 'response.output_text.delta': {
+      state.outputText = appendBounded(state.outputText, event.delta);
+      const existing = state.outputItems.get(event.output_index) ?? {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: '' }],
+      };
+      const content = Array.isArray(existing.content)
+        ? [...(existing.content as Array<Record<string, unknown>>)]
+        : [{ type: 'output_text', text: '' }];
+      const partIndex = event.content_index ?? 0;
+      const part = { ...(content[partIndex] ?? { type: 'output_text', text: '' }) };
+      if (typeof part.text === 'string') {
+        part.text = appendBounded(part.text, event.delta);
+      } else {
+        part.type = 'output_text';
+        part.text = appendBounded('', event.delta);
+      }
+      content[partIndex] = part;
+      existing.content = content;
+      state.outputItems.set(event.output_index, existing);
+      break;
+    }
+    case 'response.output_item.added':
+    case 'response.output_item.done': {
+      state.outputItems.set(event.output_index, boundOutputItem(event.item));
+      break;
+    }
+    case 'response.function_call_arguments.delta': {
+      const existing = state.outputItems.get(event.output_index) ?? {
+        type: 'function_call',
+        arguments: '',
+      };
+      const currentArgs = typeof existing.arguments === 'string' ? existing.arguments : '';
+      existing.type = 'function_call';
+      existing.arguments = appendBounded(currentArgs, event.delta);
+      state.outputItems.set(event.output_index, existing);
+      break;
+    }
+    case 'response.function_call_arguments.done': {
+      const existing = state.outputItems.get(event.output_index) ?? {
+        type: 'function_call',
+        arguments: '',
+      };
+      existing.type = 'function_call';
+      existing.arguments = truncateBounded(event.arguments);
+      state.outputItems.set(event.output_index, existing);
+      break;
+    }
+    case 'response.completed': {
+      state.completedResponse = boundCompletedResponse(event.response);
+      state.usage = extractTokenUsage(event.response);
+      break;
+    }
+    case 'response.failed': {
+      const message = event.response.error?.message ?? 'Responses stream failed';
+      recordStreamError(state, new Error(message));
+      break;
+    }
+    case 'error': {
+      recordStreamError(state, new Error(event.message));
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function buildResponsesStreamOutputs(state: ResponsesStreamState): unknown {
+  if (state.completedResponse) {
+    return state.completedResponse;
+  }
+
+  const output = [...state.outputItems.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([, item]) => item);
+
+  if (output.length === 0 && state.outputText) {
+    return {
+      output_text: state.outputText,
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: state.outputText }],
+        },
+      ],
+    };
+  }
+
+  return {
+    ...(state.outputText ? { output_text: state.outputText } : {}),
+    output,
+  };
+}
+
+function boundCompletedResponse(response: unknown): Record<string, unknown> {
+  const value = (response ?? {}) as Record<string, unknown>;
+  const output = Array.isArray(value.output)
+    ? value.output.map((item) => boundOutputItem(item))
+    : [];
+
+  return {
+    id: value.id,
+    object: value.object ?? 'response',
+    model: value.model,
+    status: value.status,
+    output,
+    usage: value.usage,
+    ...(typeof value.output_text === 'string'
+      ? { output_text: truncateBounded(value.output_text) }
+      : {}),
+  };
+}
+
+function boundOutputItem(item: unknown): Record<string, unknown> {
+  const value = { ...((item ?? {}) as Record<string, unknown>) };
+
+  if (typeof value.arguments === 'string') {
+    value.arguments = truncateBounded(value.arguments);
+  }
+
+  if (Array.isArray(value.content)) {
+    value.content = value.content.map((part) => {
+      const contentPart = { ...((part ?? {}) as Record<string, unknown>) };
+      if (typeof contentPart.text === 'string') {
+        contentPart.text = truncateBounded(contentPart.text);
+      }
+      return contentPart;
+    });
+  }
+
+  return value;
 }
 
 function appendBounded(value: string, delta: string): string {
@@ -331,6 +572,10 @@ function appendBounded(value: string, delta: string): string {
     return combined;
   }
   return combined.slice(0, MAX_ACCUMULATED_LENGTH - TRUNCATION_SUFFIX.length) + TRUNCATION_SUFFIX;
+}
+
+function truncateBounded(value: string): string {
+  return appendBounded('', value);
 }
 
 /**

--- a/libs/typescript/integrations/openai/tests/index.test.ts
+++ b/libs/typescript/integrations/openai/tests/index.test.ts
@@ -407,6 +407,233 @@ describe('tracedOpenAI', () => {
       });
       expect(span.outputs).toEqual(response);
     });
+
+    it('should keep spans open while streaming responses', async () => {
+      const openai = new OpenAI({ apiKey: 'test-key' });
+      const wrappedOpenAI = tracedOpenAI(openai);
+
+      const stream = await wrappedOpenAI.responses.create({
+        model: 'gpt-4o',
+        input: 'Hello!',
+        stream: true,
+      });
+
+      const events = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+      expect(events.length).toBeGreaterThan(0);
+      expect(span.name).toBe('Responses');
+      expect(span.status.statusCode).toBe(mlflow.SpanStatusCode.OK);
+      expect(span.outputs).toEqual({
+        id: 'responses-stream',
+        object: 'response',
+        model: 'gpt-4o',
+        status: 'completed',
+        output: [
+          {
+            id: 'msg_123',
+            type: 'message',
+            status: 'completed',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Test response', annotations: [] }],
+          },
+          {
+            id: 'fc_123',
+            type: 'function_call',
+            status: 'completed',
+            call_id: 'call_123',
+            name: 'get_weather',
+            arguments: '{"city":"Paris"}',
+          },
+        ],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens_details: { reasoning_tokens: 0 },
+        },
+        output_text: 'Test response',
+      });
+      expect(span.attributes[mlflow.SpanAttributeKey.TOKEN_USAGE]).toEqual({
+        [mlflow.TokenUsageKey.INPUT_TOKENS]: 10,
+        [mlflow.TokenUsageKey.OUTPUT_TOKENS]: 20,
+        [mlflow.TokenUsageKey.TOTAL_TOKENS]: 30,
+      });
+    });
+
+    it('should end spans when streaming responses are terminated early', async () => {
+      const openai = new OpenAI({ apiKey: 'test-key' });
+      const wrappedOpenAI = tracedOpenAI(openai);
+
+      const stream = await wrappedOpenAI.responses.create({
+        model: 'gpt-4o',
+        input: 'Hello!',
+        stream: true,
+      });
+
+      for await (const event of stream) {
+        if (event.type === 'response.output_text.delta') {
+          break;
+        }
+      }
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+      expect(span.status.statusCode).toBe(mlflow.SpanStatusCode.OK);
+      expect(span.outputs).toEqual({
+        output_text: 'Test ',
+        output: [
+          {
+            id: 'msg_123',
+            type: 'message',
+            status: 'in_progress',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Test ' }],
+          },
+        ],
+      });
+      expect(span.attributes[mlflow.SpanAttributeKey.TOKEN_USAGE]).toBeUndefined();
+    });
+
+    it('should end spans when a responses stream is consumed through tee()', async () => {
+      const wrappedOpenAI = tracedOpenAI(new OpenAI({ apiKey: 'test-key' }));
+
+      const stream = await wrappedOpenAI.responses.create({
+        model: 'gpt-4o',
+        input: 'Hello tee!',
+        stream: true,
+      });
+
+      const [left] = stream.tee();
+      const events = [];
+      for await (const event of left) {
+        events.push(event);
+      }
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+      expect(span.inputs.input).toBe('Hello tee!');
+      expect(events.length).toBeGreaterThan(0);
+      expect(span.status.statusCode).toBe(mlflow.SpanStatusCode.OK);
+      expect(span.outputs).toBeDefined();
+      expect(span.attributes[mlflow.SpanAttributeKey.TOKEN_USAGE]).toEqual({
+        [mlflow.TokenUsageKey.INPUT_TOKENS]: 10,
+        [mlflow.TokenUsageKey.OUTPUT_TOKENS]: 20,
+        [mlflow.TokenUsageKey.TOTAL_TOKENS]: 30,
+      });
+    });
+
+    it('should end spans when a responses stream is consumed through toReadableStream()', async () => {
+      const wrappedOpenAI = tracedOpenAI(new OpenAI({ apiKey: 'test-key' }));
+
+      const stream = await wrappedOpenAI.responses.create({
+        model: 'gpt-4o',
+        input: 'Hello readable!',
+        stream: true,
+      });
+
+      const reader = stream.toReadableStream().getReader();
+      while (!(await reader.read()).done) {
+        // Drain the stream
+      }
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+      expect(span.inputs.input).toBe('Hello readable!');
+      expect(span.status.statusCode).toBe(mlflow.SpanStatusCode.OK);
+      expect(span.outputs).toBeDefined();
+    });
+
+    it('should end spans when a responses stream is abandoned without being consumed', async () => {
+      const wrappedOpenAI = tracedOpenAI(new OpenAI({ apiKey: 'test-key' }));
+
+      const stream = await wrappedOpenAI.responses.create({
+        model: 'gpt-4o',
+        input: 'Hello abandoned!',
+        stream: true,
+      });
+
+      stream.controller.abort();
+
+      const trace = await getLastActiveTrace();
+      const span = trace.data.spans[0];
+      expect(span.inputs.input).toBe('Hello abandoned!');
+      expect(span.endTime).toBeDefined();
+      expect(span.outputs).toEqual({ output: [] });
+    });
+
+    it('should preserve the identity of the returned responses stream', async () => {
+      const wrappedOpenAI = tracedOpenAI(new OpenAI({ apiKey: 'test-key' }));
+
+      const stream = await wrappedOpenAI.responses.create({
+        model: 'gpt-4o',
+        input: 'Hello!',
+        stream: true,
+      });
+
+      expect(stream).toBeInstanceOf(Stream);
+      expect(stream.constructor).toBe(Stream);
+
+      stream.controller.abort();
+    });
+
+    it('should mark spans as errors when streaming responses fail', async () => {
+      class Responses {
+        create(_params: unknown) {
+          return Promise.resolve({
+            async *[Symbol.asyncIterator]() {
+              yield await Promise.resolve({
+                type: 'response.output_text.delta',
+                delta: 'Test ',
+                output_index: 0,
+                content_index: 0,
+                item_id: 'msg_1',
+                sequence_number: 1,
+              });
+              throw new Error('Stream failed');
+            },
+          });
+        }
+      }
+
+      const wrappedOpenAI = tracedOpenAI({ responses: new Responses() });
+      const stream = await wrappedOpenAI.responses.create({ stream: true });
+
+      await expect(
+        (async () => {
+          for await (const _event of stream) {
+            expect(_event).toBeDefined();
+          }
+        })(),
+      ).rejects.toThrow('Stream failed');
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.state).toBe('ERROR');
+      expect(trace.data.spans[0].status.statusCode).toBe(mlflow.SpanStatusCode.ERROR);
+    });
+
+    it('should mark spans as errors when creating a responses stream throws synchronously', async () => {
+      class Responses {
+        create(_params: unknown) {
+          throw new Error('Stream creation failed');
+        }
+      }
+
+      const wrappedOpenAI = tracedOpenAI({ responses: new Responses() });
+
+      await expect(wrappedOpenAI.responses.create({ stream: true })).rejects.toThrow(
+        'Stream creation failed',
+      );
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.state).toBe('ERROR');
+      expect(trace.data.spans[0].status.statusCode).toBe(mlflow.SpanStatusCode.ERROR);
+    });
   });
 
   describe('Embeddings API', () => {


### PR DESCRIPTION
### Related Issues/PRs

Fixes #25504

Relates to #25416 / #25410 (Chat Completions streaming span lifecycle)

Supersedes #25507 (auto-closed for incomplete PR template)

### What changes are proposed in this pull request?

`tracedOpenAI()` ended Responses API spans when `responses.create({ stream: true })` returned a stream, excluding streamed content, usage, duration, and iteration errors from traces — the same footgun #25416 fixed for Chat Completions.

- **Streaming span lifecycle**
  - Start a manual LLM span for `responses.create({ stream: true })`.
  - End it after normal completion, consumer cancellation / abandon-via-abort, or iterator failure.
  - Preserve the OpenAI `Stream` API (`async` iteration, `tee()`, `toReadableStream()`).

- **Trace data**
  - Prefer bounded outputs from `response.completed` when present.
  - Otherwise accumulate bounded `output_text` and message / function-call items from stream events.
  - Record token usage only from a `response.completed` usage payload.
  - Mark spans `ERROR` and rethrow iteration / create failures.

```ts
const stream = await openai.responses.create({
  model: 'gpt-4o-mini',
  input: 'Say hello',
  stream: true,
});

for await (const event of stream) {
  // Span remains active while events are consumed.
}
```

Non-streaming `responses.create` and the Chat Completions streaming path from #25416 are unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Focused validation under `libs/typescript`:

```bash
npm run test:openai
```

21 tests passed, including new Responses streaming coverage for full consumption + usage, early termination, `tee()`, `toReadableStream()`, abandon-via-abort, stream identity, mid-stream errors, and create-time errors.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`@mlflow/openai` now keeps Responses API streaming spans open until the stream is consumed (or aborted / fails), matching the Chat Completions streaming behavior.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bug fix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
