### PR TITLE
[BUGFIX] Preserve empty webhook fields in partial `update_webhook` calls

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -3585,14 +3585,16 @@ def _update_webhook(webhook_id: str):
     webhook = _get_model_registry_store().update_webhook(
         webhook_id=webhook_id,
         name=request_message.name or None,
-        description=request_message.description or None,
+        description=(
+            request_message.description if request_message.HasField("description") else None
+        ),
         url=request_message.url or None,
         events=(
             [WebhookEvent.from_proto(e) for e in request_message.events]
             if request_message.events
             else None
         ),
-        secret=request_message.secret or None,
+        secret=request_message.secret if request_message.HasField("secret") else None,
         status=(
             WebhookStatus.from_proto(request_message.status)
             if request_message.HasField("status")

--- a/tests/tracking/test_client_webhooks.py
+++ b/tests/tracking/test_client_webhooks.py
@@ -175,6 +175,22 @@ def test_update_webhook_partial(client: MlflowClient):
     assert updated_webhook.status == WebhookStatus.DISABLED
 
 
+def test_update_webhook_clears_empty_description_and_secret(client: MlflowClient):
+    webhook = client.create_webhook(
+        name="test_webhook",
+        url="https://example.com/webhook",
+        events=[WebhookEvent(WebhookEntity.MODEL_VERSION, WebhookAction.CREATED)],
+        description="Original description",
+        secret="Original secret",
+    )
+
+    client.update_webhook(webhook.webhook_id, description="", secret="")
+
+    stored_webhook = handlers._model_registry_store.get_webhook(webhook.webhook_id)
+    assert stored_webhook.description == ""
+    assert stored_webhook.secret == ""
+
+
 def test_update_webhook_not_found(client: MlflowClient):
     with pytest.raises(MlflowException, match="Webhook with ID nonexistent not found"):
         client.update_webhook(webhook_id="nonexistent", name="new_name")


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24842 (similar protobuf field-presence fix).

### What changes are proposed in this pull request?

The `UpdateWebhook` handler currently uses truthiness checks for the optional `description` and `secret` fields. Explicitly supplied empty strings are converted to `None`, so the model registry store leaves the previous values unchanged.

This change uses protobuf `HasField` to distinguish omitted fields from explicitly supplied empty strings, allowing clients to clear a webhook description or secret while preserving existing partial-update behavior for omitted fields.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

- `tests/tracking/test_client_webhooks.py` (13 passed)
- `tests/store/model_registry/test_rest_store_webhooks.py` (12 passed)
- `tests/store/model_registry/test_sqlalchemy_store.py -k update_webhook` (42 passed)
- Ruff check and format checks for the changed files

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I have updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Explicitly empty webhook descriptions and secrets can now be cleared through partial update APIs.
- [ ] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLflow projects, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release