### PR TITLE
Fix `add_dataset_to_experiments` binding str `experiment_id` against INTEGER column on PostgreSQL (psycopg v3)

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -7944,16 +7944,30 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
 
             experiment_ids_str = [str(exp_id) for exp_id in experiment_ids]
 
+            # ``SqlExperiment.experiment_id`` is an INTEGER column but REST callers
+            # pass string IDs. psycopg2 sent them as untyped literals PostgreSQL
+            # would coerce; psycopg v3 binds them as typed VARCHAR and PostgreSQL
+            # rejects the comparison ("operator does not exist:
+            # integer = character varying"). Coerce with the same error contract
+            # as ``_get_experiment``/``list_scorers_across_experiments``.
+            try:
+                experiment_ids_int = [int(exp_id) for exp_id in experiment_ids]
+            except (ValueError, TypeError):
+                raise MlflowException(
+                    "Invalid experiment IDs: experiment IDs must be valid integers.",
+                    INVALID_PARAMETER_VALUE,
+                )
+
             accessible_exp_ids = (
                 {
                     str(row[0])
                     for row in self
                     ._get_query(session, SqlExperiment)
-                    .filter(SqlExperiment.experiment_id.in_(experiment_ids_str))
+                    .filter(SqlExperiment.experiment_id.in_(experiment_ids_int))
                     .with_entities(SqlExperiment.experiment_id)
                     .all()
                 }
-                if experiment_ids_str
+                if experiment_ids_int
                 else set()
             )
 

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_eval_datasets.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_eval_datasets.py
@@ -713,6 +713,49 @@ def test_dataset_get_experiment_ids(store):
     assert result == []
 
 
+def test_add_dataset_to_experiments(store):
+    experiment_ids = _create_experiments(store, ["add_exp_1", "add_exp_2", "add_exp_3"])
+    created_dataset = store.create_dataset(
+        name="add_to_experiments_dataset",
+        experiment_ids=[experiment_ids[0]],
+    )
+
+    store.add_dataset_to_experiments(
+        created_dataset.dataset_id, [experiment_ids[1], experiment_ids[2]]
+    )
+
+    fetched_experiment_ids = store.get_dataset_experiment_ids(created_dataset.dataset_id)
+    assert set(fetched_experiment_ids) == set(experiment_ids)
+
+
+def test_add_dataset_to_experiments_nonexistent_experiment_raises(store):
+    experiment_ids = _create_experiments(store, ["add_exp_missing"])
+    created_dataset = store.create_dataset(
+        name="add_to_missing_experiment_dataset",
+        experiment_ids=experiment_ids,
+    )
+
+    with pytest.raises(MlflowException, match="No Experiment with id="):
+        store.add_dataset_to_experiments(created_dataset.dataset_id, ["999999"])
+
+
+def test_add_dataset_to_experiments_non_numeric_id_raises(store):
+    # Regression test: SqlExperiment.experiment_id is an INTEGER column. Passing a
+    # non-numeric id must raise a clean validation error instead of reaching the
+    # database, where it would previously fail with a raw
+    # "operator does not exist: integer = character varying" error on
+    # PostgreSQL + psycopg v3 backends (silently coerced by SQLite/psycopg2, which
+    # is why this went unnoticed in CI).
+    experiment_ids = _create_experiments(store, ["add_exp_non_numeric"])
+    created_dataset = store.create_dataset(
+        name="add_to_non_numeric_experiment_dataset",
+        experiment_ids=experiment_ids,
+    )
+
+    with pytest.raises(MlflowException, match="must be valid integers"):
+        store.add_dataset_to_experiments(created_dataset.dataset_id, ["not-a-number"])
+
+
 def test_dataset_tags_with_sql_backend(store):
     tags = {"environment": "production", "version": "2.0", "team": "ml-ops"}
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/mlflow/mlflow/issues/25282, https://github.com/mlflow/mlflow/pull/25315, https://github.com/mlflow/mlflow/issues/25188, https://github.com/mlflow/mlflow/issues/24592

### What changes are proposed in this pull request?

`add_dataset_to_experiments` validates caller-supplied experiment ids by filtering `SqlExperiment.experiment_id` (an `INTEGER` column) with a stringified id list:

```python
experiment_ids_str = [str(exp_id) for exp_id in experiment_ids]
accessible_exp_ids = (
    {
        str(row[0])
        for row in self._get_query(session, SqlExperiment)
        .filter(SqlExperiment.experiment_id.in_(experiment_ids_str))
        .with_entities(SqlExperiment.experiment_id)
        .all()
    }
    ...
```

`psycopg2` sends string parameters as untyped literals that PostgreSQL coerces implicitly, so this went unnoticed on CI (SQLite) and on psycopg2-backed Postgres. `psycopg v3` binds them as typed `VARCHAR`, and PostgreSQL rejects the comparison outright:

```
operator does not exist: integer = character varying
LINE 3: WHERE experiments.experiment_id IN ($1::VARCHAR)
```

This breaks every `add_dataset_to_experiments` call on a PostgreSQL + psycopg v3 tracking backend (used by `mlflow.genai.datasets` to attach an existing evaluation dataset to additional experiments).

This is the same VARCHAR-vs-INTEGER family as #25282 (scorer store methods, fixed in #25315) and #25188/#24592 — same root cause, a different call site that wasn't covered by any of those fixes. I found it while triaging #25282 and confirming whether the gap was isolated to the scorer methods or wider in the tracking store.

Fix: coerce ids the same way the already-fixed methods do, matching the established `int(experiment_id)` convention used elsewhere in this store (`_get_experiment`, `list_scorers_across_experiments`), and raise the same `INVALID_PARAMETER_VALUE` contract for non-numeric ids. The stringified list (`experiment_ids_str`) is still used for the `SqlEntityAssociation` comparisons and row construction further down, since `destination_id` there is a generic `String` column (correct as-is, not part of this bug).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added three tests to `test_sqlalchemy_store_eval_datasets.py`: a happy-path add, a nonexistent-but-numeric experiment id (existing `RESOURCE_DOES_NOT_EXIST` behavior, unchanged), and a non-numeric id (new `INVALID_PARAMETER_VALUE` validation, mirroring the test added for `list_scorers_across_experiments` in #25315). All 38 tests in the file pass, both `workspace-disabled` and `workspace-enabled`.

Also verified end-to-end against a **real PostgreSQL 17 + psycopg v3 backend** (not just SQLite, since SQLite's loose typing hides this class of bug — that's how it survived unnoticed here):
- Unmodified code: `store.add_dataset_to_experiments(...)` reproduces the exact reported error (`psycopg.errors.UndefinedFunction: operator does not exist: integer = character varying`).
- With this fix: the same call succeeds and returns the correct experiment ids.

Ran the full `tests/store/tracking/sqlalchemy_store/` suite as a regression check (2283 passed, 25 skipped). The 16 failures present in that run are pre-existing on unmodified `master` too (Windows `file:///` artifact-URI formatting in `test_sqlalchemy_store_experiments.py`/`test_sqlalchemy_store_runs.py`, unrelated to this change — confirmed by running the same tests against `master` directly).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `add_dataset_to_experiments` (used by `mlflow.genai.datasets`) failing with `operator does not exist: integer = character varying` on PostgreSQL tracking backends using psycopg v3.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release