### PR TITLE
fix: avoid recreating existing tables during DB initialization (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -85,7 +85,13 @@ def _is_empty_database(engine):
 
 def _initialize_tables(engine):
     _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    missing_tables = [
+        table_name
+        for table_name in InitialBase.metadata.tables
+        if not sqlalchemy.inspect(engine).has_table(table_name)
+    ]
+    if missing_tables:
+        InitialBase.metadata.create_all(engine, tables=[InitialBase.metadata.tables[name] for name in missing_tables])
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What

Fixes a database upgrade failure in MLflow 3.8.x when running `mlflow db upgrade` after an earlier partial migration or when the database already contains some initial tables (e.g., the `secrets` table). The error `pymysql.err.OperationalError: (1050, "Table 'secrets' already exists")` occurs because `_initialize_tables` calls `InitialBase.metadata.create_all(engine)` unconditionally, which attempts to create all tables defined in the initial schema even if they already exist.

## Fix

Modify `_initialize_tables` to first check which tables defined in `InitialBase.metadata` are missing from the database, and only create those missing tables. This prevents the "table already exists" error while still ensuring that all necessary initial tables are present before running Alembic upgrades.

The change is minimal and preserves existing behavior for fresh databases.

Closes #19943