### PR TITLE
helm chart: Decouple Service port from server port

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -71,23 +71,6 @@ jobs:
           render | grep -q 'mlflow.default.svc.cluster.local:5000'
           render --set service.port=80 | grep -q 'mlflow.default.svc.cluster.local:80'
 
-      - name: Render NOTES with a decoupled Service port
-        run: |
-          render() {
-            helm install mlflow charts/ --dry-run=client \
-              --set mlflow.backendStoreUri="sqlite:////tmp/mlflow.db" \
-              --set fullnameOverride=mlflow "$@"
-          }
-          # The LoadBalancer hint must point at the Service port, not the
-          # container port, once they're decoupled.
-          render --set service.type=LoadBalancer | grep -q '^  http://<EXTERNAL-IP>:5000$'
-          render --set service.type=LoadBalancer --set service.port=80 | grep -q '^  http://<EXTERNAL-IP>:80$'
-          # The port-forward hint's local port must stay the (unprivileged)
-          # container port even when the Service port is decoupled and
-          # privileged (e.g. 80), while its remote port follows the Service.
-          render | grep -q 'svc/mlflow 5000:5000$'
-          render --set service.port=80 | grep -q 'svc/mlflow 5000:80$'
-
       - name: Render ServiceMonitor
         run: |
           render() {

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -57,6 +57,37 @@ jobs:
           render | grep -q '^    - port: 5000$'
           render --set service.port=80 | grep -q '^    - port: 80$'
 
+      - name: Render CronJob with a decoupled Service port
+        run: |
+          render() {
+            helm template mlflow charts/ \
+              --set mlflow.backendStoreUri="sqlite:////tmp/mlflow.db" \
+              --set garbageCollection.enabled=true \
+              --set fullnameOverride=mlflow "$@" \
+              -s templates/cronjob.yaml
+          }
+          # MLFLOW_TRACKING_URI must reach the Service on its own port, not
+          # the container port, once they're decoupled.
+          render | grep -q 'mlflow.default.svc.cluster.local:5000'
+          render --set service.port=80 | grep -q 'mlflow.default.svc.cluster.local:80'
+
+      - name: Render NOTES with a decoupled Service port
+        run: |
+          render() {
+            helm install mlflow charts/ --dry-run=client \
+              --set mlflow.backendStoreUri="sqlite:////tmp/mlflow.db" \
+              --set fullnameOverride=mlflow "$@"
+          }
+          # The LoadBalancer hint must point at the Service port, not the
+          # container port, once they're decoupled.
+          render --set service.type=LoadBalancer | grep -q '^  http://<EXTERNAL-IP>:5000$'
+          render --set service.type=LoadBalancer --set service.port=80 | grep -q '^  http://<EXTERNAL-IP>:80$'
+          # The port-forward hint's local port must stay the (unprivileged)
+          # container port even when the Service port is decoupled and
+          # privileged (e.g. 80), while its remote port follows the Service.
+          render | grep -q 'svc/mlflow 5000:5000$'
+          render --set service.port=80 | grep -q 'svc/mlflow 5000:80$'
+
       - name: Render ServiceMonitor
         run: |
           render() {

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -46,6 +46,17 @@ jobs:
       - name: Render templates
         run: helm template mlflow charts/ --set mlflow.backendStoreUri="sqlite:////tmp/mlflow.db"
 
+      - name: Render Service port
+        run: |
+          render() {
+            helm template mlflow charts/ \
+              --set mlflow.backendStoreUri="sqlite:////tmp/mlflow.db" "$@" \
+              -s templates/service.yaml
+          }
+          # Defaults to server.value_options.port when unset.
+          render | grep -q '^    - port: 5000$'
+          render --set service.port=80 | grep -q '^    - port: 80$'
+
       - name: Render ServiceMonitor
         run: |
           render() {

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- $svcPort := include "mlflow.servicePort" . }}
 MLflow has been deployed successfully.
 
 Access the UI:
@@ -10,8 +11,8 @@ Access the UI:
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   http://$NODE_IP:$NODE_PORT
 {{- else if eq .Values.service.type "LoadBalancer" }}
-  http://<EXTERNAL-IP>:{{ .Values.server.value_options.port }}
+  http://<EXTERNAL-IP>:{{ $svcPort }}
 {{- else }}
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "mlflow.fullname" . }} {{ .Values.server.value_options.port }}:{{ .Values.server.value_options.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "mlflow.fullname" . }} {{ .Values.server.value_options.port }}:{{ $svcPort }}
   # Then open: http://127.0.0.1:{{ .Values.server.value_options.port }}
 {{- end }}

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -26,6 +26,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
+{{- define "mlflow.servicePort" -}}
+{{- .Values.service.port | default .Values.server.value_options.port }}
+{{- end }}
+
 {{/*
 Build mlflow server args from .Values.server.
   value_options: map of key/value pairs rendered as --key=value

--- a/charts/templates/cronjob.yaml
+++ b/charts/templates/cronjob.yaml
@@ -73,7 +73,7 @@ spec:
                     ;
               env:
                 - name: MLFLOW_TRACKING_URI
-                  value: {{ printf "%s://%s.%s.svc.cluster.local:%v" (ternary "https" "http" .Values.tls.enabled) (include "mlflow.fullname" .) .Release.Namespace .Values.server.value_options.port | quote }}
+                  value: {{ printf "%s://%s.%s.svc.cluster.local:%s" (ternary "https" "http" .Values.tls.enabled) (include "mlflow.fullname" .) .Release.Namespace (include "mlflow.servicePort" .) | quote }}
                 {{- if .Values.mlflow.backendStoreUriFrom }}
                 - name: MLFLOW_BACKEND_STORE_URI
                   valueFrom:

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.service.type }}
   {{- $portName := ternary "https" "http" .Values.tls.enabled }}
   ports:
-    - port: {{ .Values.server.value_options.port }}
+    - port: {{ .Values.service.port | default .Values.server.value_options.port }}
       targetPort: {{ $portName }}
       protocol: TCP
       name: {{ $portName }}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.service.type }}
   {{- $portName := ternary "https" "http" .Values.tls.enabled }}
   ports:
-    - port: {{ .Values.service.port | default .Values.server.value_options.port }}
+    - port: {{ include "mlflow.servicePort" . }}
       targetPort: {{ $portName }}
       protocol: TCP
       name: {{ $portName }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -96,6 +96,11 @@ service:
   # Service type: ClusterIP, NodePort, or LoadBalancer.
   type: ClusterIP
   annotations: {}
+  # Port the Service listens on. Defaults to server.value_options.port (i.e.
+  # the Service port matches the container port) when not set. Set this to
+  # decouple the two, e.g. to expose the server on the conventional port 80
+  # while it listens internally on 5000.
+  port: ""
 
 # Ingress for external access to the MLflow server.
 ingress:


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs
N/A

### What changes are proposed in this pull request?
In mlflow Helm chart `service.port` and `deployment.containerPort` are currently tied to the same `server.value_options.port`  value, so the `Service` can never expose a conventional port (e.g. 80) while the container listens on a non-privileged one (e.g. 5000).

This PR add an optional `service.port` value; when unset it falls back to `server.value_options.port`, so this is fully backward compatible.

### How is this PR tested?
- [x] New unit/integration tests
- [x] Manual tests

Added CI render checks in `.github/workflows/helm.yml` asserting the Service port, the CronJob `MLFLOW_TRACKING_URI`, and the NOTES LoadBalancer / port-forward hints follow `service.port` for both the default (5000) and a decoupled override (`--set service.port=80`).

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Helm chart: add ability to set `Service` port.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

