### PR TITLE
feat(helm): configure managed health probes

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -148,6 +148,45 @@ tls:
   secretName: mlflow-tls
 ```
 
+### Health probes
+
+The three probe types have different jobs:
+
+- **Startup** asks whether MLflow has finished starting. While it is failing,
+  liveness and readiness checks are held back. After 30 failed checks, the
+  container is restarted.
+- **Readiness** asks whether MLflow should receive traffic. A failed check
+  removes the pod from service endpoints, but does not restart the container.
+- **Liveness** asks whether a running MLflow process is healthy. Three failed
+  checks cause the container to restart.
+
+To use the older behavior without a startup probe, disable it explicitly:
+
+```yaml
+probes:
+  liveness:
+    initialDelaySeconds: 30
+    timeoutSeconds: 10
+  readiness:
+    initialDelaySeconds: 30
+    timeoutSeconds: 10
+  startup:
+    enabled: false
+```
+
+### Pod security context
+
+The default pod security context sets `runAsNonRoot: true` and
+`seccompProfile.type: RuntimeDefault`, while leaving `runAsUser` and `fsGroup`
+unset so OpenShift can assign namespace-compatible IDs. Explicit IDs remain
+supported when required by the deployment:
+
+```yaml
+podSecurityContext:
+  runAsUser: 1000
+  fsGroup: 1000
+```
+
 ### Ingress
 
 MLflow's host-validation middleware only allows `localhost` and private-IP hosts by default.

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -69,6 +69,7 @@ spec:
             - name: {{ $portName }}
               containerPort: {{ .Values.server.value_options.port }}
               protocol: TCP
+          {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
               path: {{ printf "%s/health" $healthPrefix }}
@@ -76,8 +77,12 @@ spec:
               {{- if .Values.tls.enabled }}
               scheme: HTTPS
               {{- end }}
-            initialDelaySeconds: 15
-            periodSeconds: 20
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
             httpGet:
               path: {{ printf "%s/health" $healthPrefix }}
@@ -85,8 +90,24 @@ spec:
               {{- if .Values.tls.enabled }}
               scheme: HTTPS
               {{- end }}
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ printf "%s/health" $healthPrefix }}
+              port: {{ $portName }}
+              {{- if .Values.tls.enabled }}
+              scheme: HTTPS
+              {{- end }}
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
           {{- if or .Values.mlflow.backendStoreUri .Values.mlflow.backendStoreUriFrom .Values.mlflow.registryStoreUri .Values.mlflow.registryStoreUriFrom .Values.mlflow.defaultArtifactRoot .Values.mlflow.artifactsDestination .Values.env }}
           env:
             {{- if or .Values.mlflow.backendStoreUri .Values.mlflow.backendStoreUriFrom }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -46,8 +46,49 @@ server:
   flag_options: []
 
   # staticPrefix: path prefix when MLflow is served under a subpath (e.g. /mlflow).
-  # Aligns the --static-prefix server arg and liveness/readiness probe paths.
+  # Aligns the --static-prefix server arg and health probe paths.
   staticPrefix: ""
+
+# HTTP health probes for the MLflow server. The chart owns the request handler
+# and always probes the health endpoint on the server's named port.
+#
+# Default sequence:
+#
+#   MLflow container starts
+#     |
+#     |-- Startup probe immediately
+#     |   GET /health every 10s
+#     |   10s timeout
+#     |   up to 30 failures (~5 minutes)
+#     |
+#     |-- Once startup succeeds:
+#           Readiness starts after 5s, then every 10s
+#           Liveness starts after 15s, then every 20s
+#
+# Startup asks, "Has MLflow finished starting?" Failure eventually restarts
+# the container. Readiness asks, "Should this pod receive traffic?" Failure
+# removes it from service, but does not restart the container. Liveness asks,
+# "Is the running process still healthy?" Three consecutive failures restart
+# it. While startup is failing, readiness and liveness are held back.
+probes:
+  liveness:
+    enabled: true
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 10
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
+  startup:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 30
 
 # Garbage collection via a CronJob that runs `mlflow gc`.
 # Permanently removes soft-deleted runs, experiments, and logged models
@@ -256,8 +297,6 @@ serviceMonitor:
 # Pod-level security context applied to all containers in the pod.
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 1000
-  fsGroup: 1000
   seccompProfile:
     type: RuntimeDefault
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to no existing issue.

### What changes are proposed in this pull request?

- Add managed liveness, readiness, and startup probe configuration to the MLflow Helm chart.
- Keep the chart-owned TLS- and `staticPrefix`-aware `/health` endpoint while exposing probe timing and enablement values.
- Make probe timeouts explicit at 10 seconds; enable startup probing by default with a five-minute failure budget.
- Remove fixed `runAsUser: 1000` and `fsGroup: 1000` defaults so OpenShift can assign namespace-compatible IDs while retaining explicit overrides.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual validation: `helm lint`, `helm template`, rendered probe override checks, TLS/static-prefix checks, security-context checks for Deployment and CronJob, and `git diff --check`.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

This changes Helm deployment configuration, not an MLflow API or agent usage workflow.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The official Helm chart now exposes configurable managed health probes, uses explicit 10-second probe timeouts, and enables a startup probe by default. The chart also omits fixed pod UID/GID defaults so OpenShift can assign namespace-compatible IDs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and GenAI evaluation
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
