### PR TITLE
Pin googleapis-common-protos<1.75.1 for TensorFlow cross-version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -131,7 +131,14 @@ tensorflow:
       # Requirements to run tests for keras
       # googleapis-common-protos>=1.75.1 ships protobuf 6.33 gencode that TensorFlow's
       # protobuf<6 pin cannot load (google.rpc import fails via pyspark.testing).
-      ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1", "googleapis-common-protos<1.75.1"]
+      ">= 0.0.0":
+        [
+          "scikit-learn",
+          "pyspark",
+          "pyarrow",
+          "transformers!=4.38.0,!=4.38.1",
+          "googleapis-common-protos<1.75.1",
+        ]
       ">= 2.21.0": ["tensorboard"]
     run: |
       pytest \

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -129,7 +129,9 @@ tensorflow:
     maximum: "2.21.0"
     requirements:
       # Requirements to run tests for keras
-      ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1"]
+      # googleapis-common-protos>=1.75.1 ships protobuf 6.33 gencode that TensorFlow's
+      # protobuf<6 pin cannot load (google.rpc import fails via pyspark.testing).
+      ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1", "googleapis-common-protos<1.75.1"]
       ">= 2.21.0": ["tensorboard"]
     run: |
       pytest \


### PR DESCRIPTION
### Related Issues/PRs

Relates to the cross-version TensorFlow test failures on `mlflow/dev` (`cross-version-tests.yml`, run 33634799066). No tracking issue was filed.

### What changes are proposed in this pull request?

The `tensorflow` cross-version test jobs (`test2 (tensorflow / models / 2.19.1)` and `2.18.1`) started failing on 2026-09-02 with:

    google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf
    Gencode/Runtime versions when loading google/rpc/error_details.proto:
    gencode 6.33.5 runtime 5.29.6.

Root cause: `googleapis-common-protos` 1.75.1 regenerated its gencode with protobuf 6.33 and raised its runtime floor to `protobuf>=6.33.5`. TensorFlow pins `protobuf<6`, so the TF test env installs `protobuf==5.29.6` alongside `googleapis-common-protos==1.75.2`, and `from google.rpc import error_details_pb2` (imported via `pyspark.testing`) fails the protobuf runtime version check. The failure appeared the day 1.75.2 was published (08-31/09-01 runs passed with the older, protobuf-5-compatible gencode).

Fix: pin `googleapis-common-protos<1.75.1` in the TensorFlow `models` test requirements. 1.75.0 is the last release whose gencode loads on a protobuf 5.x runtime, and it also works with protobuf 6.x, so the pin is safe. This only affects the TF cross-version test environment; nothing user-facing changes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The `tensorflow` cross-version test suite validates the fix.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release