### PR TITLE
Skip `setup.sh` wizard e2e tests on Windows

### DIFF
--- a/tests/agent/setup_sh_test_utils.py
+++ b/tests/agent/setup_sh_test_utils.py
@@ -1,12 +1,17 @@
 import errno
 import os
-import pty
 import select
 import signal
+import sys
 import time
 from pathlib import Path
 
 import pytest
+
+# `pty` (and the `tty`/`termios` it pulls in) is POSIX-only. Guard the import so this helper
+# module is importable on Windows; the tests that call `run_interactive` are skipped there.
+if sys.platform != "win32":
+    import pty
 
 
 def _read_until(fd: int, output: bytearray, expected: str, timeout: float = 10) -> None:

--- a/tests/agent/test_setup_sh_databricks_e2e.py
+++ b/tests/agent/test_setup_sh_databricks_e2e.py
@@ -9,6 +9,12 @@ import pytest
 
 from tests.agent.setup_sh_test_utils import run_interactive
 
+# These tests drive the interactive wizard through a POSIX pseudo-terminal (`pty`), which is
+# unavailable on Windows.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="setup.sh wizard tests require a POSIX pseudo-terminal"
+)
+
 SETUP_SCRIPT = Path(__file__).parents[2] / "mlflow" / "agent" / "setup" / "setup.sh"
 
 

--- a/tests/agent/test_setup_sh_e2e.py
+++ b/tests/agent/test_setup_sh_e2e.py
@@ -20,6 +20,12 @@ from tests.server.auth.auth_test_utils import (
 )
 from tests.tracking.integration_test_utils import _init_server
 
+# These tests drive the interactive wizard through a POSIX pseudo-terminal (`pty`), which is
+# unavailable on Windows.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="setup.sh wizard tests require a POSIX pseudo-terminal"
+)
+
 SETUP_SCRIPT = Path(__file__).parents[2] / "mlflow" / "agent" / "setup" / "setup.sh"
 
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25441 (which added the wizard and these e2e tests).

### What changes are proposed in this pull request?

`tests/agent/setup_sh_test_utils.py` imports `pty` at module scope and drives the interactive wizard through `pty.fork()`. `pty` (and the `tty`/`termios` it pulls in) is POSIX-only, so importing the helper — and therefore *collecting* `tests/agent/test_setup_sh_e2e.py` and `tests/agent/test_setup_sh_databricks_e2e.py` — fails on Windows:

```
tests/agent/setup_sh_test_utils.py:3: in <module>
    import pty
.../lib/pty.py:12: in <module>
    import tty
.../lib/tty.py:5: in <module>
    from termios import *
E   ModuleNotFoundError: No module named 'termios'
```

This:
- guards the `pty` import in the helper with `if sys.platform != "win32"` (matching the existing pattern in `mlflow/agent/setup/select.py`) so the module is importable on Windows, and
- adds a module-level `pytest.mark.skipif(sys.platform == "win32", ...)` to both e2e modules, since they require a POSIX pseudo-terminal.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Both modules collect on POSIX (7 tests each) and are skipped at collection on Windows.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release