### PR TITLE
Improve coding-agent guidance in `mlflow agent setup`

### DIFF
--- a/mlflow/agent/setup/setup.sh
+++ b/mlflow/agent/setup/setup.sh
@@ -1561,7 +1561,22 @@ build_agent_prompt() {
 		"# MLflow Tracing Setup" \
 		"" \
 		"Instrument the application in this repository with MLflow Tracing." \
-		"Inspect the project first. If there is more than one application entry point, ask which one to instrument; otherwise proceed without setup questions." \
+		"Complete these steps in order:" \
+		"" \
+		"## 1. Understand the application" \
+		"- Inspect the README, documentation, examples, tests, entry points, and agent prompts or tools." \
+		"- Identify the application's purpose, intended users, expected inputs and outputs, and primary tools or data sources." \
+		"- Find where the underlying agent, workflow, or LLM client is constructed; this is the instrumentation target." \
+		"- Group executables that use the same underlying agent or workflow as interfaces to one application, not as separate instrumentation targets." \
+		"- Do not ask the user to choose among shared wrappers such as an interactive CLI, a one-shot runner, or a batch simulator." \
+		"- Ask which application to instrument only when the repository contains multiple independent agents or applications with different construction or instrumentation paths. Otherwise proceed without setup questions." \
+		"" \
+		"## 2. Document the application" \
+		"- Summarize what you learned in the MLflow experiment description." \
+		"- Use MlflowClient.set_experiment_tag with the mlflow.note.content key." \
+		"- Resolve and update the selected experiment; do not create a different experiment." \
+		"" \
+		"## 3. Configure MLflow Tracing" \
 		""
 	case "$backend" in
 	databricks)
@@ -1628,10 +1643,34 @@ build_agent_prompt() {
 	esac
 	printf '%s\n' \
 		"" \
-		"Enable the framework-specific tracing integration before the LLM client is created, such as mlflow.openai.autolog() or mlflow.langchain.autolog()." \
-		"Do not add evaluation code, write credentials into the repository, or create setup-only files." \
-		"Run the application, exercise one traced operation, and confirm a trace reaches the experiment." \
-		"Finally report the MLflow version, modified files, and trace URL."
+		"## 4. Instrument the application" \
+		"- Prefer MLflow autologging when the application's framework is supported. Enable the framework-specific integration, such as mlflow.openai.autolog() or mlflow.langchain.autolog(), before the LLM client is created." \
+		"- Add manual spans only for important application operations that autologging does not capture." \
+		"- If the application has a session or conversation ID, record it with mlflow.update_current_trace(session_id=...). Reuse the application's ID; do not generate a different ID for every trace." \
+		"- If requests or responses are not in a typical chat format and their raw serialization makes the trace table hard to scan, set concise request_preview and response_preview values with mlflow.update_current_trace." \
+		"- Record important immutable context, such as the deployment environment (dev, staging, or prod), as trace metadata. Use values from the application's existing configuration rather than hardcoding them." \
+		"- Do not add evaluation code, write credentials into the repository, or create setup-only files." \
+		"" \
+		"## 5. Verify tracing with a realistic input" \
+		"- Run the application through its documented primary interface. If several interfaces share the same underlying agent, choose the one used by the main quickstart or usage example." \
+		"- Derive a realistic input from the README, documentation, examples, tests, or CLI help." \
+		"- Exercise a representative application path and confirm that its trace reaches the experiment." \
+		"- Do not use a placeholder prompt whose only purpose is to produce a fixed response, such as 'trace confirmed'." \
+		"- If realistic execution requires unavailable credentials or user-specific data, ask the user for a suitable safe input." \
+		"" \
+		"## 6. Validate trace quality" \
+		"- Confirm the trace is logged to the selected experiment." \
+		"- Confirm the root span represents the real application operation and records meaningful inputs and outputs." \
+		"- Confirm the expected LLM, tool, retrieval, or workflow child spans appear for the representative path and have coherent parent-child relationships." \
+		"- If the path calls an LLM, confirm input and output token counts, along with cost, are present. If any are missing, investigate the instrumentation and report the limitation; never fabricate values." \
+		"- If the application has a session or conversation ID, confirm it appears on the trace and is consistent across requests in that session." \
+		"- For complex request or response formats, confirm the request and response previews are concise and useful in the trace table. Set them manually with mlflow.update_current_trace when necessary." \
+		"- Confirm important available context, such as the deployment environment, appears in trace metadata." \
+		"- Confirm instrumentation did not create duplicate traces or spans." \
+		"- Confirm traces do not expose credentials or secrets." \
+		"" \
+		"## 7. Report results" \
+		"- Report the MLflow version, modified files, and trace URL."
 }
 
 launch_agent() {

--- a/tests/agent/test_setup_sh_unit.py
+++ b/tests/agent/test_setup_sh_unit.py
@@ -93,6 +93,49 @@ build_agent_prompt
     assert "- Experiment name: tracing-test" in result.stdout
 
 
+def test_build_agent_prompt_requires_repo_summary_and_realistic_trace_input():
+    result = run_shell(
+        """
+backend=remote
+TRACKING_URI=http://localhost:5050
+EXPERIMENT_ID=42
+EXPERIMENT_NAME=tracing-test
+build_agent_prompt
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+    checklist = [
+        "## 1. Understand the application",
+        "## 2. Document the application",
+        "## 3. Configure MLflow Tracing",
+        "## 4. Instrument the application",
+        "## 5. Verify tracing with a realistic input",
+        "## 6. Validate trace quality",
+        "## 7. Report results",
+    ]
+    assert [result.stdout.index(item) for item in checklist] == sorted(
+        result.stdout.index(item) for item in checklist
+    )
+    assert "- Summarize what you learned in the MLflow experiment description" in result.stdout
+    assert "MlflowClient.set_experiment_tag" in result.stdout
+    assert "mlflow.note.content" in result.stdout
+    assert "interfaces to one application, not as separate instrumentation targets" in result.stdout
+    assert "Do not ask the user to choose among shared wrappers" in result.stdout
+    assert "Ask which application to instrument only when" in result.stdout
+    assert "multiple independent agents or applications" in result.stdout
+    assert "- Derive a realistic input from the README" in result.stdout
+    assert "Do not use a placeholder prompt whose only purpose is to produce" in result.stdout
+    assert "Prefer MLflow autologging" in result.stdout
+    assert "mlflow.update_current_trace(session_id=...)" in result.stdout
+    assert "request_preview and response_preview" in result.stdout
+    assert "deployment environment (dev, staging, or prod)" in result.stdout
+    assert "confirm input and output token counts, along with cost, are present" in result.stdout
+    assert "never fabricate values" in result.stdout
+    assert "Trace URL opens" not in result.stdout
+    assert "exercise one traced operation" not in result.stdout
+
+
 def test_build_remote_agent_prompt_includes_workspace():
     result = run_shell(
         """


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Restructure the coding-agent prompt generated by the setup script into an ordered tracing checklist.

The prompt now directs the agent to understand and document the application before instrumenting it, recognize shared wrappers around the same underlying agent, exercise realistic repository-derived inputs, and validate trace quality. Quality checks cover autologging, meaningful span structure and previews, session and environment metadata, token usage and cost, duplicate instrumentation, and secret exposure.

### How is this PR tested?

Verified manually

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

This changes setup-wizard orchestration guidance and does not change tracing APIs or the shared instrumentation skill.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow agent setup` now gives coding agents structured guidance for realistic trace verification and trace-quality validation.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
