### PR TITLE
Add `logExpectation` and V4 assessment support to TypeScript SDK

### DIFF
--- a/libs/typescript/README.md
+++ b/libs/typescript/README.md
@@ -159,11 +159,19 @@ await client.logFeedback({
   rationale: 'The answer matches the expected fact.',
 });
 
+await client.logExpectation({
+  traceId: '<trace-id>',
+  name: 'expected_answer',
+  value: { answer: 'Paris', sources: ['encyclopedia'] },
+  source: { sourceType: AssessmentSourceType.HUMAN, sourceId: 'reviewer@example.com' },
+});
+
 const info = await client.getTraceInfo('<trace-id>');
 console.log(info.assessments);
 ```
 
-Databricks Unity Catalog V4 assessment posting is not included in this first slice.
+For Databricks Unity Catalog traces, both methods automatically use the V4 assessments API when
+given a `trace:/<catalog>.<schema>[.<table-prefix>]/<trace-id>` trace ID.
 
 Tag spans with a severity level so users (or you) can filter by **Minimum log level** in the trace UI:
 

--- a/libs/typescript/core/src/clients/client.ts
+++ b/libs/typescript/core/src/clients/client.ts
@@ -2,6 +2,7 @@ import { TraceInfo } from '../core/entities/trace_info';
 import { Trace } from '../core/entities/trace';
 import {
   CreateAssessment,
+  CreateAssessmentV4,
   CreateExperiment,
   CreateTraceInfoV4,
   DeleteExperiment,
@@ -17,12 +18,17 @@ import {
   AssessmentSourceType,
   assertFeedbackPayload,
   assertMetadataStringMap,
+  Expectation,
   Feedback,
+  serializeV4TraceLocation,
   standardizeSourceType,
   type AssessmentError,
   type AssessmentSource,
   type FeedbackValueType,
+  type ExpectationValueType,
+  type SerializedAssessment,
 } from '../core/entities/assessment';
+import { parseTraceIdV4 } from '../core/utils/trace_id';
 import { makeRawRequest, makeRequest, MlflowHttpError } from './utils';
 import { TraceData } from '../core/entities/trace_data';
 import { ArtifactsClient, getArtifactsClient } from './artifacts';
@@ -335,10 +341,8 @@ export class MlflowClient {
   }
 
   /**
-   * Log feedback on a persisted trace via the V3 assessments API.
+   * Log feedback on a persisted trace.
    * Corresponds to Python `mlflow.log_feedback`.
-   *
-   * Databricks Unity Catalog V4 assessment posting is not included in this method.
    */
   async logFeedback(params: {
     traceId: string;
@@ -370,15 +374,72 @@ export class MlflowClient {
       traceId: params.traceId,
     });
 
-    const url = CreateAssessment.getEndpoint(this.hostUrl, params.traceId);
-    const payload: CreateAssessment.Request = { assessment: feedback.toJson() };
+    return Feedback.fromJson(await this.createAssessment(params.traceId, feedback.toJson()));
+  }
+
+  /**
+   * Log an expectation, such as a ground-truth label, on a persisted trace.
+   * Corresponds to Python `mlflow.log_expectation`.
+   */
+  async logExpectation(params: {
+    traceId: string;
+    name: string;
+    value: ExpectationValueType;
+    source?: AssessmentSource;
+    metadata?: Record<string, string>;
+    spanId?: string;
+  }): Promise<Expectation> {
+    const metadata = assertMetadataStringMap(params.metadata);
+    const source = params.source
+      ? {
+          sourceType: standardizeSourceType(params.source.sourceType),
+          sourceId: params.source.sourceId || 'default',
+        }
+      : { sourceType: AssessmentSourceType.HUMAN, sourceId: 'default' };
+    const expectation = new Expectation({
+      name: params.name,
+      value: params.value,
+      source,
+      metadata,
+      spanId: params.spanId,
+      traceId: params.traceId,
+    });
+
+    return Expectation.fromJson(await this.createAssessment(params.traceId, expectation.toJson()));
+  }
+
+  private async createAssessment(
+    traceId: string,
+    assessment: SerializedAssessment,
+  ): Promise<SerializedAssessment> {
+    const [location, parsedTraceId] = parseTraceIdV4(traceId);
+    if (location && parsedTraceId) {
+      const payload: CreateAssessmentV4.Request = {
+        ...assessment,
+        trace_id: parsedTraceId,
+        trace_location: serializeV4TraceLocation(location),
+      };
+      const response = await makeRequest<CreateAssessmentV4.Response>(
+        'POST',
+        CreateAssessmentV4.getEndpoint(this.hostUrl, location, parsedTraceId),
+        this.headersProvider,
+        payload,
+      );
+      return {
+        ...response,
+        trace_id: response.trace_id ?? parsedTraceId,
+        trace_location: response.trace_location ?? payload.trace_location,
+      };
+    }
+
+    const payload: CreateAssessment.Request = { assessment };
     const response = await makeRequest<CreateAssessment.Response>(
       'POST',
-      url,
+      CreateAssessment.getEndpoint(this.hostUrl, traceId),
       this.headersProvider,
       payload,
     );
-    return Feedback.fromJson(response.assessment);
+    return response.assessment;
   }
 
   // === EXPERIMENT METHODS  ===

--- a/libs/typescript/core/src/clients/spec.ts
+++ b/libs/typescript/core/src/clients/spec.ts
@@ -168,6 +168,18 @@ export namespace CreateAssessment {
 }
 
 /**
+ * Create an assessment on a Databricks Unity Catalog trace using the V4 traces API.
+ * Endpoint: POST /api/4.0/mlflow/traces/{location}/{trace_id}/assessments
+ */
+export namespace CreateAssessmentV4 {
+  export const getEndpoint = (host: string, location: string, traceId: string) =>
+    `${host}/api/4.0/mlflow/traces/${encodeURIComponent(location)}/${encodeURIComponent(traceId)}/assessments`;
+
+  export type Request = SerializedAssessment;
+  export type Response = SerializedAssessment;
+}
+
+/**
  * OTLP span upload endpoint for OSS (non-Databricks) tracking servers.
  *
  * Endpoint: POST /v1/traces

--- a/libs/typescript/core/src/core/entities/assessment.ts
+++ b/libs/typescript/core/src/core/entities/assessment.ts
@@ -1,6 +1,7 @@
 /**
  * TypeScript counterparts of Python `mlflow.entities.assessment` for the
- * V3 assessments REST API. Field names on the wire are proto JSON (snake_case).
+ * V3 and Databricks V4 assessments REST APIs. Field names on the wire are proto JSON
+ * (snake_case).
  */
 
 export const AssessmentSourceType = {
@@ -20,6 +21,15 @@ export type FeedbackValueType =
   | FeedbackPrimitive
   | FeedbackPrimitive[]
   | { [key: string]: FeedbackPrimitive | FeedbackValueType };
+
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+export type ExpectationValueType = Exclude<JsonValue, null>;
 
 /** Matches Python `mlflow.entities.assessment_error` truncation. */
 export const STACK_TRACE_TRUNCATION_PREFIX = '[Stack trace is truncated]\n...\n';
@@ -52,6 +62,27 @@ export interface SerializedFeedbackValue {
   error?: SerializedAssessmentError;
 }
 
+export interface SerializedExpectationValue {
+  value?: unknown;
+  serialized_value?: {
+    serialization_format?: string;
+    value?: string;
+  };
+}
+
+export interface SerializedV4TraceLocation {
+  type: 'UC_SCHEMA' | 'UC_TABLE_PREFIX';
+  uc_schema?: {
+    catalog_name: string;
+    schema_name: string;
+  };
+  uc_table_prefix?: {
+    catalog_name: string;
+    schema_name: string;
+    table_prefix: string;
+  };
+}
+
 export interface SerializedAssessment {
   assessment_id?: string;
   assessment_name: string;
@@ -61,13 +92,14 @@ export interface SerializedAssessment {
   create_time?: string;
   last_update_time?: string;
   feedback?: SerializedFeedbackValue;
-  expectation?: unknown;
+  expectation?: SerializedExpectationValue;
   issue?: unknown;
   rationale?: string;
   error?: SerializedAssessmentError;
   metadata?: Record<string, string>;
   overrides?: string;
   valid?: boolean;
+  trace_location?: SerializedV4TraceLocation;
 }
 
 export class Feedback {
@@ -188,7 +220,7 @@ export class Feedback {
             stackTrace: errorJson.stack_trace,
           }
         : undefined,
-      traceId: json.trace_id,
+      traceId: traceIdFromJson(json),
       spanId: json.span_id,
       rationale: json.rationale,
       metadata: json.metadata,
@@ -201,10 +233,117 @@ export class Feedback {
   }
 }
 
-export type Assessment = Feedback | SerializedAssessment;
+const JSON_SERIALIZATION_FORMAT = 'JSON_FORMAT';
+
+export class Expectation {
+  name: string;
+  source: AssessmentSource;
+  value: ExpectationValueType;
+  traceId?: string;
+  spanId?: string;
+  metadata?: Record<string, string>;
+  assessmentId?: string;
+  createTime?: string;
+  lastUpdateTime?: string;
+  valid?: boolean;
+
+  constructor(params: {
+    name: string;
+    value: ExpectationValueType;
+    source?: AssessmentSource;
+    traceId?: string;
+    spanId?: string;
+    metadata?: Record<string, string>;
+    assessmentId?: string;
+    createTime?: string;
+    lastUpdateTime?: string;
+    valid?: boolean;
+  }) {
+    if (params.value == null) {
+      throw new Error('logExpectation requires `value`.');
+    }
+    this.name = params.name;
+    this.source = params.source
+      ? {
+          sourceType: standardizeSourceType(params.source.sourceType),
+          sourceId: params.source.sourceId || 'default',
+        }
+      : { sourceType: AssessmentSourceType.HUMAN, sourceId: 'default' };
+    this.value = params.value;
+    this.traceId = params.traceId;
+    this.spanId = params.spanId;
+    this.metadata = params.metadata;
+    this.assessmentId = params.assessmentId;
+    this.createTime = params.createTime;
+    this.lastUpdateTime = params.lastUpdateTime;
+    this.valid = params.valid;
+  }
+
+  toJson(): SerializedAssessment {
+    const json: SerializedAssessment = {
+      assessment_name: this.name,
+      source: {
+        source_type: this.source.sourceType,
+        source_id: this.source.sourceId,
+      },
+      expectation: serializeExpectationValue(this.value),
+    };
+    if (this.assessmentId != null) {
+      json.assessment_id = this.assessmentId;
+    }
+    if (this.traceId != null) {
+      json.trace_id = this.traceId;
+    }
+    if (this.spanId != null) {
+      json.span_id = this.spanId;
+    }
+    if (this.createTime != null) {
+      json.create_time = this.createTime;
+    }
+    if (this.lastUpdateTime != null) {
+      json.last_update_time = this.lastUpdateTime;
+    }
+    if (this.metadata != null) {
+      json.metadata = this.metadata;
+    }
+    if (this.valid != null) {
+      json.valid = this.valid;
+    }
+    return json;
+  }
+
+  static fromJson(json: SerializedAssessment): Expectation {
+    if (!json.expectation) {
+      throw new Error('Invalid expectation assessment: missing expectation value.');
+    }
+    return new Expectation({
+      name: json.assessment_name,
+      source: json.source
+        ? {
+            sourceType: standardizeSourceType(json.source.source_type),
+            sourceId: json.source.source_id || 'default',
+          }
+        : undefined,
+      value: deserializeExpectationValue(json.expectation),
+      traceId: traceIdFromJson(json),
+      spanId: json.span_id,
+      metadata: json.metadata,
+      assessmentId: json.assessment_id,
+      createTime: json.create_time,
+      lastUpdateTime: json.last_update_time,
+      valid: json.valid,
+    });
+  }
+}
+
+export type Assessment = Feedback | Expectation | SerializedAssessment;
 
 export function isFeedback(assessment: Assessment): assessment is Feedback {
   return assessment instanceof Feedback;
+}
+
+export function isExpectation(assessment: Assessment): assessment is Expectation {
+  return assessment instanceof Expectation;
 }
 
 /** Truncate stack traces the same way as Python `AssessmentError.to_proto`. */
@@ -234,14 +373,94 @@ export function assessmentFromJson(json: SerializedAssessment): Assessment {
   if (json.feedback) {
     return Feedback.fromJson(json);
   }
+  if (json.expectation) {
+    return Expectation.fromJson(json);
+  }
   return json;
 }
 
 export function assessmentToJson(assessment: Assessment): SerializedAssessment {
-  if (assessment instanceof Feedback) {
+  if (assessment instanceof Feedback || assessment instanceof Expectation) {
     return assessment.toJson();
   }
   return assessment;
+}
+
+export function serializeV4TraceLocation(location: string): SerializedV4TraceLocation {
+  const parts = location.split('.');
+  if (parts.length === 2 && parts.every(Boolean)) {
+    const [catalogName, schemaName] = parts;
+    return {
+      type: 'UC_SCHEMA',
+      uc_schema: { catalog_name: catalogName, schema_name: schemaName },
+    };
+  }
+  if (parts.length === 3 && parts.every(Boolean)) {
+    const [catalogName, schemaName, tablePrefix] = parts;
+    return {
+      type: 'UC_TABLE_PREFIX',
+      uc_table_prefix: {
+        catalog_name: catalogName,
+        schema_name: schemaName,
+        table_prefix: tablePrefix,
+      },
+    };
+  }
+  throw new Error(
+    `Invalid UC location: ${location}. Expected format: <catalog>.<schema>[.<table_prefix>].`,
+  );
+}
+
+function traceIdFromJson(json: SerializedAssessment): string | undefined {
+  if (!json.trace_id || !json.trace_location) {
+    return json.trace_id;
+  }
+  const location = json.trace_location.uc_schema
+    ? `${json.trace_location.uc_schema.catalog_name}.${json.trace_location.uc_schema.schema_name}`
+    : json.trace_location.uc_table_prefix
+      ? `${json.trace_location.uc_table_prefix.catalog_name}.${json.trace_location.uc_table_prefix.schema_name}.${json.trace_location.uc_table_prefix.table_prefix}`
+      : undefined;
+  return location ? `trace:/${location}/${json.trace_id}` : json.trace_id;
+}
+
+function serializeExpectationValue(value: ExpectationValueType): SerializedExpectationValue {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return { value };
+  }
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new Error('Expectation value must be JSON-serializable.');
+  }
+  if (serialized === undefined) {
+    throw new Error('Expectation value must be JSON-serializable.');
+  }
+  return {
+    serialized_value: {
+      serialization_format: JSON_SERIALIZATION_FORMAT,
+      value: serialized,
+    },
+  };
+}
+
+function deserializeExpectationValue(value: SerializedExpectationValue): ExpectationValueType {
+  if (value.serialized_value) {
+    if (value.serialized_value.serialization_format !== JSON_SERIALIZATION_FORMAT) {
+      throw new Error(
+        `Unknown expectation serialization format: ${value.serialized_value.serialization_format}. ` +
+          `Only ${JSON_SERIALIZATION_FORMAT} is supported.`,
+      );
+    }
+    if (value.serialized_value.value == null) {
+      throw new Error('Invalid serialized expectation: missing value.');
+    }
+    return JSON.parse(value.serialized_value.value) as ExpectationValueType;
+  }
+  if (value.value == null) {
+    throw new Error('Invalid expectation assessment: missing value.');
+  }
+  return value.value as ExpectationValueType;
 }
 
 export function standardizeSourceType(sourceType: string): AssessmentSourceTypeName {

--- a/libs/typescript/core/src/core/entities/trace_info.ts
+++ b/libs/typescript/core/src/core/entities/trace_info.ts
@@ -10,6 +10,7 @@ import {
   assessmentFromJson,
   assessmentToJson,
   isFeedback,
+  isExpectation,
   type Assessment,
   type SerializedAssessment,
 } from './assessment';
@@ -188,7 +189,7 @@ export class TraceInfo {
 }
 
 function normalizeAssessment(assessment: Assessment | SerializedAssessment): Assessment {
-  if (isFeedback(assessment)) {
+  if (isFeedback(assessment) || isExpectation(assessment)) {
     return assessment;
   }
   return assessmentFromJson(assessment);

--- a/libs/typescript/core/src/index.ts
+++ b/libs/typescript/core/src/index.ts
@@ -36,17 +36,21 @@ export type { Trace } from './core/entities/trace';
 export type { TraceInfo, TokenUsage } from './core/entities/trace_info';
 export {
   AssessmentSourceType,
+  Expectation,
   Feedback,
   assessmentFromJson,
   assessmentToJson,
   isFeedback,
+  isExpectation,
 } from './core/entities/assessment';
 export type {
   Assessment,
   AssessmentError,
   AssessmentSource,
   AssessmentSourceTypeName,
+  ExpectationValueType,
   FeedbackValueType,
+  JsonValue,
   SerializedAssessment,
 } from './core/entities/assessment';
 export type { TraceData } from './core/entities/trace_data';

--- a/libs/typescript/core/tests/clients/client.test.ts
+++ b/libs/typescript/core/tests/clients/client.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto';
 import * as mlflow from '../../src';
 import { MlflowClient, type SearchTracesOptions } from '../../src/clients/client';
 import type { ArtifactsClient } from '../../src/clients/artifacts';
-import { Feedback } from '../../src/core/entities/assessment';
+import { Expectation, Feedback } from '../../src/core/entities/assessment';
 import { Trace } from '../../src/core/entities/trace';
 import { TraceData } from '../../src/core/entities/trace_data';
 import { TraceInfo } from '../../src/core/entities/trace_info';
@@ -184,6 +184,51 @@ describe('MlflowClient', () => {
           source: { sourceType: 'ROBOT' as 'HUMAN', sourceId: 'bot' },
         }),
       ).rejects.toThrow(/Invalid assessment source type/);
+    });
+  });
+
+  describe('logExpectation', () => {
+    it('logs an expectation and preserves it on getTraceInfo', async () => {
+      const traceId = randomUUID();
+      await client.createTrace(
+        new TraceInfo({
+          traceId,
+          traceLocation: {
+            type: TraceLocationType.MLFLOW_EXPERIMENT,
+            mlflowExperiment: { experimentId },
+          },
+          state: TraceState.OK,
+          requestTime: 1000,
+        }),
+      );
+
+      const created = await client.logExpectation({
+        traceId,
+        name: 'expected_answer',
+        value: { answer: 'Paris', sources: ['encyclopedia'] },
+        metadata: { suite: 'typescript' },
+      });
+
+      expect(created).toBeInstanceOf(Expectation);
+      expect(created.value).toEqual({ answer: 'Paris', sources: ['encyclopedia'] });
+      expect(created.source.sourceType).toBe('HUMAN');
+      expect(created.assessmentId).toBeDefined();
+
+      const retrieved = await client.getTraceInfo(traceId);
+      const expectation = retrieved.assessments.find(
+        (assessment) => assessment instanceof Expectation && assessment.name === 'expected_answer',
+      ) as Expectation | undefined;
+      expect(expectation?.value).toEqual({ answer: 'Paris', sources: ['encyclopedia'] });
+    });
+
+    it('rejects missing values', async () => {
+      await expect(
+        client.logExpectation({
+          traceId: randomUUID(),
+          name: 'expected_answer',
+          value: null as never,
+        }),
+      ).rejects.toThrow(/logExpectation requires/);
     });
   });
 

--- a/libs/typescript/core/tests/core/entities/assessment.test.ts
+++ b/libs/typescript/core/tests/core/entities/assessment.test.ts
@@ -1,5 +1,6 @@
 import {
   AssessmentSourceType,
+  Expectation,
   Feedback,
   STACK_TRACE_TRUNCATION_LENGTH,
   STACK_TRACE_TRUNCATION_PREFIX,
@@ -7,6 +8,8 @@ import {
   assessmentToJson,
   assertFeedbackPayload,
   isFeedback,
+  isExpectation,
+  serializeV4TraceLocation,
   standardizeSourceType,
   truncateStackTrace,
 } from '../../../src/core/entities/assessment';
@@ -65,21 +68,82 @@ describe('assessment entities', () => {
     expect(() => assertFeedbackPayload({ error: 'failed' })).not.toThrow();
   });
 
-  it('leaves expectation assessments opaque so TraceInfo does not drop them', () => {
+  it('parses expectation assessments into typed entities', () => {
     const raw = {
       assessment_name: 'expected_response',
+      source: { source_type: 'HUMAN', source_id: 'reviewer' },
       expectation: { value: 'Paris' },
     };
     const parsed = assessmentFromJson(raw);
-    expect(parsed).toEqual(raw);
+    expect(parsed).toBeInstanceOf(Expectation);
+    expect((parsed as Expectation).value).toBe('Paris');
     expect(assessmentToJson(parsed)).toEqual(raw);
+  });
+
+  it('serializes structured expectation values like the Python SDK', () => {
+    const expectation = new Expectation({
+      name: 'expected_response',
+      value: { answer: 'Paris', citations: ['source-1'] },
+    });
+
+    expect(expectation.toJson().expectation).toEqual({
+      serialized_value: {
+        serialization_format: 'JSON_FORMAT',
+        value: '{"answer":"Paris","citations":["source-1"]}',
+      },
+    });
+    expect(Expectation.fromJson(expectation.toJson()).value).toEqual({
+      answer: 'Paris',
+      citations: ['source-1'],
+    });
+  });
+
+  it('defaults expectation sources to HUMAN and rejects null values', () => {
+    expect(new Expectation({ name: 'answer', value: 'Paris' }).source.sourceType).toBe('HUMAN');
+    expect(() => new Expectation({ name: 'answer', value: null as never })).toThrow(
+      /logExpectation requires/,
+    );
+  });
+
+  it('serializes UC schema and table-prefix locations for V4 assessments', () => {
+    expect(serializeV4TraceLocation('cat.sch')).toEqual({
+      type: 'UC_SCHEMA',
+      uc_schema: { catalog_name: 'cat', schema_name: 'sch' },
+    });
+    expect(serializeV4TraceLocation('cat.sch.tbl')).toEqual({
+      type: 'UC_TABLE_PREFIX',
+      uc_table_prefix: {
+        catalog_name: 'cat',
+        schema_name: 'sch',
+        table_prefix: 'tbl',
+      },
+    });
+    expect(() => serializeV4TraceLocation('cat')).toThrow(/Invalid UC location/);
+  });
+
+  it('reconstructs a V4 trace ID from an assessment response', () => {
+    const parsed = Feedback.fromJson({
+      assessment_name: 'correctness',
+      trace_id: 'abcdef',
+      trace_location: {
+        type: 'UC_TABLE_PREFIX',
+        uc_table_prefix: {
+          catalog_name: 'cat',
+          schema_name: 'sch',
+          table_prefix: 'tbl',
+        },
+      },
+      feedback: { value: true },
+    });
+    expect(parsed.traceId).toBe('trace:/cat.sch.tbl/abcdef');
   });
 
   it('exports isFeedback for public Assessment narrowing', () => {
     const feedback = new Feedback({ name: 'correctness', value: true });
-    const opaque = { assessment_name: 'expected_response', expectation: { value: 'Paris' } };
+    const expectation = new Expectation({ name: 'expected_response', value: 'Paris' });
     expect(isFeedback(feedback)).toBe(true);
-    expect(isFeedback(opaque)).toBe(false);
+    expect(isFeedback(expectation)).toBe(false);
+    expect(isExpectation(expectation)).toBe(true);
   });
 
   it('maps string error overload to ASSESSMENT_ERROR like Python Feedback', () => {

--- a/libs/typescript/core/tests/exporters/uc_table.test.ts
+++ b/libs/typescript/core/tests/exporters/uc_table.test.ts
@@ -38,6 +38,7 @@ import {
 import { TraceInfo } from '../../src/core/entities/trace_info';
 import { TraceState } from '../../src/core/entities/trace_state';
 import { DATABRICKS_UC_TABLE_HEADER, TraceMetadataKey } from '../../src/core/constants';
+import { Expectation, Feedback } from '../../src/core/entities/assessment';
 
 const testHost = 'https://dbc-12345.cloud.databricks.com';
 const testToken = 'test-token';
@@ -137,6 +138,60 @@ describe('MlflowClient UC methods', () => {
       },
     });
     expect(returned.traceLocation.ucTablePrefix?.otelSpansTableName).toBe('cat.sch.tbl_otel_spans');
+  });
+
+  it.each([
+    {
+      method: 'logFeedback',
+      invoke: (traceId: string) =>
+        client.logFeedback({ traceId, name: 'correctness', value: true }),
+      value: { feedback: { value: true } },
+      entity: Feedback,
+    },
+    {
+      method: 'logExpectation',
+      invoke: (traceId: string) =>
+        client.logExpectation({ traceId, name: 'expected_answer', value: 'Paris' }),
+      value: { expectation: { value: 'Paris' } },
+      entity: Expectation,
+    },
+  ])('$method POSTs directly to the V4 assessment endpoint', async ({ invoke, value, entity }) => {
+    const location = 'cat.sch.tbl';
+    const otelTraceId = 'abcdef1234567890abcdef1234567890';
+    const traceId = `trace:/${location}/${otelTraceId}`;
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post(
+        `${testHost}/api/4.0/mlflow/traces/${location}/${otelTraceId}/assessments`,
+        async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({
+            ...capturedBody,
+            assessment_id: 'a-1',
+          });
+        },
+      ),
+    );
+
+    const created = await invoke(traceId);
+
+    expect(capturedBody).toMatchObject({
+      assessment_name: expect.any(String),
+      trace_id: otelTraceId,
+      trace_location: {
+        type: 'UC_TABLE_PREFIX',
+        uc_table_prefix: {
+          catalog_name: 'cat',
+          schema_name: 'sch',
+          table_prefix: 'tbl',
+        },
+      },
+      ...value,
+    });
+    expect(capturedBody).not.toHaveProperty('assessment');
+    expect(created).toBeInstanceOf(entity);
+    expect(created.traceId).toBe(traceId);
+    expect(created.assessmentId).toBe('a-1');
   });
 
   it('exportOtlpSpansToUc constructs an OTLP proto exporter with the UC table header', async () => {


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25169

### What changes are proposed in this pull request?

Add `MlflowClient.logExpectation` to the TypeScript SDK and represent expectations as typed entities alongside feedback.

Automatically route both `logFeedback` and `logExpectation` to the Databricks V4 assessments endpoint for `trace:/<location>/<trace-id>` trace IDs. V4 requests use the raw trace ID, include the UC trace location, and send the assessment as the direct request body while preserving the existing V3 request format.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Validated with:

- `npm run -C libs/typescript/core build`
- `npm run -C libs/typescript/core test -- --runInBand tests/clients/client.test.ts`
- Targeted entity, trace-info, and V4 assessment tests (20 tests)
- Targeted ESLint and Prettier checks for all modified TypeScript files

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

The TypeScript README now demonstrates `logExpectation` and documents automatic V4 routing.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

The tracing skill does not currently document these `MlflowClient` assessment methods.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The TypeScript SDK now supports logging expectations and can log feedback and expectations to Databricks Unity Catalog traces through the V4 assessments API.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g. 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g. 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
