### PR TITLE
Guard mlflow.shap explainer load with MLFLOW_ALLOW_PICKLE_DESERIALIZATION

### DIFF
--- a/mlflow/shap/__init__.py
+++ b/mlflow/shap/__init__.py
@@ -11,11 +11,17 @@ import yaml
 import mlflow
 import mlflow.utils.autologging_utils
 from mlflow import pyfunc
+from mlflow.environment_variables import MLFLOW_ALLOW_PICKLE_DESERIALIZATION
+from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelInputExample, ModelSignature
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.utils import _save_example
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.utils.databricks_utils import (
+    is_in_databricks_model_serving_environment,
+    is_in_databricks_runtime,
+)
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -641,6 +647,16 @@ def _load_explainer(explainer_file, model=None):
         model: Model to override underlying explainer model.
 
     """
+    if (
+        not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get()
+        and not is_in_databricks_runtime()
+        and not is_in_databricks_model_serving_environment()
+    ):
+        raise MlflowException(
+            "Deserializing model using pickle is disallowed, but this model is saved "
+            "in pickle format. The workaround is to set environment variable "
+            "'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true'."
+        )
     import shap
 
     def inject_model_loader(_in_file):

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -13,7 +13,8 @@ from sklearn.datasets import load_diabetes
 
 import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
-from mlflow import MlflowClient
+from mlflow import MlflowClient, pyfunc
+from mlflow.exceptions import MlflowException
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import PYTHON_VERSION
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -512,3 +513,13 @@ def test_model_log_with_metadata(shap_model):
 
     reloaded_model = mlflow.pyfunc.load_model(model_uri=model_info.model_uri)
     assert reloaded_model.metadata.metadata["metadata_key"] == "metadata_value"
+
+
+@pytest.mark.parametrize("load_fn", [mlflow.shap.load_explainer, pyfunc.load_model])
+def test_load_disallows_pickle_deserialization(shap_model, tmp_path, monkeypatch, load_fn):
+    model_path = str(tmp_path.joinpath("shap_model"))
+    mlflow.shap.save_explainer(shap_model, model_path)
+
+    monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
+    with pytest.raises(MlflowException, match="MLFLOW_ALLOW_PICKLE_DESERIALIZATION"):
+        load_fn(model_path)

--- a/tests/shap/test_log.py
+++ b/tests/shap/test_log.py
@@ -518,7 +518,7 @@ def test_model_log_with_metadata(shap_model):
 @pytest.mark.parametrize("load_fn", [mlflow.shap.load_explainer, pyfunc.load_model])
 def test_load_disallows_pickle_deserialization(shap_model, tmp_path, monkeypatch, load_fn):
     model_path = str(tmp_path.joinpath("shap_model"))
-    mlflow.shap.save_explainer(shap_model, model_path)
+    mlflow.shap.save_explainer(shap_model, model_path, serialize_model_using_mlflow=False)
 
     monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
     with pytest.raises(MlflowException, match="MLFLOW_ALLOW_PICKLE_DESERIALIZATION"):


### PR DESCRIPTION
### Related Issues/PRs

Relates to GHSA-hc9r-hv64-9g82 (private security advisory).

### What changes are proposed in this pull request?

The mlflow.shap flavor was missing the pickle deserialization guard that other flavors (sklearn, statsmodels, pytorch, tensorflow, pmdarima, langchain, dspy, pyfunc, model evaluation) enforce via the `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` environment variable. This change adds the same guard pattern as statsmodels to ensure consistent security posture across all pickle-deserializing flavors.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Reported by @manus-use and @mohammedix88 via GitHub Security Advisories GHSA-hc9r-hv64-9g82 and GHSA-4qrv-m4cr-h32g.