### PR TITLE
Wrap the traces toolbar so custom-date controls don't overflow off-screen

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableToolbar.tsx
@@ -67,10 +67,13 @@ export const TracesTableToolbar: React.FC<TracesTableToolbarProps> = ({
 
   return (
     // Query container so the controls collapse on the toolbar's own width, not the viewport's.
+    // Wraps to a second row when the contents (e.g. the fixed-width CUSTOM-date RangePicker) can't
+    // fit on one line, rather than pushing the trailing controls off-screen (ML-68743/68769).
     <div
       css={{
         display: 'flex',
         alignItems: 'center',
+        flexWrap: 'wrap',
         gap: theme.spacing.sm,
         containerType: 'inline-size',
         containerName: TRACES_TOOLBAR_CONTAINER_NAME,


### PR DESCRIPTION
### Related Issues/PRs

None

### What changes are proposed in this pull request?

When the Traces V4 tab first opens with a **custom date range**, the toolbar overflows horizontally and the **Detect Issues** button (and the refresh control) gets pushed off the right edge of the screen.


- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manually verified in the browser: open the Traces tab, select a Custom date range, and confirm the Detect Issues button stays on-screen (wrapping to a second row when the window is narrow) instead of overflowing. Screenshot below.


<img width="838" height="148" alt="Screenshot 2026-09-01 at 9 50 25 PM" src="https://github.com/user-attachments/assets/942dcd71-4f31-477d-9cd5-ada31bfcdb24" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed the Traces table toolbar overflowing off-screen (hiding the Detect Issues and refresh controls) when opened with a custom date range.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release