### PR TITLE
fix(ui): sanitize HTML content in `EditableNote` to prevent XSS

### DIFF
--- a/mlflow/server/js/src/common/components/EditableNote.test.tsx
+++ b/mlflow/server/js/src/common/components/EditableNote.test.tsx
@@ -101,4 +101,17 @@ describe('EditableNote', () => {
     rerender(<EditableNote {...minimalProps} defaultMarkdown="second description" />);
     expect(screen.getByText('second description')).toBeInTheDocument();
   });
+
+  test('sanitizes malicious script tags and event handlers in note content', () => {
+    const maliciousHtml = '<div>Safe note<script>alert("xss")</script><img src="x" onerror="alert(1)" /></div>';
+    renderWithIntl(
+      <DesignSystemProvider>
+        <EditableNote {...minimalProps} defaultMarkdown={maliciousHtml} />
+      </DesignSystemProvider>,
+    );
+    const preview = screen.getByTestId('note-editor-preview-content');
+    expect(preview.innerHTML).not.toContain('<script>');
+    expect(preview.innerHTML).not.toContain('onerror');
+    expect(preview.innerHTML).toContain('Safe note');
+  });
 });

--- a/mlflow/server/js/src/common/components/EditableNote.tsx
+++ b/mlflow/server/js/src/common/components/EditableNote.tsx
@@ -268,6 +268,7 @@ type HTMLNoteContentProps = {
 
 function HTMLNoteContent(props: HTMLNoteContentProps) {
   const { content } = props;
+  const sanitizedContent = content ? sanitizeConvertedHtml(content) : '';
   return content ? (
     <div className="note-view-outer-container" data-testid="note-view-outer-container">
       <div className="note-view-text-area">
@@ -275,9 +276,8 @@ function HTMLNoteContent(props: HTMLNoteContentProps) {
           <div
             className="note-editor-preview-content"
             data-testid="note-editor-preview-content"
-            // @ts-expect-error TS(2322): Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{ __html: props.content }}
+            dangerouslySetInnerHTML={{ __html: sanitizedContent }}
           />
         </div>
       </div>


### PR DESCRIPTION
### Related Issues/PRs

Relates to #15800

### What changes are proposed in this pull request?

In `mlflow/server/js/src/common/components/EditableNote.tsx`, `HTMLNoteContent` rendered `props.content` directly into `dangerouslySetInnerHTML` without HTML sanitization. This could allow Stored Cross-Site Scripting (XSS) if unvalidated HTML content containing scripts or malicious event handlers is present in note metadata.

This PR fixes the vulnerability by:
1. Sanitizing `content` with `sanitizeConvertedHtml` from `MarkdownUtils` before rendering to `dangerouslySetInnerHTML`.
2. Removing the `@ts-expect-error TS(2322)` workaround and ensuring proper TypeScript type safety.
3. Adding an automated unit test in `EditableNote.test.tsx` to verify malicious tags (`<script>`, `onerror`) are safely stripped.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No.
- [ ] Yes.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Sanitized HTML rendering in EditableNote to harden security against XSS.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
