### PR TITLE
Drop the `parallel:` group from the Copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -22,39 +22,38 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - parallel:
-          - uses: ./.github/actions/setup-node
-          - uses: ./.github/actions/setup-python
-            with:
-              pin-micro-version: false
-          - uses: ./.github/actions/setup-java
-          - name: Restore action pins
-            uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-            with:
-              path: .cache/action-pins.json
-              key: action-pins-${{ hashFiles('dev/check_actions.py') }}
-          - name: Restore mypy cache
-            uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-            with:
-              path: .mypy_cache
-              key: mypy-ubuntu-latest-${{ hashFiles('uv.lock', 'pyproject.toml') }}
-              restore-keys: mypy-ubuntu-latest-
-          - name: Restore install-bin tools
-            uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-            with:
-              path: |
-                bin/*
-                !bin/install.py
-                !bin/README.md
-                !bin/.gitignore
-              key: install-bin-ubuntu-latest-${{ hashFiles('bin/install.py') }}
-              restore-keys: install-bin-ubuntu-latest-
-          - name: Restore pre-commit hooks
-            uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-            with:
-              path: ~/.cache/pre-commit
-              key: pre-commit-ubuntu-latest-${{ hashFiles('.pre-commit-config.yaml') }}
-              restore-keys: pre-commit-ubuntu-latest-
+      - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-python
+        with:
+          pin-micro-version: false
+      - uses: ./.github/actions/setup-java
+      - name: Restore action pins
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .cache/action-pins.json
+          key: action-pins-${{ hashFiles('dev/check_actions.py') }}
+      - name: Restore mypy cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .mypy_cache
+          key: mypy-ubuntu-latest-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+          restore-keys: mypy-ubuntu-latest-
+      - name: Restore install-bin tools
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            bin/*
+            !bin/install.py
+            !bin/README.md
+            !bin/.gitignore
+          key: install-bin-ubuntu-latest-${{ hashFiles('bin/install.py') }}
+          restore-keys: install-bin-ubuntu-latest-
+      - name: Restore pre-commit hooks
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-ubuntu-latest-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: pre-commit-ubuntu-latest-
       - name: Install dependencies
         run: |
           uv sync --only-group lint


### PR DESCRIPTION
### Related Issues/PRs

Fixes a regression from #25542.

### What changes are proposed in this pull request?

Copilot cloud agent sessions stopped launching after #25542. Two sessions on task `0f36cc5c` (`auto` and `gpt-5.6-terra`) failed in ~2s with `Failed to launch agent`, producing no session logs and no `Running Copilot cloud agent` run at all. Seven sessions succeeded before that merge and the first one after it failed.

The `parallel:` group is the only plausible cause: the agent reads this file from the default branch, which is why nothing failed while #25542 was open, and the launcher splices these steps into its own job, wrapping each in `Starting`/`Finished User Configured Setup Step` markers. A group entry is neither a `run` nor a `uses` step, and `actions/runner`'s published schema still allows only those two.

Flattening it back to sequential steps keeps the cache restores and `pin-micro-version: false`, so ~17s of the ~26s survives. CI never caught this because it runs the file as an ordinary workflow, which is green either way.

### How is this PR tested?

- [x] Manual tests

The `copilot-setup-steps` check validates the file itself. The launch fix cannot be confirmed before merging, for the same reason the regression was not caught on #25542: the agent reads this file from the default branch only. Confirmation is the first successful cloud agent session after this lands.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
