### PR TITLE
Fix V4 trace drawer review action

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
@@ -381,11 +381,48 @@ describe('TracesV4PageContent (interactions)', () => {
     // user-faithful way to exercise nav (the header's chevron buttons are icon-only, no a11y name).
     test('offers "Flag for review" in the trace drawer header', async () => {
       const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+      server.use(
+        rest.get('*/ajax-api/3.0/mlflow/review-queues/list', (req, res, ctx) =>
+          res(
+            ctx.json({
+              review_queues: req.url.searchParams.has('item_id')
+                ? []
+                : [
+                    {
+                      queue_id: 'rq-relevance',
+                      experiment_id: EXPERIMENT_ID,
+                      name: 'Relevance',
+                      queue_type: 'CUSTOM',
+                      schema_ids: ['schema-relevance'],
+                      creation_time_ms: 1,
+                      last_update_time_ms: 1,
+                    },
+                  ],
+            }),
+          ),
+        ),
+        rest.get('*/ajax-api/3.0/mlflow/label-schemas/list', (_req, res, ctx) =>
+          res(
+            ctx.json({
+              label_schemas: [
+                {
+                  schema_id: 'schema-relevance',
+                  experiment_id: EXPERIMENT_ID,
+                  name: 'Relevance',
+                  type: 'FEEDBACK',
+                  input: { text: {} },
+                },
+              ],
+            }),
+          ),
+        ),
+      );
       renderPage();
       await user.click(await findTraceRow('tr-000'));
 
       const drawer = await screen.findByRole('dialog');
-      expect(within(drawer).getByRole('button', { name: 'Flag for review' })).toBeInTheDocument();
+      await user.click(within(drawer).getByRole('button', { name: 'Flag for review' }));
+      expect(await screen.findByRole('checkbox', { name: 'Relevance' })).toBeInTheDocument();
     }, 20000); // heavy full-page userEvent render — bump off the flaky 5s default under parallel jsdom load
 
     test('ArrowRight advances to the next row, writing its V4 long id to the URL', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
@@ -74,7 +74,7 @@ describe('TracesV4PageContent (interactions)', () => {
 
       await applyErrorStateClause(user);
       expect(state.searchCalls.some((c) => c.filter?.includes("attributes.status = 'ERROR'"))).toBe(true);
-    }, 20000); // heavy full-page userEvent render — bump off the flaky 5s default under parallel jsdom load
+    }, 20000); // heavy full-page userEvent render; bump off the flaky 5s default under parallel jsdom load
 
     // TODO(traces-v4): service_name filtering was dropped in OSS (the SearchTracesV3 parser rejects span.service_name). Field + clause removed by design.
 
@@ -379,6 +379,15 @@ describe('TracesV4PageContent (interactions)', () => {
   describe('trace drawer navigation', () => {
     // The drawer binds ArrowLeft/ArrowRight at the window level; driving it via the keyboard is the
     // user-faithful way to exercise nav (the header's chevron buttons are icon-only, no a11y name).
+    test('offers "Flag for review" in the trace drawer header', async () => {
+      const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+      renderPage();
+      await user.click(await findTraceRow('tr-000'));
+
+      const drawer = await screen.findByRole('dialog');
+      expect(within(drawer).getByRole('button', { name: 'Flag for review' })).toBeInTheDocument();
+    }, 20000); // heavy full-page userEvent render — bump off the flaky 5s default under parallel jsdom load
+
     test('ArrowRight advances to the next row, writing its V4 long id to the URL', async () => {
       const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
       renderPage();

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
@@ -381,6 +381,7 @@ describe('TracesV4PageContent (interactions)', () => {
     // user-faithful way to exercise nav (the header's chevron buttons are icon-only, no a11y name).
     test('offers "Flag for review" in the trace drawer header', async () => {
       const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+      let addItemsRequest: unknown;
       server.use(
         rest.get('*/ajax-api/3.0/mlflow/review-queues/list', (req, res, ctx) =>
           res(
@@ -416,13 +417,18 @@ describe('TracesV4PageContent (interactions)', () => {
             }),
           ),
         ),
+        rest.post('*/ajax-api/3.0/mlflow/review-queues/items/add', async (req, res, ctx) => {
+          addItemsRequest = await req.json();
+          return res(ctx.json({ items: [] }));
+        }),
       );
       renderPage();
       await user.click(await findTraceRow('tr-000'));
 
       const drawer = await screen.findByRole('dialog');
       await user.click(within(drawer).getByRole('button', { name: 'Flag for review' }));
-      expect(await screen.findByRole('checkbox', { name: 'Relevance' })).toBeInTheDocument();
+      await user.click(await screen.findByRole('checkbox', { name: 'Relevance' }));
+      await waitFor(() => expect(addItemsRequest).toEqual({ queue_id: 'rq-relevance', item_ids: ['tr-000'] }));
     }, 20000); // heavy full-page userEvent render — bump off the flaky 5s default under parallel jsdom load
 
     test('ArrowRight advances to the next row, writing its V4 long id to the URL', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx
@@ -379,7 +379,7 @@ describe('TracesV4PageContent (interactions)', () => {
   describe('trace drawer navigation', () => {
     // The drawer binds ArrowLeft/ArrowRight at the window level; driving it via the keyboard is the
     // user-faithful way to exercise nav (the header's chevron buttons are icon-only, no a11y name).
-    test('offers "Flag for review" in the trace drawer header', async () => {
+    test('adds the drawer trace to a review queue and closes the drawer', async () => {
       const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
       let addItemsRequest: unknown;
       server.use(
@@ -429,7 +429,8 @@ describe('TracesV4PageContent (interactions)', () => {
       await user.click(within(drawer).getByRole('button', { name: 'Flag for review' }));
       await user.click(await screen.findByRole('checkbox', { name: 'Relevance' }));
       await waitFor(() => expect(addItemsRequest).toEqual({ queue_id: 'rq-relevance', item_ids: ['tr-000'] }));
-    }, 20000); // heavy full-page userEvent render — bump off the flaky 5s default under parallel jsdom load
+      await waitFor(() => expect(drawer).not.toBeInTheDocument());
+    }, 40000); // heavy full-page render + mutation + drawer close animation under parallel jsdom load
 
     test('ArrowRight advances to the next row, writing its V4 long id to the URL', async () => {
       const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
@@ -362,6 +362,7 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
     // and the dataset modal) to the drawer and Actions menu.
     <ModelTraceExplorerContextProvider
       renderExportTracesToDatasetsModal={actions.renderExportTracesToDatasetsModal}
+      renderAddToReviewQueueDropdown={actions.AddToReviewQueueDropdown}
       DrawerComponent={AssistantAwareDrawer}
     >
       <GenAITracesTableProvider

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
@@ -101,7 +101,11 @@ jest.mock('../../components/label-schemas', () => ({
   LabelSchemaFormModal: () => null,
 }));
 
-const renderDropdown = (props?: { open?: boolean; onOpenChange?: (open: boolean) => void }) =>
+const renderDropdown = (props?: {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  onCloseDrawer?: () => void;
+}) =>
   render(
     <IntlProvider locale="en">
       <DesignSystemProvider>
@@ -110,6 +114,7 @@ const renderDropdown = (props?: { open?: boolean; onOpenChange?: (open: boolean)
           selectedTraceInfos={[{ trace_id: 'tr-1' } as any]}
           open={props?.open}
           onOpenChange={props?.onOpenChange}
+          onCloseDrawer={props?.onCloseDrawer}
         >
           <button type="button">Trigger</button>
         </AddToReviewQueueDropdown>
@@ -170,10 +175,11 @@ describe('AddToReviewQueueDropdown', () => {
   });
 
   it('assigns traces to a searched user queue for an authenticated editor', async () => {
+    const onCloseDrawer = jest.fn();
     mockAuthAvailable = true;
     mockUsers = [{ id: 2, username: 'alice', is_admin: false }];
     mockGetOrCreateUserQueue.mockResolvedValue({ review_queue: { queue_id: 'rq-alice' } });
-    renderDropdown({ open: true });
+    renderDropdown({ open: true, onCloseDrawer });
 
     fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: 'ali' } });
     fireEvent.click(await screen.findByRole('checkbox', { name: 'alice' }));
@@ -186,6 +192,10 @@ describe('AddToReviewQueueDropdown', () => {
       }),
     );
     expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-alice', item_ids: ['tr-1'] });
+    expect(onCloseDrawer).toHaveBeenCalledTimes(1);
+    expect(onCloseDrawer.mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(Utils.displayGlobalInfoNotification).mock.invocationCallOrder[0],
+    );
   });
 
   it('hides user assignment from an authenticated READ-only user', () => {
@@ -199,11 +209,16 @@ describe('AddToReviewQueueDropdown', () => {
   });
 
   it('immediately adds traces when a queue is clicked and shows a toast', async () => {
-    renderDropdown({ open: true });
+    const onCloseDrawer = jest.fn();
+    renderDropdown({ open: true, onCloseDrawer });
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Default queue' }));
 
     await waitFor(() => expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-default', item_ids: ['tr-1'] }));
+    expect(onCloseDrawer).toHaveBeenCalledTimes(1);
+    expect(onCloseDrawer.mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(Utils.displayGlobalInfoNotification).mock.invocationCallOrder[0],
+    );
     expect(Utils.displayGlobalInfoNotification).toHaveBeenCalledTimes(1);
 
     const [toastNode, duration] = jest.mocked(Utils.displayGlobalInfoNotification).mock.calls[0];
@@ -247,17 +262,23 @@ describe('AddToReviewQueueDropdown', () => {
   });
 
   it('un-checking a queue removes the traces from it', async () => {
-    renderDropdown({ open: true });
+    const onCloseDrawer = jest.fn();
+    renderDropdown({ open: true, onCloseDrawer });
 
     // First click adds.
     fireEvent.click(screen.getByRole('checkbox', { name: 'Relevance' }));
     await waitFor(() => expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-custom', item_ids: ['tr-1'] }));
+    expect(onCloseDrawer).toHaveBeenCalledTimes(1);
+    expect(onCloseDrawer.mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(Utils.displayGlobalInfoNotification).mock.invocationCallOrder[0],
+    );
     // Wait for the checked state to settle before clicking again.
     await waitFor(() => expect(screen.getByRole('checkbox', { name: 'Relevance' })).toBeChecked());
 
     // Second click removes.
     fireEvent.click(screen.getByRole('checkbox', { name: 'Relevance' }));
     await waitFor(() => expect(mockRemoveItems).toHaveBeenCalledWith({ queue_id: 'rq-custom', item_ids: ['tr-1'] }));
+    expect(onCloseDrawer).toHaveBeenCalledTimes(1);
   });
 
   it('allows adding to multiple queues sequentially', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
@@ -64,8 +64,13 @@ jest.mock('./hooks/useGetOrCreateUserQueueMutation', () => ({
 }));
 
 let mockUsersError: Error | null = null;
+let mockUsers: any[] = [];
 jest.mock('./hooks/useAssignableUsersQuery', () => ({
-  useAssignableUsersQuery: () => ({ users: [], isLoading: false, error: mockUsersError }),
+  useAssignableUsersQuery: ({ enabled }: { enabled: boolean }) => ({
+    users: enabled ? mockUsers : [],
+    isLoading: false,
+    error: mockUsersError,
+  }),
 }));
 // The experiment's queues (the unfiltered call). One assignable CUSTOM queue
 // (its schema_id resolves against the experiment schema below), so tests can
@@ -119,6 +124,7 @@ describe('AddToReviewQueueDropdown', () => {
     mockCanEdit = true;
     mockCanManage = false;
     mockUsersError = null;
+    mockUsers = [];
     mockMemberQueues = [];
     mockMembersLoading = false;
     mockListQueues = [
@@ -161,6 +167,35 @@ describe('AddToReviewQueueDropdown', () => {
     renderDropdown({ open: true });
     expect(screen.getByText(/couldn't load users/i)).toBeInTheDocument();
     expect(screen.queryByText(/search by name to add/i)).not.toBeInTheDocument();
+  });
+
+  it('assigns traces to a searched user queue for an authenticated editor', async () => {
+    mockAuthAvailable = true;
+    mockUsers = [{ id: 2, username: 'alice', is_admin: false }];
+    mockGetOrCreateUserQueue.mockResolvedValue({ review_queue: { queue_id: 'rq-alice' } });
+    renderDropdown({ open: true });
+
+    fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: 'ali' } });
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'alice' }));
+
+    await waitFor(() =>
+      expect(mockGetOrCreateUserQueue).toHaveBeenCalledWith({
+        experiment_id: 'exp-1',
+        user: 'alice',
+        created_by: 'default',
+      }),
+    );
+    expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-alice', item_ids: ['tr-1'] });
+  });
+
+  it('hides user assignment from an authenticated READ-only user', () => {
+    mockAuthAvailable = true;
+    mockCanEdit = false;
+    mockUsers = [{ id: 2, username: 'alice', is_admin: false }];
+    renderDropdown({ open: true });
+
+    expect(screen.queryByText('Users')).not.toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', { name: 'alice' })).not.toBeInTheDocument();
   });
 
   it('immediately adds traces when a queue is clicked and shows a toast', async () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
@@ -184,18 +184,19 @@ describe('AddToReviewQueueDropdown', () => {
     fireEvent.change(screen.getByPlaceholderText(/search/i), { target: { value: 'ali' } });
     fireEvent.click(await screen.findByRole('checkbox', { name: 'alice' }));
 
-    await waitFor(() =>
+    await waitFor(() => {
       expect(mockGetOrCreateUserQueue).toHaveBeenCalledWith({
         experiment_id: 'exp-1',
         user: 'alice',
         created_by: 'default',
-      }),
-    );
-    expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-alice', item_ids: ['tr-1'] });
-    expect(onCloseDrawer).toHaveBeenCalledTimes(1);
-    expect(onCloseDrawer.mock.invocationCallOrder[0]).toBeLessThan(
-      jest.mocked(Utils.displayGlobalInfoNotification).mock.invocationCallOrder[0],
-    );
+      });
+      expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-alice', item_ids: ['tr-1'] });
+      expect(onCloseDrawer).toHaveBeenCalledTimes(1);
+      expect(Utils.displayGlobalInfoNotification).toHaveBeenCalledTimes(1);
+      expect(onCloseDrawer.mock.invocationCallOrder[0]).toBeLessThan(
+        jest.mocked(Utils.displayGlobalInfoNotification).mock.invocationCallOrder[0],
+      );
+    });
   });
 
   it('hides user assignment from an authenticated READ-only user', () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.test.tsx
@@ -282,7 +282,8 @@ describe('AddToReviewQueueDropdown', () => {
   });
 
   it('allows adding to multiple queues sequentially', async () => {
-    renderDropdown({ open: true });
+    const onCloseDrawer = jest.fn();
+    renderDropdown({ open: true, onCloseDrawer });
 
     // Add to a custom queue.
     fireEvent.click(screen.getByRole('checkbox', { name: 'Relevance' }));
@@ -293,6 +294,7 @@ describe('AddToReviewQueueDropdown', () => {
     await waitFor(() => expect(mockAddItems).toHaveBeenCalledWith({ queue_id: 'rq-default', item_ids: ['tr-1'] }));
 
     expect(Utils.displayGlobalInfoNotification).toHaveBeenCalledTimes(2);
+    expect(onCloseDrawer).toHaveBeenCalledTimes(1);
   });
 
   it('hides the New-queue link for a READ-only user', () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
@@ -96,6 +96,12 @@ export const AddToReviewQueueDropdown = ({
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;
   const isOpen = isControlled ? controlledOpen : internalOpen;
+  const hasRequestedDrawerCloseRef = useRef(false);
+  useEffect(() => {
+    if (!isOpen) {
+      hasRequestedDrawerCloseRef.current = false;
+    }
+  }, [isOpen]);
   const setOpen = useCallback(
     (next: boolean) => {
       if (isControlled) {
@@ -265,7 +271,10 @@ export const AddToReviewQueueDropdown = ({
   const showSuccessToast = useCallback(
     (queueId: string) => {
       const reviewQueuePath = getReviewQueuePageRoute(experimentId, queueId);
-      onCloseDrawer?.();
+      if (onCloseDrawer && !hasRequestedDrawerCloseRef.current) {
+        hasRequestedDrawerCloseRef.current = true;
+        onCloseDrawer();
+      }
       Utils.displayGlobalInfoNotification(
         <span css={{ whiteSpace: 'nowrap' }}>
           {intl.formatMessage(

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-review-queue/AddToReviewQueueDropdown.tsx
@@ -70,6 +70,7 @@ export const AddToReviewQueueDropdown = ({
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
   popoverAlign = 'end',
+  onCloseDrawer,
 }: {
   experimentId: string;
   selectedTraceInfos: ModelTraceInfoV3[];
@@ -77,6 +78,7 @@ export const AddToReviewQueueDropdown = ({
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   popoverAlign?: 'start' | 'end';
+  onCloseDrawer?: () => void;
 }) => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
@@ -263,6 +265,7 @@ export const AddToReviewQueueDropdown = ({
   const showSuccessToast = useCallback(
     (queueId: string) => {
       const reviewQueuePath = getReviewQueuePageRoute(experimentId, queueId);
+      onCloseDrawer?.();
       Utils.displayGlobalInfoNotification(
         <span css={{ whiteSpace: 'nowrap' }}>
           {intl.formatMessage(
@@ -282,7 +285,7 @@ export const AddToReviewQueueDropdown = ({
         3,
       );
     },
-    [experimentId, itemIds.length, intl],
+    [experimentId, itemIds.length, intl, onCloseDrawer],
   );
 
   const showErrorToast = useCallback(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24828

### What changes are proposed in this pull request?

Wire the V4 traces page review-queue dropdown into `ModelTraceExplorerContextProvider` so the V4 trace drawer header shows `Flag for review`, matching the table action and V3 behavior.

Add a regression test that opens the drawer dropdown and uses mocked review-queue and label-schema responses to verify the returned queue is rendered.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

- `node yarn/releases/yarn-4.12.0.cjs test --runTestsByPath src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx --runInBand` (26 passed, 2 skipped)
- `node yarn/releases/yarn-4.12.0.cjs prettier:check src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx`
- `node yarn/releases/yarn-4.12.0.cjs eslint src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.interactions.test.tsx`
- Local dev server on backend `5100` and frontend `3100`; seeded a trace and verified with Playwright that the V4 trace drawer shows `Flag for review`.

![V4 trace drawer showing Flag for review](https://github.com/user-attachments/assets/f5f23140-c634-497c-824c-4ebfd63aa15f)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Restores the `Flag for review` action in the V4 trace drawer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g. 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g. 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release