### PR TITLE
Add first-class span description support to `@mlflow.trace` and `mlflow.start_span`

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -483,6 +483,7 @@ mlflow.entities.LiveSpan.from_dict
 mlflow.entities.LiveSpan.record_exception
 mlflow.entities.LiveSpan.set_attribute
 mlflow.entities.LiveSpan.set_attributes
+mlflow.entities.LiveSpan.set_description
 mlflow.entities.LiveSpan.set_inputs
 mlflow.entities.LiveSpan.set_log_level
 mlflow.entities.LiveSpan.set_outputs
@@ -539,6 +540,7 @@ mlflow.entities.NoOpSpan.end
 mlflow.entities.NoOpSpan.record_exception
 mlflow.entities.NoOpSpan.set_attribute
 mlflow.entities.NoOpSpan.set_attributes
+mlflow.entities.NoOpSpan.set_description
 mlflow.entities.NoOpSpan.set_inputs
 mlflow.entities.NoOpSpan.set_log_level
 mlflow.entities.NoOpSpan.set_outputs

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -214,6 +214,11 @@ class Span:
         return SpanLogLevel(raw)
 
     @property
+    def description(self) -> str | None:
+        """The description of the span, or ``None`` if it was not set."""
+        return self.get_attribute(SpanAttributeKey.DESCRIPTION)
+
+    @property
     def model_name(self) -> str | None:
         """The model name used in the span."""
         return self.get_attribute(SpanAttributeKey.MODEL)
@@ -704,6 +709,10 @@ class LiveSpan(Span):
     def set_span_type(self, span_type: str):
         """Set the type of the span."""
         self.set_attribute(SpanAttributeKey.SPAN_TYPE, span_type)
+
+    def set_description(self, description: str):
+        """Set the description of the span."""
+        self.set_attribute(SpanAttributeKey.DESCRIPTION, description)
 
     def set_log_level(self, level: SpanLogLevel | str):
         """
@@ -1446,6 +1455,9 @@ class NoOpSpan(Span):
         pass
 
     def set_attribute(self, key: str, value: Any):
+        pass
+
+    def set_description(self, description: str):
         pass
 
     def set_log_level(self, level: SpanLogLevel | int | str):

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -215,7 +215,7 @@ class Span:
 
     @property
     def description(self) -> str | None:
-        """The description of the span, or ``None`` if it was not set."""
+        """The description of the span."""
         return self.get_attribute(SpanAttributeKey.DESCRIPTION)
 
     @property

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -105,6 +105,7 @@ class SpanAttributeKey:
     # means the span was not classified.
     LOG_LEVEL = "mlflow.spanLogLevel"
     FUNCTION_NAME = "mlflow.spanFunctionName"
+    DESCRIPTION = "mlflow.spanDescription"
     START_TIME_NS = "mlflow.spanStartTimeNs"
     CHAT_TOOLS = "mlflow.chat.tools"
     # This attribute is used to store token usage information from LLM responses.

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -103,6 +103,7 @@ def trace(
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
     links: list[Link] | None = None,
+    description: str | None = None,
 ) -> Callable[_P, _R]: ...
 
 
@@ -117,6 +118,7 @@ def trace(
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
     links: list[Link] | None = None,
+    description: str | None = None,
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...
 
 
@@ -130,6 +132,7 @@ def trace(
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
     links: list[Link] | None = None,
+    description: str | None = None,
 ) -> Callable[..., Any]:
     """
     A decorator that creates a new span for the decorated function.
@@ -240,6 +243,7 @@ def trace(
             (e.g. ``"INFO"``, ``"DEBUG"``). If not provided, the span level is
             resolved from the span type at end time.
         links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with the span.
+        description: An optional human-readable description of the span.
     """
 
     # Validate sampling_ratio_override
@@ -268,6 +272,7 @@ def trace(
                 sampling_ratio_override,
                 log_level,
                 links,
+                description,
             )
         else:
             if output_reducer is not None:
@@ -283,6 +288,7 @@ def trace(
                 sampling_ratio_override,
                 log_level,
                 links,
+                description,
             )
 
         # If the original was a descriptor, wrap the result back as the same type of descriptor
@@ -305,6 +311,7 @@ def _wrap_function(
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
     links: list[Link] | None = None,
+    description: str | None = None,
 ) -> Callable[..., Any]:
     class _WrappingContext:
         # define the wrapping logic as a coroutine to avoid code duplication
@@ -320,6 +327,7 @@ def _wrap_function(
                 trace_destination=trace_destination,
                 log_level=log_level,
                 links=links,
+                description=description,
             ) as span:
                 span.set_attribute(SpanAttributeKey.FUNCTION_NAME, fn.__name__)
                 inputs = capture_function_input_args(fn, args, kwargs)
@@ -387,6 +395,7 @@ def _wrap_generator(
     sampling_ratio_override: float | None = None,
     log_level: SpanLogLevel | str | None = None,
     links: list[Link] | None = None,
+    description: str | None = None,
 ) -> Callable[..., Any]:
     """
     Wrap a generator function to create a span.
@@ -426,6 +435,7 @@ def _wrap_generator(
                 experiment_id=getattr(trace_destination, "experiment_id", None),
                 log_level=log_level,
                 links=links,
+                description=description,
             )
         except Exception as e:
             _logger.debug(f"Failed to start stream span: {e}")
@@ -539,6 +549,7 @@ def start_span(
     log_level: SpanLogLevel | str | None = None,
     run_id: str | None = None,
     links: list[Link] | None = None,
+    description: str | None = None,
 ) -> Generator[LiveSpan, None, None]:
     """
     Context manager to create a new span and start it as the current span in the context.
@@ -606,6 +617,7 @@ def start_span(
             precedence over the active run.
         links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with
             the span.
+        description: An optional human-readable description of the span.
 
     Returns:
         Yields an :py:class:`mlflow.entities.Span` that represents the created span.
@@ -643,6 +655,8 @@ def start_span(
             mlflow_span.set_span_type(span_type)
             attributes = dict(attributes) if attributes is not None else {}
             mlflow_span.set_attributes(attributes)
+            if description is not None:
+                mlflow_span.set_attribute(SpanAttributeKey.DESCRIPTION, description)
             if log_level is not None:
                 mlflow_span.set_log_level(log_level)
 
@@ -698,6 +712,7 @@ def start_span_no_context(
     start_time_ns: int | None = None,
     log_level: SpanLogLevel | str | None = None,
     links: list[Link] | None = None,
+    description: str | None = None,
 ) -> LiveSpan:
     """
     Start a span without attaching it to the global tracing context.
@@ -727,6 +742,7 @@ def start_span_no_context(
             resolved from the span type at end time.
         links: A list of :py:class:`Link <mlflow.entities.Link>` objects to associate with
             the span.
+        description: An optional human-readable description of the span.
 
     Returns:
         A :py:class:`mlflow.entities.Span` that represents the created span.
@@ -798,6 +814,8 @@ def start_span_no_context(
         if inputs is not None:
             mlflow_span.set_inputs(inputs)
         mlflow_span.set_attributes(attributes or {})
+        if description is not None:
+            mlflow_span.set_attribute(SpanAttributeKey.DESCRIPTION, description)
         if log_level is not None:
             mlflow_span.set_log_level(log_level)
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -3296,3 +3296,95 @@ def test_flush_trace_async_logging_no_spurious_error_when_tracing_disabled():
     with mock.patch("mlflow.tracking.fluent._logger") as mock_logger:
         mlflow.flush_trace_async_logging(terminate=True)
     mock_logger.error.assert_not_called()
+
+
+def test_trace_decorator_with_description():
+    @mlflow.trace(description="Calculates sum of two integers")
+    def add(x, y):
+        return x + y
+
+    add(3, 4)
+    traces = get_traces()
+    assert len(traces) == 1
+    span = traces[0].data.spans[0]
+    assert span.description == "Calculates sum of two integers"
+    assert span.attributes[SpanAttributeKey.DESCRIPTION] == "Calculates sum of two integers"
+
+
+def test_trace_decorator_with_description_async():
+    @mlflow.trace(description="Async square calculation")
+    async def square(x):
+        return x * x
+
+    asyncio.run(square(5))
+    traces = get_traces()
+    assert len(traces) == 1
+    span = traces[0].data.spans[0]
+    assert span.description == "Async square calculation"
+    assert span.attributes[SpanAttributeKey.DESCRIPTION] == "Async square calculation"
+
+
+def test_trace_decorator_with_description_generator():
+    @mlflow.trace(description="Streams number range")
+    def number_stream(n):
+        for i in range(n):
+            yield i
+
+    list(number_stream(3))
+    traces = get_traces()
+    assert len(traces) == 1
+    span = traces[0].data.spans[0]
+    assert span.description == "Streams number range"
+    assert span.attributes[SpanAttributeKey.DESCRIPTION] == "Streams number range"
+
+
+def test_start_span_with_description():
+    with mlflow.start_span("test_span", description="Validates transaction risk") as span:
+        assert span.description == "Validates transaction risk"
+
+    traces = get_traces()
+    assert len(traces) == 1
+    root_span = traces[0].data.spans[0]
+    assert root_span.description == "Validates transaction risk"
+    assert root_span.attributes[SpanAttributeKey.DESCRIPTION] == "Validates transaction risk"
+
+
+def test_start_span_no_context_with_description():
+    span = mlflow.start_span_no_context("detached_span", description="Detached span task")
+    assert span.description == "Detached span task"
+    span.end()
+
+    traces = get_traces()
+    assert len(traces) == 1
+    root_span = traces[0].data.spans[0]
+    assert root_span.description == "Detached span task"
+    assert root_span.attributes[SpanAttributeKey.DESCRIPTION] == "Detached span task"
+
+
+def test_span_set_description():
+    with mlflow.start_span("dynamic_desc_span") as span:
+        assert span.description is None
+        span.set_description("Dynamically updated description")
+        assert span.description == "Dynamically updated description"
+
+    traces = get_traces()
+    assert len(traces) == 1
+    root_span = traces[0].data.spans[0]
+    assert root_span.description == "Dynamically updated description"
+    assert root_span.attributes[SpanAttributeKey.DESCRIPTION] == "Dynamically updated description"
+
+
+def test_span_description_default_none():
+    @mlflow.trace
+    def func_no_desc(x):
+        return x
+
+    func_no_desc(1)
+    with mlflow.start_span("span_no_desc") as span:
+        pass
+
+    traces = get_traces()
+    for trace in traces:
+        for span in trace.data.spans:
+            assert span.description is None
+            assert SpanAttributeKey.DESCRIPTION not in span.attributes

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -3384,6 +3384,7 @@ def test_span_description_default_none():
         pass
 
     traces = get_traces()
+    assert len(traces) == 2
     for trace in traces:
         for span in trace.data.spans:
             assert span.description is None


### PR DESCRIPTION
### Related Issues/PRs

Closes #24781

### What changes are proposed in this pull request?

When MLflow traces agent workflows (such as LangGraph or custom multi-step pipelines), spans are identified only by function names without human-readable descriptions explaining the intent of each step.

This PR implements first-class support for attaching human-readable descriptions to spans across the Python tracing API:
- Adds `DESCRIPTION = "mlflow.spanDescription"` to `SpanAttributeKey` in `mlflow/tracing/constant.py`.
- Adds `description: str | None = None` convenience parameter to `@mlflow.trace`, `mlflow.start_span`, and `mlflow.start_span_no_context` in `mlflow/tracing/fluent.py`.
- Adds `@property def description(self) -> str | None` on `Span` and `set_description(self, description: str)` on `LiveSpan` / `NoOpSpan` in `mlflow/entities/span.py`.
- Propagates `description` through `_wrap_function` and `_wrap_generator` so it works transparently across sync, async, and generator functions.
- Per maintainer discussion in #24781, UI surfacing and framework-specific autologging (e.g. LangChain docstrings) are intentionally excluded from this PR and deferred to follow-ups.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added comprehensive unit tests in `tests/tracing/test_fluent.py`:
- `test_trace_decorator_with_description`: Tests sync functions decorated with `@mlflow.trace(description="...")`.
- `test_trace_decorator_with_description_async`: Tests async coroutine functions with `@mlflow.trace(description="...")`.
- `test_trace_decorator_with_description_generator`: Tests generator streaming functions with `@mlflow.trace(description="...")`.
- `test_start_span_with_description`: Tests `with mlflow.start_span(description="...")` context manager.
- `test_start_span_no_context_with_description`: Tests detached span `mlflow.start_span_no_context(description="...")`.
- `test_span_set_description`: Tests dynamic mutation via `span.set_description("...")`.
- `test_span_description_default_none`: Verifies backward compatibility when `description` is omitted.
- Formatted and validated with `ruff==0.16.4` (0 errors).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add first-class span description support in MLflow Tracing via `@mlflow.trace(description=...)`, `mlflow.start_span(description=...)`, and `span.description`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
