### PR TITLE
Reject unsupported `env_manager` values when building a model container

### DIFF
--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -21,7 +21,6 @@ from mlflow.environment_variables import MLFLOW_DISABLE_ENV_CREATION
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.pyfunc import _extract_conda_env, scoring_server
 from mlflow.utils import env_manager as em
 from mlflow.utils.environment import _PythonEnv
@@ -145,10 +144,9 @@ def _install_model_dependencies_to_env(model_path, env_manager) -> list[str]:
     # Checked before the environment file is copied below, so an unsupported manager fails
     # with this message rather than partway through a copy it was never going to use.
     if env_manager not in (em.CONDA, em.VIRTUALENV):
-        raise MlflowException(
+        raise MlflowException.invalid_parameter_value(
             f"Invalid value for `env_manager`: {env_manager}. Building a model container "
             f"supports one of {[em.LOCAL, em.CONDA, em.VIRTUALENV]}.",
-            error_code=INVALID_PARAMETER_VALUE,
         )
 
     _logger.info("creating and activating custom environment")

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -18,8 +18,10 @@ from subprocess import Popen, check_call
 import mlflow
 from mlflow import pyfunc
 from mlflow.environment_variables import MLFLOW_DISABLE_ENV_CREATION
+from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.pyfunc import _extract_conda_env, scoring_server
 from mlflow.utils import env_manager as em
 from mlflow.utils.environment import _PythonEnv
@@ -139,6 +141,15 @@ def _install_model_dependencies_to_env(model_path, env_manager) -> list[str]:
         if Popen(pip_args).wait() != 0:
             raise Exception("Failed to install model dependencies.")
         return []
+
+    # Checked before the environment file is copied below, so an unsupported manager fails
+    # with this message rather than partway through a copy it was never going to use.
+    if env_manager not in (em.CONDA, em.VIRTUALENV):
+        raise MlflowException(
+            f"Invalid value for `env_manager`: {env_manager}. Building a model container "
+            f"supports one of {[em.LOCAL, em.CONDA, em.VIRTUALENV]}.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
 
     _logger.info("creating and activating custom environment")
 

--- a/tests/models/test_container.py
+++ b/tests/models/test_container.py
@@ -233,5 +233,5 @@ def test_unsupported_env_manager_raises(tmp_path, env_manager):
     model_path = str(tmp_path)
     _create_model_artifact(model_path, dependencies=["pip"])
 
-    with pytest.raises(MlflowException, match=r"Invalid value for `env_manager`"):
+    with pytest.raises(MlflowException, match=r"Building a model container supports one of"):
         _install_model_dependencies_to_env(model_path, env_manager=env_manager)

--- a/tests/models/test_container.py
+++ b/tests/models/test_container.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 import yaml
 
+from mlflow.exceptions import MlflowException
 from mlflow.models.container import _install_model_dependencies_to_env
 from mlflow.utils import env_manager as em
 
@@ -225,3 +226,12 @@ def test_package_name_with_requirements_substring_not_modified(tmp_path):
         assert "my-requirements.txt-parser" in call_args
         assert "requirements.txt-tools" in call_args
         assert not any(model_path in arg for arg in call_args if "parser" in arg or "tools" in arg)
+
+
+@pytest.mark.parametrize("env_manager", [em.UV, "unknown"])
+def test_unsupported_env_manager_raises(tmp_path, env_manager):
+    model_path = str(tmp_path)
+    _create_model_artifact(model_path, dependencies=["pip"])
+
+    with pytest.raises(MlflowException, match=r"Invalid value for `env_manager`"):
+        _install_model_dependencies_to_env(model_path, env_manager=env_manager)


### PR DESCRIPTION
### Related Issues/PRs

Closes #15211

### What changes are proposed in this pull request?

`_install_model_dependencies_to_env` binds `activate_cmd` only in its `conda`
and `virtualenv` branches, and `local` returns before them. `uv` is a valid
environment manager everywhere else in MLflow — `mlflow/utils/env_manager.py`
lists it in `validate()`'s `allowed_values`, and `mlflow models serve
--env-manager uv` works — so `mlflow models generate-dockerfile --env-manager
uv` is accepted, written into the generated Dockerfile, and falls off the end
of this function during `docker build`:

```
File ".../mlflow/models/container/__init__.py", line 174, in _install_model_dependencies_to_env
  return activate_cmd
UnboundLocalError: local variable 'activate_cmd' referenced before assignment
```

This raises `MlflowException(INVALID_PARAMETER_VALUE)` instead, with a message
shaped like the one `env_manager.validate()` already raises, so the caller is
told which managers this path supports. It is the change @serena-ruan
described in the thread; supporting `uv` here is the separate feature she
distinguished it from, and is not part of this.

**One decision worth flagging.** The comment asked for "an `else` branch inside
`_install_model_dependencies_to_env`", which read literally is the `else` of
the `if conda / elif virtualenv` chain at the bottom. The check is placed above
that chain instead, immediately after the `local` early return, because by the
bottom of the function it has already logged "creating and activating custom
environment", read the conda environment's name out of the model config and
copied a file into `/opt/mlflow/` — all for a request that could not succeed.
That stretch also needs `/opt/ml/model`, which exists only inside the serving
container, so a check below it could not be unit-tested at all. What a user
sees is the same either way; happy to move it if you would rather it read as
the literal `else`.

### How is this PR tested?

- [x] New unit/integration tests

`tests/models/test_container.py::test_unsupported_env_manager_raises`,
parametrised over `uv` and an unrecognised string, built on the file's existing
`_create_model_artifact` helper.

To be exact about what it proves: with the fix reverted it fails with
`KeyError: 'conda'` from `_extract_conda_env`, three lines earlier than the
`UnboundLocalError` in the issue, because the test's model artifact declares a
virtualenv environment and no conda one — and the reported traceback needs
`/opt/ml/model`, so it is not reachable outside a serving container. Both are
the same fall-through, and neither happens once an unsupported manager is
refused.

`tests/models/test_container.py` was 11 passed before this change and is 13
passed after, same eleven by name. `ruff==0.16.0` (`requirements/lint-requirements.txt`)
reports `All checks passed!` and `2 files already formatted`; `clint` reports
`No errors found!`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow models generate-dockerfile --env-manager uv` now fails with a
  message naming the supported environment managers, instead of an
  `UnboundLocalError` raised part-way through `docker build`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
