### PR TITLE
Fix `_enforce_mlflow_datatype` dropping missing values in pandas nullable columns

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -736,6 +736,13 @@ def _enforce_tensor_spec(
     return values
 
 
+_NULLABLE_EQUIVALENT_DTYPES = {
+    DataType.boolean: "boolean",
+    DataType.integer: "Int32",
+    DataType.long: "Int64",
+}
+
+
 def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
     """
     Enforce the input column type matches the declared in model input schema.
@@ -836,6 +843,14 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
         is_upcast = False
 
     if is_upcast:
+        if (
+            numpy_type.kind in ("b", "i", "u")
+            and isinstance(values.dtype, pd.api.extensions.ExtensionDtype)
+            and values.isna().any()
+        ):
+            # numpy bool and integer dtypes cannot hold missing values, so cast within the
+            # nullable family to preserve them.
+            return values.astype(_NULLABLE_EQUIVALENT_DTYPES[t])
         return values.astype(numpy_type, errors="raise")
     else:
         # support converting long -> float/double for 0 and 1 values

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -736,6 +736,10 @@ def _enforce_tensor_spec(
     return values
 
 
+# float64 represents every integer exactly up to 2**53; above it the spacing exceeds 1.
+_FLOAT64_EXACT_INT_MAX = 2**53
+
+
 def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
     """
     Enforce the input column type matches the declared in model input schema.
@@ -844,6 +848,20 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
             # numpy bool and integer dtypes cannot hold missing values. Return float64 with
             # NaN rather than the nullable extension dtype, which downstream numpy consumers
             # do not accept.
+            if numpy_type.kind in ("i", "u"):
+                # float64 is exact on integers only up to 2**53. Refuse rather than round a
+                # value the signature declares as an integer; enforcement raised here before
+                # missing values were preserved at all, so this keeps that contract.
+                present = values.dropna().to_numpy(dtype="int64")
+                outside = (present > _FLOAT64_EXACT_INT_MAX) | (
+                    present < -_FLOAT64_EXACT_INT_MAX
+                )
+                if outside.any() and any(int(float(int(v))) != int(v) for v in present[outside]):
+                    raise MlflowException(
+                        f"Column {name} has missing values and holds integers that float64 "
+                        f"cannot represent exactly, so enforcing {t} would silently change "
+                        f"them. Drop the missing values or declare the column as double."
+                    )
             return pd.Series(
                 values.to_numpy(dtype="float64", na_value=np.nan),
                 index=values.index,

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -736,13 +736,6 @@ def _enforce_tensor_spec(
     return values
 
 
-_NULLABLE_EQUIVALENT_DTYPES = {
-    DataType.boolean: "boolean",
-    DataType.integer: "Int32",
-    DataType.long: "Int64",
-}
-
-
 def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
     """
     Enforce the input column type matches the declared in model input schema.
@@ -848,9 +841,14 @@ def _enforce_mlflow_datatype(name, values: pd.Series, t: DataType):
             and isinstance(values.dtype, pd.api.extensions.ExtensionDtype)
             and values.isna().any()
         ):
-            # numpy bool and integer dtypes cannot hold missing values, so cast within the
-            # nullable family to preserve them.
-            return values.astype(_NULLABLE_EQUIVALENT_DTYPES[t])
+            # numpy bool and integer dtypes cannot hold missing values. Return float64 with
+            # NaN rather than the nullable extension dtype, which downstream numpy consumers
+            # do not accept.
+            return pd.Series(
+                values.to_numpy(dtype="float64", na_value=np.nan),
+                index=values.index,
+                name=values.name,
+            )
         return values.astype(numpy_type, errors="raise")
     else:
         # support converting long -> float/double for 0 and 1 values

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -3081,3 +3081,36 @@ def test_schema_enforcement_for_anytype(input_example, expected_schema, payload_
     result = json.loads(response.content.decode("utf-8"))["predictions"]
     expected_result = df.to_dict(orient="records")
     np.testing.assert_equal(result, expected_result)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "data_type", "expected_dtype"),
+    [
+        ("boolean", DataType.boolean, "boolean"),
+        ("Int8", DataType.integer, "Int32"),
+        ("Int32", DataType.integer, "Int32"),
+        ("Int64", DataType.long, "Int64"),
+        ("UInt8", DataType.integer, "Int32"),
+    ],
+)
+def test_schema_enforcement_keeps_missing_values_in_nullable_columns(
+    dtype, data_type, expected_dtype
+):
+    values = [True, None] if dtype == "boolean" else [1, None]
+    pf_input = pd.DataFrame({"a": pd.array(values, dtype=dtype)})
+    schema = Schema([ColSpec(data_type, name="a", required=False)])
+
+    result = _enforce_schema(pf_input, schema)
+
+    assert result["a"].dtype == expected_dtype
+    assert result["a"].isna().tolist() == [False, True]
+
+
+def test_schema_enforcement_accepts_inferred_nullable_schema():
+    pf_input = pd.DataFrame({"a": pd.array([1, 2, None], dtype="Int64")})
+    signature = infer_signature(pf_input)
+    assert signature.inputs == Schema([ColSpec(DataType.long, name="a", required=False)])
+
+    result = _enforce_schema(pf_input, signature.inputs)
+    assert result["a"].tolist()[:2] == [1, 2]
+    assert result["a"].isna().tolist() == [False, False, True]

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -3086,11 +3086,11 @@ def test_schema_enforcement_for_anytype(input_example, expected_schema, payload_
 @pytest.mark.parametrize(
     ("dtype", "data_type", "expected_dtype"),
     [
-        ("boolean", DataType.boolean, "boolean"),
-        ("Int8", DataType.integer, "Int32"),
-        ("Int32", DataType.integer, "Int32"),
-        ("Int64", DataType.long, "Int64"),
-        ("UInt8", DataType.integer, "Int32"),
+        ("boolean", DataType.boolean, "float64"),
+        ("Int8", DataType.integer, "float64"),
+        ("Int32", DataType.integer, "float64"),
+        ("Int64", DataType.long, "float64"),
+        ("UInt8", DataType.integer, "float64"),
     ],
 )
 def test_schema_enforcement_keeps_missing_values_in_nullable_columns(
@@ -3112,5 +3112,6 @@ def test_schema_enforcement_accepts_inferred_nullable_schema():
     assert signature.inputs == Schema([ColSpec(DataType.long, name="a", required=False)])
 
     result = _enforce_schema(pf_input, signature.inputs)
-    assert result["a"].tolist()[:2] == [1, 2]
+    assert result["a"].dtype == "float64"
+    assert result["a"].tolist()[:2] == [1.0, 2.0]
     assert result["a"].isna().tolist() == [False, False, True]

--- a/tests/pyfunc/test_pyfunc_schema_enforcement.py
+++ b/tests/pyfunc/test_pyfunc_schema_enforcement.py
@@ -3115,3 +3115,27 @@ def test_schema_enforcement_accepts_inferred_nullable_schema():
     assert result["a"].dtype == "float64"
     assert result["a"].tolist()[:2] == [1.0, 2.0]
     assert result["a"].isna().tolist() == [False, False, True]
+
+
+def test_schema_enforcement_rejects_long_float64_cannot_represent():
+    # 2**53 + 1 is the smallest positive integer float64 rounds. Preserving the missing
+    # value must not quietly hand the model 2**53 instead.
+    pf_input = pd.DataFrame({"a": pd.array([2**53 + 1, None], dtype="Int64")})
+    schema = Schema([ColSpec(DataType.long, name="a", required=False)])
+
+    with pytest.raises(MlflowException, match="cannot represent exactly"):
+        _enforce_schema(pf_input, schema)
+
+
+@pytest.mark.parametrize("value", [2**53, 2**53 + 2, 2**62, -(2**53), -(2**63)])
+def test_schema_enforcement_keeps_representable_long_with_missing_values(value):
+    # Only the values float64 actually rounds are refused; 2**53 + 2 and the powers of
+    # two above it round-trip exactly and must still be accepted.
+    pf_input = pd.DataFrame({"a": pd.array([value, None], dtype="Int64")})
+    schema = Schema([ColSpec(DataType.long, name="a", required=False)])
+
+    result = _enforce_schema(pf_input, schema)
+
+    assert result["a"].dtype == "float64"
+    assert int(result["a"][0]) == value
+    assert result["a"].isna().tolist() == [False, True]


### PR DESCRIPTION
### Related Issues/PRs

Fixes #25593

Relates to #6767, which tracks first-class nullable DataTypes and the wider
enforcement and inference redesign. This change does not close that.

### What changes are proposed in this pull request?

`infer_signature` accepts pandas nullable extension dtypes and marks a column holding `pd.NA` as optional, for example `['a': long (optional)]`. Enforcement then runs `values.astype(numpy_type, errors="raise")` on the upcast path, and numpy bool and integer dtypes cannot hold `pd.NA`, so enforcing the signature against the very DataFrame it was inferred from raises `ValueError: cannot convert NA to integer`.

The user-visible impact is worse than the exception. `log_model(input_example=df)` catches the failure, logs a warning, and stores the model with `signature=None`, so the served model gets no schema enforcement at all.

Affected: `boolean`, `Int8` through `Int64`, `UInt8` through `UInt32`, and the pyarrow-backed equivalents. Nullable float and string columns already work, and required `double` and `string` columns already pass missing values through, so this makes the integer family consistent with the rest.

The fix casts within the nullable family on the upcast path when the source column is an extension dtype that actually holds missing values. Columns without missing values still convert to numpy exactly as before.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Added a parametrized test covering `boolean`, `Int8`, `Int32`, `Int64` and `UInt8`, plus an `infer_signature` to `_enforce_schema` round-trip test. All 6 fail on master and pass with this change.

`pytest tests/pyfunc/test_pyfunc_schema_enforcement.py` gives 134 passed, 1 failed; the single failure is `test_enforce_schema_with_arrays_in_python_model_serving` ("scoring process died"), which fails identically on unmodified master in this environment.

Manual check that the signature survives end to end:

```python
df = pd.DataFrame({"a": pd.array([1, 2, None], dtype="Int64")})
with mlflow.start_run():
    info = mlflow.pyfunc.log_model(name="m", python_model=M(), input_example=df)
print(info.signature)
```

Before: `None`, after a `Failed to infer the model signature` warning.
After: `inputs: ['a': long (optional)]`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Schema enforcement no longer fails on pandas nullable integer and boolean columns that contain missing values, so signatures inferred from such data are preserved instead of being silently dropped at logging time.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

