### PR TITLE
Preserve an unset `max_attempts` in `FallbackConfig.from_proto`

### DIFF
--- a/mlflow/entities/gateway_endpoint.py
+++ b/mlflow/entities/gateway_endpoint.py
@@ -116,7 +116,7 @@ class FallbackConfig(_MlflowObject):
         )
         return cls(
             strategy=strategy,
-            max_attempts=proto.max_attempts,
+            max_attempts=proto.max_attempts if proto.HasField("max_attempts") else None,
         )
 
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -34,7 +34,6 @@ from mlflow.entities import (
     Expectation,
     ExperimentTag,
     FallbackConfig,
-    FallbackStrategy,
     Feedback,
     FileInfo,
     GatewayEndpointModelConfig,
@@ -6072,16 +6071,11 @@ def _create_gateway_endpoint():
             "Name can only contain letters, numbers, underscores, hyphens, and dots."
         )
     # Convert proto fallback_config to entity FallbackConfig
-    fallback_config = None
-    if request_message.HasField("fallback_config"):
-        fallback_config = FallbackConfig(
-            strategy=FallbackStrategy.from_proto(request_message.fallback_config.strategy)
-            if request_message.fallback_config.HasField("strategy")
-            else None,
-            max_attempts=request_message.fallback_config.max_attempts
-            if request_message.fallback_config.HasField("max_attempts")
-            else None,
-        )
+    fallback_config = (
+        FallbackConfig.from_proto(request_message.fallback_config)
+        if request_message.HasField("fallback_config")
+        else None
+    )
 
     for index, config in enumerate(request_message.model_configs):
         _assert_linkage_type_specified(config, index)
@@ -6151,16 +6145,11 @@ def _update_gateway_endpoint():
             "Name can only contain letters, numbers, underscores, hyphens, and dots."
         )
     # Convert proto fallback_config to entity FallbackConfig
-    fallback_config = None
-    if request_message.HasField("fallback_config"):
-        fallback_config = FallbackConfig(
-            strategy=FallbackStrategy.from_proto(request_message.fallback_config.strategy)
-            if request_message.fallback_config.HasField("strategy")
-            else None,
-            max_attempts=request_message.fallback_config.max_attempts
-            if request_message.fallback_config.HasField("max_attempts")
-            else None,
-        )
+    fallback_config = (
+        FallbackConfig.from_proto(request_message.fallback_config)
+        if request_message.HasField("fallback_config")
+        else None
+    )
 
     # Convert proto model_configs to entity GatewayEndpointModelConfig list
     model_configs = None

--- a/tests/entities/test_gateway_endpoint.py
+++ b/tests/entities/test_gateway_endpoint.py
@@ -1,4 +1,5 @@
 from mlflow.entities import (
+    FallbackConfig,
     GatewayEndpoint,
     GatewayEndpointBinding,
     GatewayEndpointModelMapping,
@@ -6,6 +7,7 @@ from mlflow.entities import (
     GatewayModelLinkageType,
     GatewayResourceType,
 )
+from mlflow.entities.gateway_endpoint import FallbackStrategy
 
 
 def test_model_definition_creation_full():
@@ -406,3 +408,24 @@ def test_endpoint_binding_proto_round_trip():
     assert restored.last_updated_at == binding.last_updated_at
     assert restored.created_by == binding.created_by
     assert restored.last_updated_by == binding.last_updated_by
+
+
+def test_fallback_config_proto_round_trip_preserves_unset_max_attempts():
+    config = FallbackConfig(strategy=FallbackStrategy.SEQUENTIAL, max_attempts=None)
+
+    proto = config.to_proto()
+    assert not proto.HasField("max_attempts")
+
+    restored = FallbackConfig.from_proto(proto)
+
+    # None means "try all fallback models"; it must not come back as 0,
+    # which would mean the opposite.
+    assert restored.max_attempts is None
+    assert restored.strategy == config.strategy
+
+
+def test_fallback_config_proto_round_trip_preserves_max_attempts():
+    for max_attempts in (0, 1, 5):
+        config = FallbackConfig(strategy=FallbackStrategy.SEQUENTIAL, max_attempts=max_attempts)
+        restored = FallbackConfig.from_proto(config.to_proto())
+        assert restored.max_attempts == max_attempts

--- a/tests/entities/test_gateway_endpoint.py
+++ b/tests/entities/test_gateway_endpoint.py
@@ -1,5 +1,8 @@
+import pytest
+
 from mlflow.entities import (
     FallbackConfig,
+    FallbackStrategy,
     GatewayEndpoint,
     GatewayEndpointBinding,
     GatewayEndpointModelMapping,
@@ -7,7 +10,6 @@ from mlflow.entities import (
     GatewayModelLinkageType,
     GatewayResourceType,
 )
-from mlflow.entities.gateway_endpoint import FallbackStrategy
 
 
 def test_model_definition_creation_full():
@@ -424,8 +426,8 @@ def test_fallback_config_proto_round_trip_preserves_unset_max_attempts():
     assert restored.strategy == config.strategy
 
 
-def test_fallback_config_proto_round_trip_preserves_max_attempts():
-    for max_attempts in (0, 1, 5):
-        config = FallbackConfig(strategy=FallbackStrategy.SEQUENTIAL, max_attempts=max_attempts)
-        restored = FallbackConfig.from_proto(config.to_proto())
-        assert restored.max_attempts == max_attempts
+@pytest.mark.parametrize("max_attempts", [0, 1, 5])
+def test_fallback_config_proto_round_trip_preserves_max_attempts(max_attempts):
+    config = FallbackConfig(strategy=FallbackStrategy.SEQUENTIAL, max_attempts=max_attempts)
+    restored = FallbackConfig.from_proto(config.to_proto())
+    assert restored.max_attempts == max_attempts

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -14,6 +14,7 @@ from werkzeug.exceptions import RequestedRangeNotSatisfiable
 import mlflow
 from mlflow.entities import (
     Experiment,
+    FallbackStrategy,
     GatewayBudgetPolicy,
     Issue,
     IssueSeverity,
@@ -140,6 +141,9 @@ from mlflow.protos.service_pb2 import (
     SetTraceTag,
     SetTraceTagV3,
     TraceLocation,
+)
+from mlflow.protos.service_pb2 import (
+    FallbackStrategy as ProtoFallbackStrategy,
 )
 from mlflow.protos.service_pb2 import (
     GatewayModelLinkageType as ProtoGatewayModelLinkageType,
@@ -4268,6 +4272,39 @@ def test_create_gateway_endpoint_rejects_unspecified_linkage_type(
     assert "'linkage_type' in model_configs[0]" in response_data["message"]
     assert "PRIMARY, FALLBACK" in response_data["message"]
     mock_tracking_store.create_gateway_endpoint.assert_not_called()
+
+
+@pytest.mark.parametrize("max_attempts", [None, 0, 3])
+def test_create_gateway_endpoint_parses_fallback_config_max_attempts(
+    mock_get_request_message, mock_tracking_store, max_attempts
+):
+    """The handler must preserve an unset `max_attempts` as None.
+
+    The proto field has explicit presence, so leaving it unset has to stay
+    distinct from an explicit 0 once it reaches the entity.
+    """
+    from mlflow.protos.service_pb2 import CreateGatewayEndpoint
+    from mlflow.server.handlers import _create_gateway_endpoint
+
+    request_msg = CreateGatewayEndpoint()
+    request_msg.name = "valid-name"
+    config = request_msg.model_configs.add()
+    config.model_definition_id = "d-123"
+    config.linkage_type = ProtoGatewayModelLinkageType.PRIMARY
+    request_msg.fallback_config.strategy = ProtoFallbackStrategy.SEQUENTIAL
+    if max_attempts is not None:
+        request_msg.fallback_config.max_attempts = max_attempts
+    mock_get_request_message.return_value = request_msg
+
+    mock_endpoint = mock.MagicMock()
+    mock_endpoint.to_proto.return_value = GatewayEndpoint(endpoint_id="ep-123")
+    mock_tracking_store.create_gateway_endpoint.return_value = mock_endpoint
+
+    _create_gateway_endpoint()
+
+    kwargs = mock_tracking_store.create_gateway_endpoint.call_args.kwargs
+    assert kwargs["fallback_config"].max_attempts == max_attempts
+    assert kwargs["fallback_config"].strategy == FallbackStrategy.SEQUENTIAL
 
 
 def test_create_gateway_endpoint_reports_offending_model_config_index(


### PR DESCRIPTION
### Related Issues/PRs

Relates to #19483

### What changes are proposed in this pull request?

`FallbackConfig.to_proto` writes `max_attempts` only when it is set:

```python
if self.max_attempts is not None:
    proto.max_attempts = self.max_attempts
```

but `from_proto` reads it back unconditionally:

```python
return cls(
    strategy=strategy,
    max_attempts=proto.max_attempts,
)
```

For an unset field protobuf returns the scalar default, so `None` becomes `0` on a round trip:

```python
config = FallbackConfig(strategy=FallbackStrategy.SEQUENTIAL, max_attempts=None)
proto = config.to_proto()
proto.HasField("max_attempts")                 # False
FallbackConfig.from_proto(proto).max_attempts  # 0, not None
```

That matters because the docstring gives the two values opposite meanings:

> `max_attempts`: Maximum number of fallback models to try (`None` = try all).

so a config that meant "try all fallback models" comes back meaning "try none". `strategy`, two lines above in the same method, already guards with `HasField`; this makes `max_attempts` consistent with it. The field has presence, so `0` and `None` remain distinguishable — `0` still round-trips as `0`.

I found this with a round-trip check over the `mlflow.entities` classes (`to_proto`/`from_proto`, `to_dict`/`from_dict`); this was the one case where a genuinely optional field lost its value.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added two tests to `tests/entities/test_gateway_endpoint.py`:

- `test_fallback_config_proto_round_trip_preserves_unset_max_attempts` — asserts the proto field is unset and that `None` survives the round trip. Fails without the change with `assert 0 is None`.
- `test_fallback_config_proto_round_trip_preserves_max_attempts` — asserts `0`, `1` and `5` still round-trip, so the `HasField` guard does not swallow a real `0`.

`tests/entities/test_gateway_endpoint.py`: 19 passed. `ruff check` and `ruff format --check` clean with the pinned 0.16.0.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. `FallbackConfig` no longer turns an unset `max_attempts` into `0` when deserialized from protobuf, so the entity round-trips faithfully. Note (per review): the current runtime consumer treats `0` and `None` alike (`max_attempts or len(fallback_models)`), so this corrects the entity/serialization contract rather than changing live routing behaviour.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


