### PR TITLE
Exclude `anyio` 4.15.0 which breaks server `/health`

### DIFF
--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -29,6 +29,7 @@ requires-python = ">=3.10"
 # installable within the existing ranges, and pinning them is the responsibility of the
 # application. See https://sethmlarson.dev/library-version-specifiers-not-for-vulnerabilities
 dependencies = [
+  "anyio<5,>=3.6.2,!=4.15.0",
   "cachetools<8,>=5.0.0",
   "click<9,>=7.0",
   "cloudpickle<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "Flask<4",
   "aiohttp<4,>=3.7.0",
   "alembic<2,!=1.10.0",
+  "anyio<5,>=3.6.2,!=4.15.0",
   "cachetools<8,>=5.0.0",
   "click<9,>=7.0",
   "cloudpickle<4",

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -4,6 +4,16 @@
 # and Databricks. When we release a new major/minor version, this file is automatically
 # updated as a part of the release process.
 
+anyio:
+  pip_release: anyio
+  # Imported directly by mlflow/server/fastapi_app.py and pulled in transitively via
+  # starlette's WSGI bridge. anyio 4.15.0 dropped `from_thread` from its top-level
+  # lazy-import shim, which breaks starlette's WSGIResponder.start_response and makes
+  # the server /health endpoint return 500 (readiness probes then fail).
+  minimum: "3.6.2"
+  max_major_version: 4
+  unsupported: ["4.15.0"]
+
 click:
   pip_release: click
   minimum: "7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -4247,6 +4247,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "alembic" },
+    { name = "anyio" },
     { name = "cachetools" },
     { name = "click" },
     { name = "cloudpickle" },
@@ -4479,6 +4480,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.7.0,<4" },
     { name = "alembic", specifier = "!=1.10.0,<2" },
     { name = "aliyunstoreplugin", marker = "extra == 'aliyun-oss'" },
+    { name = "anyio", specifier = ">=3.6.2,!=4.15.0,<5" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.6.1" },
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12" },
     { name = "azure-storage-file-datalake", marker = "extra == 'databricks'", specifier = ">12" },


### PR DESCRIPTION
### Related Issues/PRs

Relates to the Helm Chart `e2e` CI failure on release branch `branch-3.16`

### What changes are proposed in this pull request?

`anyio` 4.15.0 (released 2026-09-02) removed `from_thread` from its top-level lazy-import shim. MLflow's server wraps the Flask app via starlette's WSGI bridge (`mlflow/server/fastapi_app.py`), whose `WSGIResponder.start_response` calls `anyio.from_thread.run(...)`. With 4.15.0 installed this raises `AttributeError: module 'anyio' has no attribute 'from_thread'` on every request, so `GET /health` returns 500.

This surfaced in the Helm Chart `e2e` job: the container is built with `pip install mlflow==<appVersion>` (resolving deps live from PyPI, not from `uv.lock`), so it picked up `anyio` 4.15.0, `/health` 500'd, the pod never became ready, and `helm install --wait` failed with `context deadline exceeded`. The last green run installed `anyio` 4.14.2.

`anyio` is imported directly by `mlflow/server/fastapi_app.py` but was previously only pulled in transitively via starlette, so it was undeclared. This PR declares it in `requirements/skinny-requirements.yaml` with `>=3.6.2,<5` and excludes the broken `4.15.0`, then regenerates the derived `pyproject.toml`, `libs/skinny/pyproject.toml`, and `uv.lock`. The `!=4.15.0` constraint ships in the published `mlflow-skinny` metadata, so `pip install mlflow` will no longer resolve the broken version.

### How is this PR tested?

- [x] Existing unit/integration tests

The Helm Chart `e2e` job exercises exactly this path (build image → deploy → probe `/health`); it should return to green with `anyio` 4.14.2 resolved.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a server startup regression where `anyio` 4.15.0 caused the MLflow server `/health` endpoint (and all requests) to return HTTP 500.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR is critical and needs to be in the next patch release
