### PR TITLE
Update ML package versions for 3.16.0

### DIFF
--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -99,7 +99,7 @@ sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
 kubernetes = ["kubernetes"]
-langchain = ["langchain>=1.0.0,<=1.3.15"]
+langchain = ["langchain>=1.0.0,<=1.3.17"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -98,8 +98,8 @@ keras:
       uv pip install --system --upgrade git+https://github.com/keras-team/keras.git
 
   models:
-    minimum: "3.5.0"
-    maximum: "3.15.0"
+    minimum: "3.6.0"
+    maximum: "3.15.1"
     requirements:
       ">= 3.0.0": ["jax[cpu]>0.4"]
       "< 3.10.0": ["jax[cpu]<0.6"]
@@ -108,8 +108,8 @@ keras:
       pytest tests/keras/test_callback.py
 
   autologging:
-    minimum: "3.5.0"
-    maximum: "3.15.0"
+    minimum: "3.6.0"
+    maximum: "3.15.1"
     requirements:
       ">= 3.0.0": ["jax[cpu]>0.4"]
       "< 3.10.0": ["jax[cpu]<0.6"]
@@ -155,8 +155,8 @@ xgboost:
       uv pip install --system git+https://github.com/dmlc/xgboost.git#subdirectory=python-package
 
   models:
-    minimum: "2.1.1"
-    maximum: "3.3.0"
+    minimum: "2.1.2"
+    maximum: "3.4.1"
     requirements:
       ">= 0.0.0": ["scikit-learn"]
       # scikit-learn 1.8.0 dropped the attribute-based estimator type that
@@ -167,8 +167,8 @@ xgboost:
       pytest tests/xgboost/test_xgboost_model_export.py
 
   autologging:
-    minimum: "2.1.1"
-    maximum: "3.3.0"
+    minimum: "2.1.2"
+    maximum: "3.4.1"
     requirements:
       ">= 0.0.0": ["scikit-learn", "matplotlib"]
       "< 3.1.3": ["scikit-learn<1.8"]
@@ -252,8 +252,8 @@ semantic_kernel:
       uv pip install --system git+https://github.com/microsoft/semantic-kernel.git@main#subdirectory=python
 
   autologging:
-    minimum: "1.35.1"
-    maximum: "1.44.0"
+    minimum: "1.36.2"
+    maximum: "1.44.1"
     requirements:
       ">= 1.34.0": [
           "pydantic>=2.0,<2.12",
@@ -276,7 +276,7 @@ spacy:
 
   models:
     minimum: "3.8.2"
-    maximum: "3.8.14"
+    maximum: "3.8.16"
     run: |
       pytest tests/spacy/test_spacy_model_export.py
 
@@ -387,7 +387,7 @@ prophet:
 
   models:
     minimum: "1.1.6"
-    maximum: "1.3.0"
+    maximum: "1.4.0"
     requirements:
       # Prophet does not handle numpy 2 yet. https://github.com/facebook/prophet/issues/2595
       ">= 0.0.0": ["numpy<2"]
@@ -427,8 +427,8 @@ h2o:
   package_info:
     pip_release: "h2o"
   models:
-    minimum: "3.46.0.5"
-    maximum: "3.46.0.11"
+    minimum: "3.46.0.6"
+    maximum: "3.46.0.12"
     run: |
       pytest tests/h2o
 
@@ -470,8 +470,8 @@ transformers:
     install_dev: |
       uv pip install --system git+https://github.com/huggingface/transformers
   models:
-    minimum: "4.43.4"
-    maximum: "5.15.0"
+    minimum: "4.45.0"
+    maximum: "5.16.1"
     test_every_n_versions: 4
     unsupported: [
         # Avoid this patch: https://github.com/huggingface/transformers/pull/29032
@@ -523,8 +523,8 @@ transformers:
       uv pip uninstall --system accelerate
       pytest tests/transformers/test_transformers_model_export.py -k "test_transformers_pt_model_save_dependencies_without_accelerate"
   autologging:
-    minimum: "4.43.4"
-    maximum: "5.15.0"
+    minimum: "4.45.0"
+    maximum: "5.16.1"
     test_every_n_versions: 4
     unsupported: [
         # https://github.com/huggingface/transformers/issues/38269
@@ -564,7 +564,7 @@ diffusers:
       uv pip install --system git+https://github.com/huggingface/diffusers
   models:
     minimum: "0.37.0"
-    maximum: "0.39.0"
+    maximum: "0.40.0"
     requirements:
       ">= 0.0.0": ["transformers", "safetensors", "accelerate", "peft", "torch"]
       # diffusers>=0.38.0 depends on safetensors>=0.8.0rc0 (pre-release).
@@ -581,8 +581,8 @@ openai:
     install_dev: |
       uv pip install --system git+https://github.com/openai/openai-python
   models:
-    minimum: "1.97.2"
-    maximum: "2.47.0"
+    minimum: "1.105.0"
+    maximum: "3.5.0"
     requirements:
       ">= 0.0.0": [
           "pyspark",
@@ -599,8 +599,8 @@ openai:
     # many test tasks for openai. Reducing the number of testing only for every 10 version.
     test_every_n_versions: 10
   autologging:
-    minimum: "1.97.2"
-    maximum: "2.47.0"
+    minimum: "1.105.0"
+    maximum: "3.5.0"
     requirements:
       ">= 0.0.0": [
           "tiktoken",
@@ -624,14 +624,14 @@ dspy:
     install_dev: |
       uv pip install --system git+https://github.com/stanfordnlp/dspy.git
   models:
-    minimum: "3.0.0"
+    minimum: "3.0.4"
     maximum: "3.3.1"
     requirements:
       ">= 0.0.0": ["openai"]
     run: |
       pytest tests/dspy --ignore tests/dspy/test_dspy_autolog.py
   autologging:
-    minimum: "3.0.0"
+    minimum: "3.0.4"
     maximum: "3.3.1"
     requirements:
       ">= 0.0.0": ["openai"]
@@ -652,7 +652,7 @@ langchain:
   models:
     # Where the large package update was made (langchain-core, community, ...)
     minimum: "1.0.0"
-    maximum: "1.3.15"
+    maximum: "1.3.17"
     requirements:
       ">= 0.0.0": [
           "pyspark",
@@ -708,7 +708,7 @@ langchain:
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
   autologging:
     minimum: "1.0.0"
-    maximum: "1.3.15"
+    maximum: "1.3.17"
     requirements:
       ">= 0.0.0": [
           "openai",
@@ -751,8 +751,8 @@ langgraph:
       uv pip install --system --force-reinstall --no-deps git+https://github.com/langchain-ai/langgraph#subdirectory=libs/prebuilt
 
   models:
-    minimum: "0.6.2"
-    maximum: "1.2.9"
+    minimum: "0.6.7"
+    maximum: "1.2.11"
     requirements:
       ">= 0.0.0": [
           "langchain",
@@ -769,8 +769,8 @@ langgraph:
       pytest tests/langgraph --ignore tests/langgraph/test_langgraph_autolog.py
 
   autologging:
-    minimum: "0.6.2"
-    maximum: "1.2.9"
+    minimum: "0.6.7"
+    maximum: "1.2.11"
     requirements:
       ">= 0.0.0": [
           "langchain",
@@ -797,8 +797,8 @@ llama_index:
       uv pip install --system git+https://github.com/run-llama/llama_index.git
   models:
     # New event/span framework is fully implemented in 0.10.44
-    minimum: "0.13.0"
-    maximum: "0.14.23"
+    minimum: "0.13.5"
+    maximum: "0.14.24"
     unsupported:
       # 0.14.17+ requires llama-index-llms-openai>=0.7 which conflicts with
       # llama-index-llms-databricks (requires llama-index-llms-openai-like<0.6)
@@ -822,8 +822,8 @@ llama_index:
       ">= 0.13.0": ["llama-index-vector-stores-qdrant", "qdrant-client<1.16.0"]
     run: pytest tests/llama_index --ignore tests/llama_index/test_llama_index_autolog.py --ignore tests/llama_index/test_llama_index_tracer.py
   autologging:
-    minimum: "0.13.0"
-    maximum: "0.14.23"
+    minimum: "0.13.5"
+    maximum: "0.14.24"
     unsupported:
       # 0.14.17+ requires llama-index-llms-openai>=0.7 which conflicts with
       # llama-index-llms-databricks (requires llama-index-llms-openai-like<0.6)
@@ -846,8 +846,8 @@ ag2:
     pip_release: "ag2"
     module_name: "autogen"
   autologging:
-    minimum: "0.9.8.post1"
-    maximum: "0.14.0"
+    minimum: "0.9.10"
+    maximum: "1.0.2"
     requirements:
       ">= 0.0.0": [
           # Required to run tests/openai/mock_openai.py
@@ -864,7 +864,7 @@ autogen:
     pip_release: "autogen-agentchat"
     module_name: "autogen_agentchat"
   autologging:
-    minimum: "0.7.2"
+    minimum: "0.7.5"
     maximum: "0.7.5"
     requirements:
       ">= 0.0.0": [
@@ -891,8 +891,8 @@ gemini:
     install_dev: |
       uv pip install --system git+https://github.com/googleapis/python-genai
   autologging:
-    minimum: "1.28.0"
-    maximum: "2.18.1"
+    minimum: "1.33.0"
+    maximum: "2.20.0"
     requirements:
     run: |
       # Install legacy gemini SDK to ensure the integration works for the legacy SDK
@@ -909,8 +909,8 @@ anthropic:
     install_dev: |
       uv pip install --system git+https://github.com/anthropics/anthropic-sdk-python
   autologging:
-    minimum: "0.61.0"
-    maximum: "0.118.0"
+    minimum: "0.66.0"
+    maximum: "1.1.0"
     requirements:
     run: pytest tests/anthropic
     # Our CI runs tests for every minor version of the library by default, which results in
@@ -927,7 +927,7 @@ crewai:
     install_dev: |
       uv pip install --system git+https://github.com/crewAIInc/crewAI#subdirectory=lib/crewai
   autologging:
-    minimum: "0.152.0"
+    minimum: "0.177.0"
     maximum: "1.15.17"
     requirements:
       # crewai tests import litellm directly (ModelResponse, litellm.completion mock).
@@ -946,8 +946,8 @@ agno:
     install_dev: |
       uv pip install --system git+https://github.com/agno-agi/agno.git#subdirectory=libs/agno
   autologging:
-    minimum: "1.7.7"
-    maximum: "2.8.0"
+    minimum: "1.8.2"
+    maximum: "3.0.1"
     requirements:
       ">= 0.0.0": ["anthropic", "yfinance"]
       ">= 2.0.0": ["opentelemetry-exporter-otlp", "openinference-instrumentation-agno"]
@@ -979,8 +979,8 @@ pydantic_ai:
         "git+https://github.com/pydantic/pydantic-ai.git#egg=pydantic-ai-slim&subdirectory=pydantic_ai_slim" \
         "git+https://github.com/pydantic/pydantic-ai.git#egg=pydantic-ai"
   autologging:
-    minimum: "0.4.10"
-    maximum: "2.31.1"
+    minimum: "1.0.0"
+    maximum: "2.35.0"
     unsupported: [">=2.0.0,<2.5.0"]
     requirements:
       # pydantic-ai < 2.0.0 does `from mcp.client.streamable_http import GetSessionIdCallback`,
@@ -1008,7 +1008,7 @@ smolagents:
     install_dev: |
       uv pip install --system "git+https://github.com/huggingface/smolagents"
   autologging:
-    minimum: "1.21.0"
+    minimum: "1.22.0"
     maximum: "1.26.0"
     requirements:
       # `duckduckgo_search` has been renamed to `ddgs` since 1.21.0:
@@ -1026,8 +1026,8 @@ strands:
     install_dev: |
       uv pip install --system "git+https://github.com/strands-agents/sdk-python"
   autologging:
-    minimum: "1.4.0"
-    maximum: "1.48.0"
+    minimum: "1.7.1"
+    maximum: "1.53.0"
     run: pytest tests/strands
     test_tracing_sdk: true
 
@@ -1039,8 +1039,8 @@ haystack:
     install_dev: |
       uv pip install --system git+https://github.com/deepset-ai/haystack
   autologging:
-    minimum: "2.4.0"
-    maximum: "3.0.0"
+    minimum: "2.5.0"
+    maximum: "3.1.0"
     requirements:
       # `OpenTelemetryTracer` moved out of the core package in haystack 3.0
       ">= 3.0.0": ["opentelemetry-haystack"]
@@ -1062,8 +1062,8 @@ mistral:
       uv pip install --system .
       rm -rf $TMP_DIR
   autologging:
-    minimum: "1.9.6"
-    maximum: "2.7.1"
+    minimum: "1.9.11"
+    maximum: "2.9.4"
     requirements:
       # mistralai 2.x hard-pins opentelemetry-semantic-conventions==0.60b1, which is only
       # paired with opentelemetry-sdk 1.39.x. mlflow's `.[extras]` install pulls in the
@@ -1083,7 +1083,7 @@ sentence_transformers:
       uv pip install --system git+https://github.com/UKPLab/sentence-transformers#egg=sentence-transformers
   models:
     minimum: "3.1.0"
-    maximum: "5.6.0"
+    maximum: "6.0.0"
     requirements:
       ">= 0.0.0": [
           "pyspark",
@@ -1104,7 +1104,7 @@ johnsnowlabs:
   package_info:
     pip_release: "johnsnowlabs"
   models:
-    minimum: "5.4.0"
+    minimum: "5.4.4"
     maximum: "6.4.1"
     requirements:
       ">= 0.0.0": ["pandas<=1.5.3"]
@@ -1123,8 +1123,8 @@ groq:
     install_dev: |
       uv pip install --system git+https://github.com/groq/groq-python
   autologging:
-    minimum: "0.31.0"
-    maximum: "1.5.0"
+    minimum: "0.31.1"
+    maximum: "1.7.0"
     requirements:
     run: pytest tests/groq
     test_tracing_sdk: true
@@ -1137,7 +1137,7 @@ bedrock:
     module_name: "boto3"
   autologging:
     # BedrockRuntime client is added in boto3 1.33
-    minimum: "1.39.17"
-    maximum: "1.43.54"
+    minimum: "1.40.23"
+    maximum: "1.43.81"
     run: pytest tests/bedrock
     test_tracing_sdk: true

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -504,8 +504,6 @@ transformers:
           # TODO: Try the latest version of moto (https://github.com/getmoto/moto/issues/8498) and remove this pin
           "boto3<1.36",
         ]
-      # peft >= 0.14 relies on classes from newer versions of transformers
-      "< 4.45": ["peft<0.14.0"]
       # The TAPAS tokenizer raises "len() of unsized object" under pandas 3, fixed in 5.10.4.
       "< 5.10.4": ["pandas<3"]
       # peft >= 0.18 requires transformers.modeling_layers which was added in transformers 4.52.0

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -580,7 +580,10 @@ openai:
       uv pip install --system git+https://github.com/openai/openai-python
   models:
     minimum: "1.105.0"
-    maximum: "3.5.0"
+    # openai 3.x switched its internal HTTP client from httpx to httpx2, which
+    # breaks the autolog tests' mocking. Hold the max at the last known-good
+    # release until the openai integration is updated for 3.x.
+    maximum: "2.47.0"
     requirements:
       ">= 0.0.0": [
           "pyspark",
@@ -598,7 +601,7 @@ openai:
     test_every_n_versions: 10
   autologging:
     minimum: "1.105.0"
-    maximum: "3.5.0"
+    maximum: "2.47.0"
     requirements:
       ">= 0.0.0": [
           "tiktoken",
@@ -844,8 +847,10 @@ ag2:
     pip_release: "ag2"
     module_name: "autogen"
   autologging:
+    # ag2 1.x removed the top-level `autogen` module the tests import, so hold
+    # the max at the last known-good release until the integration supports 1.x.
     minimum: "0.9.10"
-    maximum: "1.0.2"
+    maximum: "0.14.0"
     requirements:
       ">= 0.0.0": [
           # Required to run tests/openai/mock_openai.py
@@ -1102,7 +1107,7 @@ johnsnowlabs:
   package_info:
     pip_release: "johnsnowlabs"
   models:
-    minimum: "5.4.4"
+    minimum: "5.4.0"
     maximum: "6.4.1"
     requirements:
       ">= 0.0.0": ["pandas<=1.5.3"]

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -17,11 +17,11 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "1.105.0",
-            "maximum": "3.5.0"
+            "maximum": "2.47.0"
         },
         "autologging": {
             "minimum": "1.105.0",
-            "maximum": "3.5.0"
+            "maximum": "2.47.0"
         }
     },
     "dspy": {
@@ -84,7 +84,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "0.9.10",
-            "maximum": "1.0.2"
+            "maximum": "0.14.0"
         }
     },
     "autogen": {
@@ -437,7 +437,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "johnsnowlabs"
         },
         "models": {
-            "minimum": "5.4.4",
+            "minimum": "5.4.0",
             "maximum": "6.4.1"
         }
     }

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -7,8 +7,8 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "semantic-kernel"
         },
         "autologging": {
-            "minimum": "1.35.1",
-            "maximum": "1.44.0"
+            "minimum": "1.36.2",
+            "maximum": "1.44.1"
         }
     },
     "openai": {
@@ -16,12 +16,12 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "openai"
         },
         "models": {
-            "minimum": "1.97.2",
-            "maximum": "2.47.0"
+            "minimum": "1.105.0",
+            "maximum": "3.5.0"
         },
         "autologging": {
-            "minimum": "1.97.2",
-            "maximum": "2.47.0"
+            "minimum": "1.105.0",
+            "maximum": "3.5.0"
         }
     },
     "dspy": {
@@ -29,11 +29,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "dspy"
         },
         "models": {
-            "minimum": "3.0.0",
+            "minimum": "3.0.4",
             "maximum": "3.3.1"
         },
         "autologging": {
-            "minimum": "3.0.0",
+            "minimum": "3.0.4",
             "maximum": "3.3.1"
         }
     },
@@ -43,11 +43,11 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "1.0.0",
-            "maximum": "1.3.15"
+            "maximum": "1.3.17"
         },
         "autologging": {
             "minimum": "1.0.0",
-            "maximum": "1.3.15"
+            "maximum": "1.3.17"
         }
     },
     "langgraph": {
@@ -55,12 +55,12 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "langgraph"
         },
         "models": {
-            "minimum": "0.6.2",
-            "maximum": "1.2.9"
+            "minimum": "0.6.7",
+            "maximum": "1.2.11"
         },
         "autologging": {
-            "minimum": "0.6.2",
-            "maximum": "1.2.9"
+            "minimum": "0.6.7",
+            "maximum": "1.2.11"
         }
     },
     "llama_index": {
@@ -69,12 +69,12 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "llama_index.core"
         },
         "models": {
-            "minimum": "0.13.0",
-            "maximum": "0.14.23"
+            "minimum": "0.13.5",
+            "maximum": "0.14.24"
         },
         "autologging": {
-            "minimum": "0.13.0",
-            "maximum": "0.14.23"
+            "minimum": "0.13.5",
+            "maximum": "0.14.24"
         }
     },
     "ag2": {
@@ -83,8 +83,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "autogen"
         },
         "autologging": {
-            "minimum": "0.9.8.post1",
-            "maximum": "0.14.0"
+            "minimum": "0.9.10",
+            "maximum": "1.0.2"
         }
     },
     "autogen": {
@@ -93,7 +93,7 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "autogen_agentchat"
         },
         "autologging": {
-            "minimum": "0.7.2",
+            "minimum": "0.7.5",
             "maximum": "0.7.5"
         }
     },
@@ -103,8 +103,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "google.genai"
         },
         "autologging": {
-            "minimum": "1.28.0",
-            "maximum": "2.18.1"
+            "minimum": "1.33.0",
+            "maximum": "2.20.0"
         }
     },
     "anthropic": {
@@ -112,8 +112,8 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "anthropic"
         },
         "autologging": {
-            "minimum": "0.61.0",
-            "maximum": "0.118.0"
+            "minimum": "0.66.0",
+            "maximum": "1.1.0"
         }
     },
     "crewai": {
@@ -122,7 +122,7 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "crewai"
         },
         "autologging": {
-            "minimum": "0.152.0",
+            "minimum": "0.177.0",
             "maximum": "1.15.17"
         }
     },
@@ -132,8 +132,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "agno"
         },
         "autologging": {
-            "minimum": "1.7.7",
-            "maximum": "2.8.0"
+            "minimum": "1.8.2",
+            "maximum": "3.0.1"
         }
     },
     "pydantic_ai": {
@@ -142,8 +142,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "pydantic_ai"
         },
         "autologging": {
-            "minimum": "0.4.10",
-            "maximum": "2.31.1"
+            "minimum": "1.0.0",
+            "maximum": "2.35.0"
         }
     },
     "smolagents": {
@@ -152,7 +152,7 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "smolagents"
         },
         "autologging": {
-            "minimum": "1.21.0",
+            "minimum": "1.22.0",
             "maximum": "1.26.0"
         }
     },
@@ -162,8 +162,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "strands"
         },
         "autologging": {
-            "minimum": "1.4.0",
-            "maximum": "1.48.0"
+            "minimum": "1.7.1",
+            "maximum": "1.53.0"
         }
     },
     "mistral": {
@@ -172,8 +172,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "mistralai"
         },
         "autologging": {
-            "minimum": "1.9.6",
-            "maximum": "2.7.1"
+            "minimum": "1.9.11",
+            "maximum": "2.9.4"
         }
     },
     "groq": {
@@ -181,8 +181,8 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "groq"
         },
         "autologging": {
-            "minimum": "0.31.0",
-            "maximum": "1.5.0"
+            "minimum": "0.31.1",
+            "maximum": "1.7.0"
         }
     },
     "bedrock": {
@@ -191,8 +191,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "boto3"
         },
         "autologging": {
-            "minimum": "1.39.17",
-            "maximum": "1.43.54"
+            "minimum": "1.40.23",
+            "maximum": "1.43.81"
         }
     },
     "sklearn": {
@@ -241,12 +241,12 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "keras"
         },
         "models": {
-            "minimum": "3.5.0",
-            "maximum": "3.15.0"
+            "minimum": "3.6.0",
+            "maximum": "3.15.1"
         },
         "autologging": {
-            "minimum": "3.5.0",
-            "maximum": "3.15.0"
+            "minimum": "3.6.0",
+            "maximum": "3.15.1"
         }
     },
     "tensorflow": {
@@ -267,12 +267,12 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "xgboost"
         },
         "models": {
-            "minimum": "2.1.1",
-            "maximum": "3.3.0"
+            "minimum": "2.1.2",
+            "maximum": "3.4.1"
         },
         "autologging": {
-            "minimum": "2.1.1",
-            "maximum": "3.3.0"
+            "minimum": "2.1.2",
+            "maximum": "3.4.1"
         }
     },
     "lightgbm": {
@@ -312,7 +312,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "3.8.2",
-            "maximum": "3.8.14"
+            "maximum": "3.8.16"
         }
     },
     "statsmodels": {
@@ -348,7 +348,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "1.1.6",
-            "maximum": "1.3.0"
+            "maximum": "1.4.0"
         }
     },
     "pmdarima": {
@@ -365,8 +365,8 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "h2o"
         },
         "models": {
-            "minimum": "3.46.0.5",
-            "maximum": "3.46.0.11"
+            "minimum": "3.46.0.6",
+            "maximum": "3.46.0.12"
         }
     },
     "shap": {
@@ -396,12 +396,12 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "transformers"
         },
         "models": {
-            "minimum": "4.43.4",
-            "maximum": "5.15.0"
+            "minimum": "4.45.0",
+            "maximum": "5.16.1"
         },
         "autologging": {
-            "minimum": "4.43.4",
-            "maximum": "5.15.0"
+            "minimum": "4.45.0",
+            "maximum": "5.16.1"
         }
     },
     "diffusers": {
@@ -410,7 +410,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "0.37.0",
-            "maximum": "0.39.0"
+            "maximum": "0.40.0"
         }
     },
     "haystack": {
@@ -419,8 +419,8 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "haystack"
         },
         "autologging": {
-            "minimum": "2.4.0",
-            "maximum": "3.0.0"
+            "minimum": "2.5.0",
+            "maximum": "3.1.0"
         }
     },
     "sentence_transformers": {
@@ -429,7 +429,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "3.1.0",
-            "maximum": "5.6.0"
+            "maximum": "6.0.0"
         }
     },
     "johnsnowlabs": {
@@ -437,7 +437,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "johnsnowlabs"
         },
         "models": {
-            "minimum": "5.4.0",
+            "minimum": "5.4.4",
             "maximum": "6.4.1"
         }
     }

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -101,7 +101,7 @@ sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
 kubernetes = ["kubernetes"]
-langchain = ["langchain>=1.0.0,<=1.3.15"]
+langchain = ["langchain>=1.0.0,<=1.3.17"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
 kubernetes = ["kubernetes"]
-langchain = ["langchain>=1.0.0,<=1.3.15"]
+langchain = ["langchain>=1.0.0,<=1.3.17"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -722,7 +722,7 @@ def test_violates_pep_440():
         ("pytorch", "1.5.99", False),
         ("pyspark.ml", "3.5.1", True),
         ("pyspark.ml", "3.0.0", False),
-        ("llama_index", "0.13.1", True),
+        ("llama_index", "0.13.5", True),
         ("llama_index", "0.1.2", False),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -4513,7 +4513,7 @@ requires-dist = [
     { name = "importlib-metadata", specifier = ">=3.7.0,!=4.7.0,<10" },
     { name = "kubernetes", marker = "extra == 'extras'" },
     { name = "kubernetes", marker = "extra == 'kubernetes'" },
-    { name = "langchain", marker = "extra == 'langchain'", specifier = ">=1.0.0,<=1.3.15" },
+    { name = "langchain", marker = "extra == 'langchain'", specifier = ">=1.0.0,<=1.3.17" },
     { name = "matplotlib", specifier = "<4" },
     { name = "mlflow-dbstore", marker = "extra == 'sqlserver'" },
     { name = "mlflow-jfrog-plugin", marker = "extra == 'jfrog'" },


### PR DESCRIPTION
### Related Issues/PRs

Relates to the MLflow 3.16.0 release.

### What changes are proposed in this pull request?

Updates the tested minimum/maximum ML package versions for the 3.16.0 release (regenerated via `dev/update_requirements.py` / `dev/pyproject.py`), and fixes a resulting cross-version matrix failure.

Bumping the transformers `models`/`autologging` minimum to `4.45.0` left the `"< 4.45": ["peft<0.14.0"]` requirement selector matching no candidate versions. `validate_requirements` in `dev/flavors/src/flavors/_matrix.py` treats a selector that matches zero in-range versions as an error, so `set-matrix` (and the dependent `flavors` job) failed with:

```
ValueError: Found unused requirements '< 4.45' for transformers / models. Please remove it or adjust the version specifier.
```

This PR removes that obsolete selector. The remaining `"< 4.52": ["peft<0.18.0"]` selector is still reachable (versions 4.45–4.51 exist) and is kept.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Ran full cross-version matrix generation locally (`flavors matrix --no-dev`) across all flavors — it now completes successfully with no unused-requirement errors.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release