### PR TITLE
Scope `mlflow gc` to the IDs it was given

### DIFF
--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -817,8 +817,22 @@ def _gc_tracking_resources(
     """
     from mlflow.utils.time import get_current_time_millis
 
+    # `--run-ids`, `--experiment-ids` and `--logged-model-ids` each name exactly what to
+    # delete, so naming one must not sweep up the kinds that were not named: `gc
+    # --run-ids <id>` deletes that run, not every soft-deleted experiment in the store
+    # as well. Only a bare `gc`, which names nothing, collects everything that is in the
+    # `deleted` lifecycle stage.
+    ids_were_given = any(ids is not None for ids in (run_ids, experiment_ids, logged_model_ids))
+
     deleted_run_ids_older_than = backend_store._get_deleted_runs(older_than=time_delta)
-    run_ids_to_delete = run_ids if run_ids is not None else list(deleted_run_ids_older_than)
+    if run_ids is not None:
+        # A copy, because the experiment sweep below extends this list and `run_ids`
+        # belongs to the caller.
+        run_ids_to_delete = list(run_ids)
+    elif ids_were_given:
+        run_ids_to_delete = []
+    else:
+        run_ids_to_delete = list(deleted_run_ids_older_than)
 
     deleted_logged_model_ids = (
         backend_store._get_deleted_logged_models() if not skip_logged_models else []
@@ -829,11 +843,12 @@ def _gc_tracking_resources(
         if not skip_logged_models
         else []
     )
-    logged_model_ids_to_delete = (
-        logged_model_ids
-        if logged_model_ids is not None
-        else list(deleted_logged_model_ids_older_than)
-    )
+    if logged_model_ids is not None:
+        logged_model_ids_to_delete = list(logged_model_ids)
+    elif ids_were_given:
+        logged_model_ids_to_delete = []
+    else:
+        logged_model_ids_to_delete = list(deleted_logged_model_ids_older_than)
 
     time_threshold = get_current_time_millis() - time_delta
     experiment_ids_to_delete = []
@@ -875,7 +890,7 @@ def _gc_tracking_resources(
                         error_code=INVALID_PARAMETER_VALUE,
                     )
             experiment_ids_to_delete = list(experiment_ids)
-        else:
+        elif not ids_were_given:
             filter_string = f"last_update_time < {time_threshold}" if older_than else None
 
             def fetch_experiments(token=None):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1890,3 +1890,100 @@ def test_mlflow_gc_only_deletes_finalized_jobs(sqlite_store_with_jobs):
         job_store.get_job(timeout_job.job_id)
     with pytest.raises(MlflowException, match=r"Job .+ not found"):
         job_store.get_job(canceled_job.job_id)
+
+
+def _create_deleted_experiment_with_deleted_run(store, name):
+    experiment_id = store.create_experiment(name)
+    run = store.create_run(
+        experiment_id=experiment_id,
+        user_id="Anderson",
+        start_time=get_current_time_millis(),
+        tags=[],
+        run_name="name",
+    )
+    store.delete_run(run.info.run_id)
+    store.delete_experiment(experiment_id)
+    return experiment_id, run.info.run_id
+
+
+def test_mlflow_gc_run_ids_does_not_delete_other_deleted_runs(sqlite_store):
+    """`gc --run-ids` must delete the runs it was given and nothing else.
+
+    Regression test for https://github.com/mlflow/mlflow/issues/13254. The
+    experiment sweep used to run whenever `--experiment-ids` was omitted, so
+    naming a run also collected every soft-deleted experiment in the store and
+    every soft-deleted run inside it.
+    """
+    store = sqlite_store[0]
+    target = _create_run_in_store(store, create_artifacts=False)
+    store.delete_run(target.info.run_id)
+    bystander_experiment_id, bystander_run_id = _create_deleted_experiment_with_deleted_run(
+        store, "bystander"
+    )
+
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "mlflow",
+        "gc",
+        "--backend-store-uri",
+        sqlite_store[1],
+        "--run-ids",
+        target.info.run_id,
+    ])
+
+    with pytest.raises(MlflowException, match=r"Run .+ not found"):
+        store.get_run(target.info.run_id)
+    assert store.get_run(bystander_run_id).info.run_id == bystander_run_id
+    assert store.get_experiment(bystander_experiment_id).name == "bystander"
+
+
+def test_mlflow_gc_experiment_ids_does_not_delete_other_deleted_runs(sqlite_store):
+    """`gc --experiment-ids` must not also collect every soft-deleted run.
+
+    The mirror image of the same defect: `run_ids_to_delete` fell back to every
+    soft-deleted run in the store whenever `--run-ids` was omitted.
+    """
+    store = sqlite_store[0]
+    bystander = _create_run_in_store(store, create_artifacts=False)
+    store.delete_run(bystander.info.run_id)
+    target_experiment_id, target_run_id = _create_deleted_experiment_with_deleted_run(
+        store, "target"
+    )
+
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "mlflow",
+        "gc",
+        "--backend-store-uri",
+        sqlite_store[1],
+        "--experiment-ids",
+        target_experiment_id,
+    ])
+
+    with pytest.raises(MlflowException, match=r"Run .+ not found"):
+        store.get_run(target_run_id)
+    assert store.get_run(bystander.info.run_id).info.run_id == bystander.info.run_id
+
+
+def test_mlflow_gc_without_ids_still_deletes_everything(sqlite_store):
+    store = sqlite_store[0]
+    loose_run = _create_run_in_store(store, create_artifacts=False)
+    store.delete_run(loose_run.info.run_id)
+    experiment_id, run_id = _create_deleted_experiment_with_deleted_run(store, "swept")
+
+    subprocess.check_call([
+        sys.executable,
+        "-m",
+        "mlflow",
+        "gc",
+        "--backend-store-uri",
+        sqlite_store[1],
+    ])
+
+    for deleted in (loose_run.info.run_id, run_id):
+        with pytest.raises(MlflowException, match=r"Run .+ not found"):
+            store.get_run(deleted)
+    with pytest.raises(MlflowException, match=r"No Experiment with id="):
+        store.get_experiment(experiment_id)


### PR DESCRIPTION
### Related Issues/PRs

Relates to #13254

### What changes are proposed in this pull request?

`mlflow gc --run-ids <id>` permanently deletes the run it was given and then, in
the same pass, every soft-deleted experiment in the store together with every
soft-deleted run inside those experiments. `--experiment-ids <id>` has the
mirror problem: it also deletes every soft-deleted run anywhere in the store.
`gc` is a hard delete, so a user who names one run loses an unbounded set. In
#13254 this is the second of the two problems the reporter describes — the
traceback he pasted names a run he had not asked about, in an experiment he had
not asked about.

`_gc_tracking_resources` takes three selectors, and each falls back to
"everything in the `deleted` lifecycle stage" when it is not supplied. The
fallbacks run even when one of the *other* selectors was supplied, so naming a
run never suppressed the experiment sweep and naming an experiment never
suppressed the run sweep. That dates from #6977, which added `--experiment-ids`
to a command that until then took only `--run-ids` and placed the new experiment
sweep unconditionally in the shared path.

A selector's fallback now runs only when no selector at all was given. That is
what a bare `mlflow gc` means, and what each option's help text already
promises — "If run ids are not specified, data is removed for all runs in the
`deleted` lifecycle stage." The alternative of warning, or documenting the
behaviour as intended, seemed wrong for an unrecoverable delete that exceeds
what was asked for. This also copies `run_ids` before extending it, since the
experiment sweep was appending to the caller's list.

This does not touch the other half of #13254, the `metrics_run_uuid_fkey`
violation on postgres, which is why this says "Relates to" rather than "Closes".
That one needs the schema migration @serena-ruan sketched in the thread, needs
postgres to demonstrate, and is a separate concern; I have not attempted it
here.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Three tests in `tests/test_cli.py`.
`test_mlflow_gc_run_ids_does_not_delete_other_deleted_runs` and
`test_mlflow_gc_experiment_ids_does_not_delete_other_deleted_runs` both fail on
`master` with `MlflowException: Run with id=... not found` for the bystander
run. `test_mlflow_gc_without_ids_still_deletes_everything` passes either way and
is there to pin the behaviour of a bare `mlflow gc`, so this cannot quietly turn
into "delete less".

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes.

`mlflow gc` no longer deletes soft-deleted resources that were not named:
passing `--run-ids`, `--experiment-ids` or `--logged-model-ids` now restricts
the deletion to those IDs. A bare `mlflow gc` is unchanged and still collects
everything in the `deleted` lifecycle stage.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
