### PR TITLE
Reject IPv6-transition addresses embedding private IPv4 in webhook SSRF guard

### DIFF
--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -898,6 +898,32 @@ def _validate_webhook_name(name: str) -> None:
         )
 
 
+_NAT64_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
+
+
+def _embedded_ipv4(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    """Decode IPv6 transition formats that carry an embedded IPv4 address.
+
+    This normalizes IPv6-transition addresses (IPv4-mapped, 6to4, NAT64) to their
+    embedded IPv4 address so that a wrapped private/CGNAT/link-local address cannot
+    masquerade as global.
+    """
+    if isinstance(ip, ipaddress.IPv6Address):
+        embedded = ip.ipv4_mapped or ip.sixtofour
+        if embedded is None and ip in _NAT64_PREFIX:
+            embedded = ipaddress.IPv4Address(int(ip) & 0xFFFFFFFF)
+        if embedded is not None:
+            return embedded
+    return ip
+
+
+def _is_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Check if an IP is public, accounting for IPv6-transition address formats."""
+    return _embedded_ipv4(ip).is_global
+
+
 def _resolve_hostname_with_timeout(hostname: str, field_name: str):
     acquired = _HOSTNAME_RESOLUTION_SEMAPHORE.acquire(timeout=_HOSTNAME_RESOLUTION_TIMEOUT_SECONDS)
     if not acquired:
@@ -944,7 +970,7 @@ def _validate_hostname_resolves_to_public_ips(hostname: str, field_name: str) ->
             raise MlflowException.invalid_parameter_value(
                 f"{field_name} hostname {hostname!r} resolved to an invalid IP address: {e}"
             ) from e
-        if not ip.is_global:
+        if not _is_public_ip(ip):
             raise MlflowException.invalid_parameter_value(
                 f"{field_name} must not resolve to a non-public IP address. "
                 f"{hostname!r} resolves to {ip}."

--- a/mlflow/webhooks/ssrf.py
+++ b/mlflow/webhooks/ssrf.py
@@ -27,6 +27,7 @@ from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.poolmanager import PoolManager, ProxyManager
 
 from mlflow.environment_variables import _MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS
+from mlflow.utils.validation import _is_public_ip
 
 
 class SSRFProtectionError(Exception):
@@ -58,7 +59,7 @@ def _assert_public_peer(sock: socket.socket) -> None:
             f"Webhook connection resolved to an invalid IP address: {peer_ip!r}"
         ) from e
 
-    if not ip.is_global:
+    if not _is_public_ip(ip):
         sock.close()
         raise SSRFProtectionError(
             f"Webhook connection blocked: {ip} is not a public IP address. "

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -498,6 +498,8 @@ def test_validate_webhook_url_rejects_invalid_input(url, expected_match):
         ("https://cgnat.internal/hook", "100.64.0.1"),
         ("https://ipv6-loopback.internal/hook", "::1"),
         ("https://ipv6-private.internal/hook", "fc00::1"),
+        ("https://nat64-metadata.internal/hook", "64:ff9b::169.254.169.254"),
+        ("https://ipv6-mapped-cgnat.internal/hook", "::ffff:100.64.0.1"),
     ],
 )
 def test_validate_webhook_url_rejects_private_ips(url, resolved_ip):
@@ -781,3 +783,37 @@ def test_validate_model_renaming_invalid_chars(invalid_name):
         check=lambda e: e.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE),
     ):
         _validate_model_renaming(invalid_name)
+
+
+@pytest.mark.parametrize(
+    "ipv6_transition_ip",
+    [
+        "64:ff9b::169.254.169.254",
+        "::ffff:100.64.0.1",
+        "2001:db8::ffff:169.254.169.254",
+    ],
+)
+def test_validate_public_https_url_rejects_ipv6_transition_addresses_with_private_ipv4(
+    ipv6_transition_ip: str,
+):
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo(ipv6_transition_ip),
+    ):
+        with pytest.raises(MlflowException, match="must not resolve to a non-public"):
+            _validate_public_https_url("https://example.com/icon.png", field_name="Icon URL")
+
+
+@pytest.mark.parametrize(
+    "public_ipv6",
+    [
+        "2001:4860:4860::8888",
+        "::ffff:8.8.8.8",
+    ],
+)
+def test_validate_public_https_url_accepts_public_ipv6_addresses(public_ipv6: str):
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo(public_ipv6),
+    ):
+        _validate_public_https_url("https://example.com/icon.png", field_name="Icon URL")

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -500,6 +500,7 @@ def test_validate_webhook_url_rejects_invalid_input(url, expected_match):
         ("https://ipv6-private.internal/hook", "fc00::1"),
         ("https://nat64-metadata.internal/hook", "64:ff9b::169.254.169.254"),
         ("https://ipv6-mapped-cgnat.internal/hook", "::ffff:100.64.0.1"),
+        ("https://6to4-private.internal/hook", "2002:a9fe:a9fe::"),
     ],
 )
 def test_validate_webhook_url_rejects_private_ips(url, resolved_ip):
@@ -790,7 +791,7 @@ def test_validate_model_renaming_invalid_chars(invalid_name):
     [
         "64:ff9b::169.254.169.254",
         "::ffff:100.64.0.1",
-        "2001:db8::ffff:169.254.169.254",
+        "2002:a9fe:a9fe::",
     ],
 )
 def test_validate_public_https_url_rejects_ipv6_transition_addresses_with_private_ipv4(
@@ -799,9 +800,10 @@ def test_validate_public_https_url_rejects_ipv6_transition_addresses_with_privat
     with patch(
         "mlflow.utils.validation.socket.getaddrinfo",
         side_effect=_mock_getaddrinfo(ipv6_transition_ip),
-    ):
+    ) as mock_getaddrinfo:
         with pytest.raises(MlflowException, match="must not resolve to a non-public"):
             _validate_public_https_url("https://example.com/icon.png", field_name="Icon URL")
+        mock_getaddrinfo.assert_called()
 
 
 @pytest.mark.parametrize(
@@ -815,5 +817,6 @@ def test_validate_public_https_url_accepts_public_ipv6_addresses(public_ipv6: st
     with patch(
         "mlflow.utils.validation.socket.getaddrinfo",
         side_effect=_mock_getaddrinfo(public_ipv6),
-    ):
+    ) as mock_getaddrinfo:
         _validate_public_https_url("https://example.com/icon.png", field_name="Icon URL")
+        mock_getaddrinfo.assert_called()

--- a/tests/webhooks/test_ssrf.py
+++ b/tests/webhooks/test_ssrf.py
@@ -136,13 +136,16 @@ def test_getpeername_oserror_fails_closed(loopback_server: int):
     [
         "64:ff9b::169.254.169.254",
         "::ffff:100.64.0.1",
-        "2001:db8::ffff:169.254.169.254",
+        "2002:a9fe:a9fe::",
     ],
 )
 def test_ipv6_transition_addresses_embedding_private_ipv4_are_blocked(
     loopback_server: int, peer_ip: str
 ):
     session = _create_webhook_session()
-    with mock.patch.object(socket.socket, "getpeername", return_value=(peer_ip, loopback_server)):
+    with mock.patch.object(
+        socket.socket, "getpeername", return_value=(peer_ip, loopback_server)
+    ) as mock_getpeername:
         with pytest.raises(SSRFProtectionError, match="not a public IP"):
             session.post(f"http://127.0.0.1:{loopback_server}/", timeout=10)
+        mock_getpeername.assert_called()

--- a/tests/webhooks/test_ssrf.py
+++ b/tests/webhooks/test_ssrf.py
@@ -129,3 +129,20 @@ def test_getpeername_oserror_fails_closed(loopback_server: int):
     with mock.patch.object(socket.socket, "getpeername", side_effect=OSError("ENOTCONN")):
         with pytest.raises(SSRFProtectionError, match="peer address"):
             session.post(f"http://127.0.0.1:{loopback_server}/", timeout=10)
+
+
+@pytest.mark.parametrize(
+    "peer_ip",
+    [
+        "64:ff9b::169.254.169.254",
+        "::ffff:100.64.0.1",
+        "2001:db8::ffff:169.254.169.254",
+    ],
+)
+def test_ipv6_transition_addresses_embedding_private_ipv4_are_blocked(
+    loopback_server: int, peer_ip: str
+):
+    session = _create_webhook_session()
+    with mock.patch.object(socket.socket, "getpeername", return_value=(peer_ip, loopback_server)):
+        with pytest.raises(SSRFProtectionError, match="not a public IP"):
+            session.post(f"http://127.0.0.1:{loopback_server}/", timeout=10)


### PR DESCRIPTION
### Related Issues/PRs

Relates to GHSA-7646-8p3r-42ch and GHSA-m56c-jhmp-2mx2 (private security advisories); hardens the CVE-2026-64849 fix.

### What changes are proposed in this pull request?

The webhook SSRF guard classified peer/resolved IPs with a bare `ipaddress.ip_address(...).is_global`, which does not decode IPv6-transition formats that embed an IPv4 address. It now decodes IPv4-mapped, 6to4, and NAT64-prefixed (`64:ff9b::/96`) IPv6 addresses to their embedded IPv4 before the public-IP check. This closes two bypasses of the CVE-2026-64849 fix:

- `64:ff9b::169.254.169.254` (NAT64 wrapping cloud metadata) previously passed as global.
- `::ffff:100.64.0.1` (IPv4-mapped CGNAT) previously passed as global.

Changes:
- Added `_embedded_ipv4()` and `_is_public_ip()` helpers in `mlflow/utils/validation.py`.
- `_validate_hostname_resolves_to_public_ips()` (pre-flight) now uses `_is_public_ip()`.
- `_assert_public_peer()` in `mlflow/webhooks/ssrf.py` (connection-time) now uses `_is_public_ip()`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New parametrized tests in `tests/webhooks/test_ssrf.py` and `tests/utils/test_validation.py` assert the guard now blocks `64:ff9b::169.254.169.254` (NAT64 metadata), `::ffff:100.64.0.1` (IPv4-mapped CGNAT), and a 6to4 private address, while still accepting genuinely public addresses (`::ffff:8.8.8.8`, `2001:4860:4860::8888`) and still blocking plain private IPv4.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Webhook SSRF protection now rejects IPv6-transition addresses (NAT64 `64:ff9b::/96`, IPv4-mapped, and 6to4) that embed a private, CGNAT, or link-local IPv4, closing bypasses of the connection-time and pre-flight guards.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Reported by @DhiyaneshGeek and @kta1kri via GitHub Security Advisories GHSA-7646-8p3r-42ch and GHSA-m56c-jhmp-2mx2.
