### PR TITLE
Fix host-only Databricks CLI commands in tracing setup

### DIFF
--- a/mlflow/agent/setup/setup.sh
+++ b/mlflow/agent/setup/setup.sh
@@ -926,9 +926,9 @@ ensure_databricks_cli() {
 
 dbx_json() {
 	if [ -n "$PROFILE" ]; then
-		"$DATABRICKS_BIN" "$@" --output json --profile "$PROFILE"
+		DATABRICKS_HOST= "$DATABRICKS_BIN" "$@" --output json --profile "$PROFILE"
 	elif [ -n "$WORKSPACE_URL" ]; then
-		"$DATABRICKS_BIN" "$@" --output json --host "$WORKSPACE_URL"
+		DATABRICKS_CONFIG_PROFILE= DATABRICKS_HOST="$WORKSPACE_URL" "$DATABRICKS_BIN" "$@" --output json
 	else
 		"$DATABRICKS_BIN" "$@" --output json
 	fi
@@ -938,7 +938,7 @@ databricks_token_user() {
 	if [ -n "$PROFILE" ]; then
 		token_json=$("$DATABRICKS_BIN" auth token "$PROFILE" --output json 2>/dev/null) || return
 	elif [ -n "$WORKSPACE_URL" ]; then
-		token_json=$("$DATABRICKS_BIN" auth token --host "$WORKSPACE_URL" --output json 2>/dev/null) || return
+		token_json=$(DATABRICKS_CONFIG_PROFILE= DATABRICKS_HOST="$WORKSPACE_URL" "$DATABRICKS_BIN" auth token --output json 2>/dev/null) || return
 	else
 		token_json=$("$DATABRICKS_BIN" auth token --output json 2>/dev/null) || return
 	fi
@@ -973,7 +973,7 @@ databricks_auth_valid() {
 	if [ -n "$PROFILE" ]; then
 		"$DATABRICKS_BIN" auth token "$PROFILE" --output json >/dev/null 2>&1
 	elif [ -n "$WORKSPACE_URL" ]; then
-		"$DATABRICKS_BIN" auth token --host "$WORKSPACE_URL" --output json >/dev/null 2>&1
+		DATABRICKS_CONFIG_PROFILE= DATABRICKS_HOST="$WORKSPACE_URL" "$DATABRICKS_BIN" auth token --output json >/dev/null 2>&1
 	else
 		"$DATABRICKS_BIN" auth token --output json >/dev/null 2>&1
 	fi
@@ -1072,7 +1072,7 @@ authenticate_databricks() {
 		if [ -n "$PROFILE" ]; then
 			"$DATABRICKS_BIN" auth login --host "$WORKSPACE_URL" --profile "$PROFILE" <"$TTY_DEVICE" || die "Databricks authentication failed."
 		else
-			"$DATABRICKS_BIN" auth login --host "$WORKSPACE_URL" <"$TTY_DEVICE" || die "Databricks authentication failed."
+			DATABRICKS_CONFIG_PROFILE= "$DATABRICKS_BIN" auth login --host "$WORKSPACE_URL" <"$TTY_DEVICE" || die "Databricks authentication failed."
 		fi
 		databricks_auth_valid || die "Databricks authentication could not be verified."
 	fi

--- a/tests/agent/test_setup_sh_databricks_e2e.py
+++ b/tests/agent/test_setup_sh_databricks_e2e.py
@@ -34,6 +34,10 @@ calls_path = Path(os.environ["DATABRICKS_TEST_CALLS"])
 with calls_path.open("a") as calls:
     calls.write(json.dumps(args) + "\n")
 
+if "--host" in args and args[:2] != ["auth", "login"]:
+    print(f"unknown flag: --host for {' '.join(args[:2])}", file=sys.stderr)
+    raise SystemExit(2)
+
 routes = json.loads(Path(os.environ["DATABRICKS_TEST_ROUTES"]).read_text())
 state_path = Path(os.environ["DATABRICKS_TEST_STATE"])
 state = json.loads(state_path.read_text()) if state_path.exists() else {}

--- a/tests/agent/test_setup_sh_databricks_e2e.py
+++ b/tests/agent/test_setup_sh_databricks_e2e.py
@@ -32,7 +32,11 @@ from pathlib import Path
 args = sys.argv[1:]
 calls_path = Path(os.environ["DATABRICKS_TEST_CALLS"])
 with calls_path.open("a") as calls:
-    calls.write(json.dumps(args) + "\n")
+    calls.write(json.dumps({
+        "args": args,
+        "host": os.environ.get("DATABRICKS_HOST"),
+        "profile": os.environ.get("DATABRICKS_CONFIG_PROFILE"),
+    }) + "\n")
 
 if "--host" in args and args[:2] != ["auth", "login"]:
     print(f"unknown flag: --host for {' '.join(args[:2])}", file=sys.stderr)
@@ -223,6 +227,18 @@ def _read_calls(config: DatabricksTestConfig) -> list[list[str]]:
 
     Returns:
         One argument array for each Databricks CLI invocation.
+    """
+    return [invocation["args"] for invocation in _read_invocations(config)]
+
+
+def _read_invocations(config: DatabricksTestConfig) -> list[dict[str, object]]:
+    """Read CLI arguments and Databricks selector environment variables.
+
+    Args:
+        config: Test configuration containing the call log path.
+
+    Returns:
+        One invocation record for each Databricks CLI command.
     """
     return [json.loads(line) for line in config.calls_path.read_text().splitlines()]
 
@@ -508,6 +524,59 @@ def test_authentication_fallback_uses_host_and_profile_flags(
         "--profile",
         "DEFAULT",
     ] in _read_calls(databricks_config)
+
+
+@pytest.mark.timeout(30)
+def test_host_only_workspace_propagates_environment(databricks_config: DatabricksTestConfig):
+    routes = _base_routes(token_responses=[{"returncode": 1}, {"stdout": "{}"}])
+    routes[0]["stdout"] = "Name Host Valid\nDEFAULT https://other.example.com YES"
+    _set_routes(
+        databricks_config,
+        routes
+        + [
+            {"args": ["auth", "login"], "stdout": "{}"},
+            {
+                "args": ["experiments", "get-experiment"],
+                "stdout": _experiment_json(trace_destination=None),
+            },
+        ],
+    )
+    env = databricks_config.env | {"DATABRICKS_CONFIG_PROFILE": "AMBIENT"}
+
+    exit_code, output = run_interactive(
+        [
+            str(SETUP_SCRIPT),
+            "--workspace-url",
+            "https://workspace.example.com",
+            "--experiment-id",
+            "existing-id",
+            "--agent",
+            "codex",
+        ],
+        databricks_config.project,
+        env,
+        [],
+    )
+
+    assert exit_code == 0, output
+    invocations = _read_invocations(databricks_config)
+    token_calls = [call for call in invocations if call["args"][:2] == ["auth", "token"]]
+    assert token_calls
+    assert all(call["host"] == "https://workspace.example.com" for call in token_calls)
+    assert all(call["profile"] == "" for call in token_calls)
+    login_call = next(call for call in invocations if call["args"][:2] == ["auth", "login"])
+    assert login_call["args"] == [
+        "auth",
+        "login",
+        "--host",
+        "https://workspace.example.com",
+    ]
+    assert login_call["profile"] == ""
+    experiment_call = next(
+        call for call in invocations if call["args"][:2] == ["experiments", "get-experiment"]
+    )
+    assert experiment_call["host"] == "https://workspace.example.com"
+    assert experiment_call["profile"] == ""
 
 
 @pytest.mark.timeout(30)

--- a/tests/agent/test_setup_sh_unit.py
+++ b/tests/agent/test_setup_sh_unit.py
@@ -321,6 +321,32 @@ resolve_databricks_profile
     assert "points to https://workspace-a.example.com" in result.stderr
 
 
+def test_dbx_json_passes_host_through_environment(tmp_path: Path):
+    databricks = tmp_path / "databricks"
+    databricks.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"${DATABRICKS_HOST:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*\"\n"
+    )
+    databricks.chmod(0o755)
+
+    result = run_shell(
+        """
+DATABRICKS_BIN=$1
+PROFILE=
+WORKSPACE_URL=https://workspace.example.com
+DATABRICKS_CONFIG_PROFILE=AMBIENT
+export DATABRICKS_CONFIG_PROFILE
+dbx_json experiments get-experiment 42
+""",
+        str(databricks),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == (
+        "https://workspace.example.com||experiments get-experiment 42 --output json"
+    )
+
+
 def test_validate_agent_name_rejects_unknown_agent():
     result = run_shell(
         """

--- a/tests/agent/test_setup_sh_unit.py
+++ b/tests/agent/test_setup_sh_unit.py
@@ -324,8 +324,7 @@ resolve_databricks_profile
 def test_dbx_json_passes_host_through_environment(tmp_path: Path):
     databricks = tmp_path / "databricks"
     databricks.write_text(
-        "#!/bin/sh\n"
-        "printf '%s\\n' \"${DATABRICKS_HOST:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*\"\n"
+        "#!/bin/sh\nprintf '%s\\n' \"${DATABRICKS_HOST:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*\"\n"
     )
     databricks.chmod(0o755)
 

--- a/tests/agent/test_setup_sh_unit.py
+++ b/tests/agent/test_setup_sh_unit.py
@@ -324,7 +324,9 @@ resolve_databricks_profile
 def test_dbx_json_passes_host_through_environment(tmp_path: Path):
     databricks = tmp_path / "databricks"
     databricks.write_text(
-        "#!/bin/sh\nprintf '%s\\n' \"${DATABRICKS_HOST:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*\"\n"
+        r"""#!/bin/sh
+printf '%s\n' "${DATABRICKS_HOST:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*"
+"""
     )
     databricks.chmod(0o755)
 
@@ -343,6 +345,34 @@ dbx_json experiments get-experiment 42
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == (
         "https://workspace.example.com||experiments get-experiment 42 --output json"
+    )
+
+
+def test_dbx_json_clears_ambient_host_for_profile(tmp_path: Path):
+    databricks = tmp_path / "databricks"
+    databricks.write_text(
+        r"""#!/bin/sh
+printf '%s\n' "${DATABRICKS_HOST:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*"
+"""
+    )
+    databricks.chmod(0o755)
+
+    result = run_shell(
+        """
+DATABRICKS_BIN=$1
+PROFILE=selected
+WORKSPACE_URL=https://workspace.example.com
+DATABRICKS_HOST=https://ambient.example.com
+DATABRICKS_CONFIG_PROFILE=AMBIENT
+export DATABRICKS_HOST DATABRICKS_CONFIG_PROFILE
+dbx_json experiments get-experiment 42
+""",
+        str(databricks),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == (
+        "|AMBIENT|experiments get-experiment 42 --output json --profile selected"
     )
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25441

### What changes are proposed in this pull request?

Pass a host-only Databricks workspace through `DATABRICKS_HOST` instead of the unsupported global `--host` flag for generated experiment and resource commands. Clear an ambient profile for these calls so it cannot redirect the request.

The Databricks CLI test double now rejects `--host` outside `auth login`, matching the real CLI behavior.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

`uv run pytest tests/agent/test_setup_sh_unit.py tests/agent/test_setup_sh_databricks_e2e.py -q` — 36 passed.

Also verified with `sh -n`, Ruff, and `git diff --check`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixes tracing setup for Databricks workspace URLs that are not backed by a named CLI profile.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release