### PR TITLE
Add `texttable` to dev script requirements

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -4,6 +4,7 @@ requests
 packaging
 pydantic
 pyyaml
+texttable
 toml
 ./dev/pypi
 ./dev/flavors


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25081 (which added the `texttable` import).

### What changes are proposed in this pull request?

`dev/gen_rest_api.py` imports `from texttable import Texttable`, and `tests/dev/test_gen_rest_api.py` imports that module, so `texttable` must be present wherever the dev scripts and their tests run. It is declared in the `test` dependency group but was never added to `dev/requirements.txt`. As a result, an environment that installs only the dev script requirements (for example, the "Test requirements" workflow) fails to collect `tests/dev/test_gen_rest_api.py`:

```
ImportError while importing test module '.../tests/dev/test_gen_rest_api.py'.
ModuleNotFoundError: No module named 'texttable'
```

This adds `texttable` to `dev/requirements.txt`, alongside the other `gen_rest_api.py` dependencies (`click`, `pydantic`, `pyyaml`).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Covered by the existing "Test requirements" workflow, which collects `tests/dev/test_gen_rest_api.py`.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release