### PR TITLE
[chart] Expose Helm liveness/readiness/startup probes as configuration variables

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -57,6 +57,30 @@ jobs:
           # validation rejects as null.
           render --set metrics.path= | grep -q '^      path: /metrics$'
 
+      - name: Render probes
+        run: |
+          render() {
+            helm template mlflow charts/ \
+              --set mlflow.backendStoreUri="sqlite:////tmp/mlflow.db" "$@"
+          }
+          # All three probes render by default, with the chart-owned /health path.
+          default=$(render)
+          echo "$default" | grep -q '^          livenessProbe:$'
+          echo "$default" | grep -q '^          readinessProbe:$'
+          echo "$default" | grep -q '^          startupProbe:$'
+          echo "$default" | grep -q '^              path: /health$'
+          # enabled: false cleanly omits a probe.
+          if render --set probes.startup.enabled=false | grep -q 'startupProbe:'; then
+            echo "startupProbe should have been omitted" >&2
+            exit 1
+          fi
+          # TLS and staticPrefix flow through to the probe's httpGet request.
+          tls=$(render --set tls.enabled=true --set server.staticPrefix=/mlflow)
+          echo "$tls" | grep -q '^              path: /mlflow/health$'
+          echo "$tls" | grep -q '^              scheme: HTTPS$'
+          # Threshold/timing overrides are honored.
+          render --set probes.readiness.failureThreshold=9 | grep -q '^            failureThreshold: 9$'
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/charts/README.md
+++ b/charts/README.md
@@ -148,6 +148,41 @@ tls:
   secretName: mlflow-tls
 ```
 
+### Health probes
+
+The chart configures liveness, readiness, and startup probes against MLflow's
+`/health` endpoint (under `server.staticPrefix` when set, and over HTTPS when
+`tls.enabled` is true). Timing and thresholds for each probe are configurable;
+set `enabled: false` on any of them to omit it from the rendered Deployment.
+
+The startup probe gates liveness and readiness until it succeeds, which is
+useful for slow-starting deployments (e.g. an external database or a sidecar
+proxy). Increase `timeoutSeconds` if your health endpoint can be slow to
+respond under load — the Kubernetes default of 1 second is often too
+aggressive for production environments.
+
+```yaml
+probes:
+  liveness:
+    enabled: true
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 10
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
+  startup:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 30
+```
+
 ### Ingress
 
 MLflow's host-validation middleware only allows `localhost` and private-IP hosts by default.

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -43,3 +43,34 @@ Build mlflow server args from .Values.server.
 - --{{ . | replace "_" "-" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Render a liveness/readiness/startup probe body from a probes.* values entry.
+The chart always owns the httpGet request (path, port, scheme); only the
+timing/threshold fields are read from the probe values.
+Expects a dict with:
+  probe: the .Values.probes.<name> map (must have .enabled == true)
+  path:  the health check path
+  port:  the named container port
+  tls:   whether to set scheme: HTTPS
+*/}}
+{{- define "mlflow.probe" -}}
+httpGet:
+  path: {{ .path }}
+  port: {{ .port }}
+  {{- if .tls }}
+  scheme: HTTPS
+  {{- end }}
+{{- with .probe.initialDelaySeconds }}
+initialDelaySeconds: {{ . }}
+{{- end }}
+{{- with .probe.periodSeconds }}
+periodSeconds: {{ . }}
+{{- end }}
+{{- with .probe.timeoutSeconds }}
+timeoutSeconds: {{ . }}
+{{- end }}
+{{- with .probe.failureThreshold }}
+failureThreshold: {{ . }}
+{{- end }}
+{{- end }}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -69,24 +69,19 @@ spec:
             - name: {{ $portName }}
               containerPort: {{ .Values.server.value_options.port }}
               protocol: TCP
+          {{- $probeArgs := dict "path" (printf "%s/health" $healthPrefix) "port" $portName "tls" .Values.tls.enabled }}
+          {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
-            httpGet:
-              path: {{ printf "%s/health" $healthPrefix }}
-              port: {{ $portName }}
-              {{- if .Values.tls.enabled }}
-              scheme: HTTPS
-              {{- end }}
-            initialDelaySeconds: 15
-            periodSeconds: 20
+            {{- include "mlflow.probe" (merge (dict "probe" .Values.probes.liveness) $probeArgs) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
-            httpGet:
-              path: {{ printf "%s/health" $healthPrefix }}
-              port: {{ $portName }}
-              {{- if .Values.tls.enabled }}
-              scheme: HTTPS
-              {{- end }}
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            {{- include "mlflow.probe" (merge (dict "probe" .Values.probes.readiness) $probeArgs) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            {{- include "mlflow.probe" (merge (dict "probe" .Values.probes.startup) $probeArgs) | nindent 12 }}
+          {{- end }}
           {{- if or .Values.mlflow.backendStoreUri .Values.mlflow.backendStoreUriFrom .Values.mlflow.registryStoreUri .Values.mlflow.registryStoreUriFrom .Values.mlflow.defaultArtifactRoot .Values.mlflow.artifactsDestination .Values.env }}
           env:
             {{- if or .Values.mlflow.backendStoreUri .Values.mlflow.backendStoreUriFrom }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -49,6 +49,38 @@ server:
   # Aligns the --static-prefix server arg and liveness/readiness probe paths.
   staticPrefix: ""
 
+# Liveness, readiness, and startup probe configuration for the mlflow container.
+# The chart always generates the underlying httpGet request itself (the
+# server.staticPrefix + "/health" path, the dynamic http/https named port, and
+# the HTTPS scheme when tls.enabled is true) — these blocks only control
+# whether each probe is enabled and its timing/threshold behavior.
+#
+# The startup probe gates liveness and readiness until it succeeds, which is
+# useful for slow-starting deployments (e.g. external databases, sidecar
+# proxies). Set probes.startup.enabled: false to disable it explicitly.
+#
+# Set timeoutSeconds higher than the Kubernetes default (1s) if your
+# deployment's health endpoint can be slow to respond under load.
+probes:
+  liveness:
+    enabled: true
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 10
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 3
+  startup:
+    enabled: true
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 10
+    failureThreshold: 30
+
 # Garbage collection via a CronJob that runs `mlflow gc`.
 # Permanently removes soft-deleted runs, experiments, and logged models
 # along with their artifacts. Resources must be soft-deleted first


### PR DESCRIPTION
### Related Issues/PRs

Closes #25525

### What changes are proposed in this pull request?

Exposes the MLflow Helm chart's liveness, readiness, and startup probe behavior as configurable chart values.

- Adds a `probes.{liveness,readiness,startup}` block to `values.yaml` (`enabled`/`initialDelaySeconds`/`periodSeconds`/`timeoutSeconds`/`failureThreshold`), matching the shape proposed in #25525.
- The chart continues to own the underlying `httpGet` request itself: `server.staticPrefix` + `/health`, the dynamic `http`/`https` named port, and the HTTPS scheme when `tls.enabled` is true. User values only control per-probe enablement and timing.
- Renders a new `startupProbe` (previously absent), which gates liveness/readiness until it succeeds. Disable explicitly with `probes.startup.enabled: false`.
- Adds a shared `mlflow.probe` named template in `_helpers.tpl` to avoid duplicating the `httpGet`-building logic across the three probes.
- Adds a "Render probes" CI step to `.github/workflows/helm.yml`, in the same grep-assertion style as the existing ServiceMonitor render-check.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

`helm lint charts/` passes. `helm template` verified for default values, `tls.enabled=true` + `server.staticPrefix`, `probes.startup.enabled=false` (cleanly omits the probe), and per-field overrides (e.g. `probes.readiness.failureThreshold`).

Also deployed end-to-end on a local `kind` cluster: built `docker/Dockerfile`, loaded into kind, `helm install`'d the patched chart, and confirmed the pod reached `1/1 Running`. `kubectl describe pod` showed the liveness/readiness/startup probes rendered with the configured `timeoutSeconds`/`failureThreshold` values instead of the old hardcoded ones, and `curl http://127.0.0.1:5000/health` returned `200`.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

Added a "Health probes" section to `charts/README.md` documenting the new values block.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The Helm chart's liveness, readiness, and startup probes are now configurable via `probes.{liveness,readiness,startup}` in `values.yaml`, instead of being hardcoded. A `startupProbe` is now rendered by default (previously absent).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
