### PR TITLE
Add shared skill content library: source fetching, safe extraction, `SKILL.md` inspection, and digest

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1787,3 +1787,11 @@ MLFLOW_SKIP_PIP_REQUIREMENTS_CHECK = _BooleanEnvironmentVariable(
 MLFLOW_READ_REPLICA_BACKEND_STORE_URI = _EnvironmentVariable(
     "MLFLOW_READ_REPLICA_BACKEND_STORE_URI", str, None
 )
+
+#: Specifies the maximum decompressed size in bytes of skill content handled by the skill
+#: registry client and server: uploaded skill archives, fetched ZIP and OCI sources, and
+#: cloned or downloaded skill trees. Content larger than this limit is rejected.
+#: (default: ``26214400``, 25 MiB)
+MLFLOW_SKILL_CONTENT_MAX_DECOMPRESSED_SIZE = _EnvironmentVariable(
+    "MLFLOW_SKILL_CONTENT_MAX_DECOMPRESSED_SIZE", int, 25 * 1024**2
+)

--- a/mlflow/genai/skill_content/__init__.py
+++ b/mlflow/genai/skill_content/__init__.py
@@ -1,0 +1,11 @@
+"""
+Shared client-side content handling for the skill registry (RFC-0008).
+
+This package owns the pieces of the registry that touch skill *content* rather than registry
+metadata: fetching Git, OCI, ZIP, and MLflow artifact sources, safe archive validation and
+extraction, ``SKILL.md`` inspection, and the canonical content digest. Registration, import,
+introspection, and pull flows all call into it so that content access and identity are
+implemented once.
+
+Nothing here is part of the public ``mlflow.genai`` API.
+"""

--- a/mlflow/genai/skill_content/archive.py
+++ b/mlflow/genai/skill_content/archive.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import gzip
+import os
+import stat
+import tarfile
+import zipfile
+import zlib
+from contextlib import contextmanager
+from pathlib import Path
+from typing import IO, Iterator
+
+from mlflow.environment_variables import MLFLOW_SKILL_CONTENT_MAX_DECOMPRESSED_SIZE
+from mlflow.genai.skill_content.errors import content_unreadable, display_path, invalid_content
+from mlflow.genai.skill_content.paths import (
+    PathCollisionGuard,
+    assert_regular_tree,
+    canonical_relative_path,
+    collect_tree,
+    ensure_within,
+    is_under_subpath,
+    normalize_subpath,
+)
+
+# Bounds the number of archive entries so a tiny archive cannot force millions of file
+# operations even when its declared content size is within the byte limit.
+MAX_ARCHIVE_ENTRIES = 10_000
+# Tar metadata (headers, padding, PAX and GNU long-name payloads) is read by the tar parser
+# before any member is surfaced, so it is bounded separately from content by a fixed allowance.
+_TAR_METADATA_ALLOWANCE = 1024 * MAX_ARCHIVE_ENTRIES
+_COPY_CHUNK_SIZE = 1024 * 1024
+_MSDOS_DIRECTORY_ATTRIBUTE = 0x10
+_ZIP_ENCRYPTED_FLAG = 0x1
+_ZIP_TYPE_MASK = 0o170000
+_SUPPORTED_ZIP_METHODS = (
+    zipfile.ZIP_STORED,
+    zipfile.ZIP_DEFLATED,
+    zipfile.ZIP_BZIP2,
+    zipfile.ZIP_LZMA,
+)
+
+
+def get_max_decompressed_size(max_bytes: int | None = None) -> int:
+    """
+    The decompressed byte budget for skill content.
+
+    ``max_bytes`` overrides the shared ``MLFLOW_SKILL_CONTENT_MAX_DECOMPRESSED_SIZE`` setting
+    for a single operation; every other caller shares the configured default.
+    """
+    limit = MLFLOW_SKILL_CONTENT_MAX_DECOMPRESSED_SIZE.get() if max_bytes is None else max_bytes
+    if limit <= 0:
+        raise invalid_content(f"Skill content size limit must be positive, got {limit}.")
+    return limit
+
+
+def _member_relative_path(name: str) -> str | None:
+    """Canonicalize an exact archive entry name; ``None`` means the entry is the root itself."""
+    value = name.removeprefix("./")
+    if value in ("", ".", "./"):
+        return None
+    try:
+        return canonical_relative_path(value)
+    except Exception as e:
+        raise invalid_content(f"Archive entry '{display_path(name)}' has an unsafe path: {e}")
+
+
+class _ByteBudget:
+    def __init__(self, limit: int):
+        self.limit = limit
+        self.used = 0
+
+    def consume(self, amount: int, what: str) -> None:
+        self.used += amount
+        if self.used > self.limit:
+            raise invalid_content(
+                f"{what} exceeds the skill content size limit of {self.limit} bytes."
+            )
+
+
+class _BoundedStream:
+    """Read-only wrapper that fails once more than ``limit`` decompressed bytes pass through."""
+
+    def __init__(self, inner: IO[bytes], limit: int):
+        self._inner = inner
+        self._limit = limit
+        self._read = 0
+
+    def read(self, size: int = -1) -> bytes:
+        chunk = self._inner.read(size)
+        self._read += len(chunk)
+        if self._read > self._limit:
+            raise invalid_content(
+                f"Archive decompresses to more than {self._limit} bytes including metadata, "
+                "which exceeds the skill content size limit."
+            )
+        return chunk
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+class _ArchiveLayout:
+    """Tracks entries of one archive so files and directories cannot shadow each other."""
+
+    def __init__(self):
+        self._guard = PathCollisionGuard()
+        self._files: set[str] = set()
+        self._dirs: set[str] = set()
+
+    def _register_dir(self, path: str, raw_name: str) -> None:
+        if path in self._dirs:
+            return
+        if path in self._files:
+            raise invalid_content(
+                f"Archive entry '{display_path(raw_name)}' uses '{path}' as a directory, "
+                "but it is a file."
+            )
+        self._guard.register(path)
+        self._dirs.add(path)
+
+    def add(self, relative: str, raw_name: str, *, is_dir: bool) -> None:
+        parts = relative.split("/")
+        for depth in range(1, len(parts)):
+            self._register_dir("/".join(parts[:depth]), raw_name)
+        if is_dir:
+            self._register_dir(relative, raw_name)
+            return
+        if relative in self._dirs:
+            raise invalid_content(
+                f"Archive entry '{display_path(raw_name)}' is a file, but '{relative}' is "
+                "also a directory."
+            )
+        self._guard.register(relative)
+        self._files.add(relative)
+
+
+def _copy_with_budget(src: IO[bytes], dst: IO[bytes], budget: _ByteBudget, what: str) -> None:
+    while chunk := src.read(_COPY_CHUNK_SIZE):
+        budget.consume(len(chunk), what)
+        dst.write(chunk)
+
+
+def _require_empty_dir(dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    if any(dest.iterdir()):
+        raise invalid_content(f"Extraction destination '{dest}' must be an empty directory.")
+
+
+def _write_entry(
+    dest: Path, relative: str, raw_name: str, source: IO[bytes] | None, budget: _ByteBudget
+) -> None:
+    target = dest.joinpath(*relative.split("/"))
+    ensure_within(dest, target)
+    try:
+        if source is None:
+            target.mkdir(parents=True, exist_ok=True)
+            return
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with source, open(target, "wb") as out:
+            _copy_with_budget(source, out, budget, "Archive content")
+    except OSError as e:
+        raise invalid_content(f"Cannot extract archive entry '{display_path(raw_name)}': {e}")
+
+
+# --- gzip tar ---------------------------------------------------------------------------------
+
+
+def package_skill_tree(root: str | os.PathLike[str], output: str | os.PathLike[str]) -> Path:
+    """
+    Package the regular files under ``root`` as a reproducible gzip-compressed tar archive.
+
+    The archive contains exactly the tree that ``compute_tree_digest`` hashes: the same file
+    set in the same canonical order, with timestamps, ownership, and permissions normalized so
+    identical content produces byte-identical archives on every platform.
+    """
+    files = collect_tree(root)
+    output_path = Path(output)
+    with (
+        open(output_path, "wb") as raw,
+        gzip.GzipFile(filename="", fileobj=raw, mode="wb", mtime=0) as gz,
+        tarfile.open(fileobj=gz, mode="w", format=tarfile.PAX_FORMAT) as tar,
+    ):
+        for entry in files:
+            info = tarfile.TarInfo(name=entry.path)
+            info.size = entry.size
+            info.mtime = 0
+            info.mode = 0o644
+            info.uid = info.gid = 0
+            info.uname = info.gname = ""
+            try:
+                with open(entry.local_path, "rb") as fh:
+                    tar.addfile(info, fh)
+            except OSError as e:
+                raise content_unreadable(entry.local_path, e)
+    return output_path
+
+
+_TAR_FAILURES = (tarfile.TarError, EOFError, OSError, zlib.error, RecursionError, ValueError)
+
+
+@contextmanager
+def _open_tar(archive: Path, *, compressed: bool, limit: int) -> Iterator[tarfile.TarFile]:
+    """
+    Open ``archive`` as a sequential tar stream whose decompressed bytes are bounded.
+
+    Streaming mode makes the parser read headers and content strictly in order, and the
+    bounded stream underneath fails the moment the archive decompresses past the content
+    limit plus a fixed metadata allowance, so oversized PAX or GNU long-name headers are cut
+    off instead of being buffered in memory.
+    """
+    with open(archive, "rb") as raw:
+        inner = gzip.GzipFile(fileobj=raw, mode="rb") if compressed else raw
+        bounded = _BoundedStream(inner, limit + _TAR_METADATA_ALLOWANCE)
+        try:
+            with tarfile.open(fileobj=bounded, mode="r|") as tar:
+                yield tar
+        except _TAR_FAILURES as e:
+            raise invalid_content(f"'{archive.name}' is not a readable tar archive: {e}")
+
+
+def _iter_tar_members(tar: tarfile.TarFile) -> Iterator[tarfile.TarInfo]:
+    count = 0
+    try:
+        for member in tar:
+            count += 1
+            if count > MAX_ARCHIVE_ENTRIES:
+                raise invalid_content(f"Archive contains more than {MAX_ARCHIVE_ENTRIES} entries.")
+            yield member
+    except _TAR_FAILURES as e:
+        raise invalid_content(f"Archive is malformed: {e}")
+
+
+def _tar_entry_kind(member: tarfile.TarInfo) -> bool:
+    """Return ``is_dir`` for an accepted entry, or raise for any other entry type."""
+    if member.isdir():
+        return True
+    if member.isreg():
+        return False
+    raise invalid_content(f"Archive entry '{member.name}' is not a regular file or directory.")
+
+
+def validate_skill_archive(
+    archive: str | os.PathLike[str],
+    *,
+    max_bytes: int | None = None,
+    compressed: bool = True,
+    subpath: str | None = None,
+) -> int:
+    """
+    Validate a skill archive without extracting it.
+
+    Every entry is checked: absolute paths, ``..`` segments, backslashes, drive or stream
+    colons, reserved names, entries that are not regular files or directories, and names that
+    collide after Unicode normalization or case folding are rejected. When ``subpath`` is
+    given, only entries at or beneath it count toward the decompressed size limit, because
+    only those are extracted.
+
+    Returns:
+        The total declared size of the regular files that would be extracted.
+    """
+    limit = get_max_decompressed_size(max_bytes)
+    prefix = normalize_subpath(subpath)
+    budget = _ByteBudget(limit)
+    layout = _ArchiveLayout()
+    with _open_tar(Path(archive), compressed=compressed, limit=limit) as tar:
+        for member in _iter_tar_members(tar):
+            relative = _member_relative_path(member.name)
+            is_dir = _tar_entry_kind(member)
+            if relative is None:
+                if not is_dir:
+                    raise invalid_content("Archive root entry must be a directory.")
+                continue
+            layout.add(relative, member.name, is_dir=is_dir)
+            if not is_dir and is_under_subpath(relative, prefix):
+                budget.consume(member.size, "Archive content")
+    return budget.used
+
+
+def extract_skill_archive(
+    archive: str | os.PathLike[str],
+    dest: str | os.PathLike[str],
+    *,
+    max_bytes: int | None = None,
+    compressed: bool = True,
+    subpath: str | None = None,
+) -> Path:
+    """
+    Validate ``archive`` and extract it into the empty directory ``dest``.
+
+    Only regular files and directories are written, the decompressed size limit is enforced on
+    the bytes actually read, and the result is verified with ``assert_regular_tree``. When
+    ``subpath`` is given, entries outside it are validated but not written, so the extracted
+    tree contains just ``dest/<subpath>``.
+    """
+    archive_path = Path(archive)
+    dest_path = Path(dest)
+    limit = get_max_decompressed_size(max_bytes)
+    prefix = normalize_subpath(subpath)
+    validate_skill_archive(archive_path, max_bytes=limit, compressed=compressed, subpath=prefix)
+    _require_empty_dir(dest_path)
+    budget = _ByteBudget(limit)
+    with _open_tar(archive_path, compressed=compressed, limit=limit) as tar:
+        for member in _iter_tar_members(tar):
+            relative = _member_relative_path(member.name)
+            if relative is None or not is_under_subpath(relative, prefix):
+                continue
+            if member.isdir():
+                _write_entry(dest_path, relative, member.name, None, budget)
+                continue
+            source = tar.extractfile(member)
+            if source is None:
+                raise invalid_content(f"Archive entry '{member.name}' has no readable content.")
+            _write_entry(dest_path, relative, member.name, source, budget)
+    assert_regular_tree(dest_path)
+    return dest_path
+
+
+# --- zip --------------------------------------------------------------------------------------
+
+
+def _zip_is_dir(info: zipfile.ZipInfo) -> bool:
+    mode = (info.external_attr >> 16) & _ZIP_TYPE_MASK
+    return (
+        info.is_dir()
+        or mode == stat.S_IFDIR
+        or bool(info.external_attr & _MSDOS_DIRECTORY_ATTRIBUTE)
+    )
+
+
+def _zip_entry_kind(info: zipfile.ZipInfo) -> bool:
+    if info.flag_bits & _ZIP_ENCRYPTED_FLAG:
+        raise invalid_content(f"Archive entry '{display_path(info.filename)}' is encrypted.")
+    if _zip_is_dir(info):
+        return True
+    if info.compress_type not in _SUPPORTED_ZIP_METHODS:
+        raise invalid_content(
+            f"Archive entry '{display_path(info.filename)}' uses unsupported compression "
+            f"method {info.compress_type}."
+        )
+    mode = (info.external_attr >> 16) & _ZIP_TYPE_MASK
+    if mode in (0, stat.S_IFREG):
+        return False
+    raise invalid_content(f"Archive entry '{info.filename}' is not a regular file or directory.")
+
+
+@contextmanager
+def _open_zip(archive: Path) -> Iterator[zipfile.ZipFile]:
+    try:
+        with zipfile.ZipFile(archive) as zf:
+            yield zf
+    except (
+        zipfile.BadZipFile,
+        EOFError,
+        OSError,
+        zlib.error,
+        RuntimeError,
+        NotImplementedError,
+    ) as e:
+        raise invalid_content(f"'{archive.name}' is not a readable ZIP archive: {e}")
+
+
+def validate_zip_archive(
+    archive: str | os.PathLike[str], *, max_bytes: int | None = None, subpath: str | None = None
+) -> int:
+    """Validate a ZIP archive with the same path, entry type, collision, and size rules as tar."""
+    prefix = normalize_subpath(subpath)
+    budget = _ByteBudget(get_max_decompressed_size(max_bytes))
+    layout = _ArchiveLayout()
+    with _open_zip(Path(archive)) as zf:
+        infos = zf.infolist()
+        if len(infos) > MAX_ARCHIVE_ENTRIES:
+            raise invalid_content(f"Archive contains more than {MAX_ARCHIVE_ENTRIES} entries.")
+        for info in infos:
+            relative = _member_relative_path(info.filename)
+            is_dir = _zip_entry_kind(info)
+            if relative is None:
+                if not is_dir:
+                    raise invalid_content("Archive root entry must be a directory.")
+                continue
+            layout.add(relative, info.filename, is_dir=is_dir)
+            if not is_dir and is_under_subpath(relative, prefix):
+                budget.consume(info.file_size, "Archive content")
+    return budget.used
+
+
+def extract_zip_archive(
+    archive: str | os.PathLike[str],
+    dest: str | os.PathLike[str],
+    *,
+    max_bytes: int | None = None,
+    subpath: str | None = None,
+) -> Path:
+    """Validate ``archive`` and extract it, or only ``subpath``, into empty directory ``dest``."""
+    dest_path = Path(dest)
+    limit = get_max_decompressed_size(max_bytes)
+    prefix = normalize_subpath(subpath)
+    validate_zip_archive(archive, max_bytes=limit, subpath=prefix)
+    _require_empty_dir(dest_path)
+    budget = _ByteBudget(limit)
+    with _open_zip(Path(archive)) as zf:
+        for info in zf.infolist():
+            relative = _member_relative_path(info.filename)
+            if relative is None or not is_under_subpath(relative, prefix):
+                continue
+            if _zip_is_dir(info):
+                _write_entry(dest_path, relative, info.filename, None, budget)
+                continue
+            try:
+                source = zf.open(info)
+            except (
+                zipfile.BadZipFile,
+                zlib.error,
+                OSError,
+                RuntimeError,
+                NotImplementedError,
+            ) as e:
+                raise invalid_content(
+                    f"Cannot extract archive entry '{display_path(info.filename)}': {e}"
+                )
+            _write_entry(dest_path, relative, info.filename, source, budget)
+    assert_regular_tree(dest_path)
+    return dest_path

--- a/mlflow/genai/skill_content/archive.py
+++ b/mlflow/genai/skill_content/archive.py
@@ -13,7 +13,7 @@ from typing import IO, Iterator
 from mlflow.environment_variables import MLFLOW_SKILL_CONTENT_MAX_DECOMPRESSED_SIZE
 from mlflow.genai.skill_content.errors import content_unreadable, display_path, invalid_content
 from mlflow.genai.skill_content.paths import (
-    PathCollisionGuard,
+    TreeLayout,
     assert_regular_tree,
     canonical_relative_path,
     collect_tree,
@@ -101,41 +101,6 @@ class _BoundedStream:
 
     def close(self) -> None:
         self._inner.close()
-
-
-class _ArchiveLayout:
-    """Tracks entries of one archive so files and directories cannot shadow each other."""
-
-    def __init__(self):
-        self._guard = PathCollisionGuard()
-        self._files: set[str] = set()
-        self._dirs: set[str] = set()
-
-    def _register_dir(self, path: str, raw_name: str) -> None:
-        if path in self._dirs:
-            return
-        if path in self._files:
-            raise invalid_content(
-                f"Archive entry '{display_path(raw_name)}' uses '{path}' as a directory, "
-                "but it is a file."
-            )
-        self._guard.register(path)
-        self._dirs.add(path)
-
-    def add(self, relative: str, raw_name: str, *, is_dir: bool) -> None:
-        parts = relative.split("/")
-        for depth in range(1, len(parts)):
-            self._register_dir("/".join(parts[:depth]), raw_name)
-        if is_dir:
-            self._register_dir(relative, raw_name)
-            return
-        if relative in self._dirs:
-            raise invalid_content(
-                f"Archive entry '{display_path(raw_name)}' is a file, but '{relative}' is "
-                "also a directory."
-            )
-        self._guard.register(relative)
-        self._files.add(relative)
 
 
 def _copy_with_budget(src: IO[bytes], dst: IO[bytes], budget: _ByteBudget, what: str) -> None:
@@ -276,7 +241,7 @@ def validate_skill_archive(
     limit = get_max_decompressed_size(max_bytes)
     prefix = normalize_subpath(subpath)
     budget = _ByteBudget(limit)
-    layout = _ArchiveLayout()
+    layout = TreeLayout()
     with _open_tar(Path(archive), compressed=compressed) as (tar, bounded):
         for member in _iter_tar_members(tar, bounded):
             relative = _member_relative_path(member.name)
@@ -380,7 +345,7 @@ def validate_zip_archive(
     """Validate a ZIP archive with the same path, entry type, collision, and size rules as tar."""
     prefix = normalize_subpath(subpath)
     budget = _ByteBudget(get_max_decompressed_size(max_bytes))
-    layout = _ArchiveLayout()
+    layout = TreeLayout()
     with _open_zip(Path(archive)) as zf:
         infos = zf.infolist()
         if len(infos) > MAX_ARCHIVE_ENTRIES:

--- a/mlflow/genai/skill_content/archive.py
+++ b/mlflow/genai/skill_content/archive.py
@@ -90,10 +90,14 @@ class _BoundedStream:
         self._read += len(chunk)
         if self._read > self._limit:
             raise invalid_content(
-                f"Archive decompresses to more than {self._limit} bytes including metadata, "
-                "which exceeds the skill content size limit."
+                f"Archive metadata decompresses to more than {self._limit} bytes, which "
+                "exceeds the allowance for tar headers."
             )
         return chunk
+
+    def grant(self, amount: int) -> None:
+        """Allow ``amount`` more bytes through: a member's declared payload is not metadata."""
+        self._limit += amount
 
     def close(self) -> None:
         self._inner.close()
@@ -199,32 +203,43 @@ _TAR_FAILURES = (tarfile.TarError, EOFError, OSError, zlib.error, RecursionError
 
 
 @contextmanager
-def _open_tar(archive: Path, *, compressed: bool, limit: int) -> Iterator[tarfile.TarFile]:
+def _open_tar(
+    archive: Path, *, compressed: bool
+) -> Iterator[tuple[tarfile.TarFile, _BoundedStream]]:
     """
-    Open ``archive`` as a sequential tar stream whose decompressed bytes are bounded.
+    Open ``archive`` as a sequential tar stream whose metadata bytes are bounded.
 
-    Streaming mode makes the parser read headers and content strictly in order, and the
-    bounded stream underneath fails the moment the archive decompresses past the content
-    limit plus a fixed metadata allowance, so oversized PAX or GNU long-name headers are cut
-    off instead of being buffered in memory.
+    Streaming mode makes the parser read headers and content strictly in order. The bounded
+    stream underneath starts with only the metadata allowance, and ``_iter_tar_members``
+    grants each member's declared payload as its header is parsed, so oversized PAX or GNU
+    long-name headers are cut off instead of being buffered in memory while file contents,
+    selected or not, never count against that allowance. Selected content is budgeted
+    separately by the callers.
     """
     with open(archive, "rb") as raw:
         inner = gzip.GzipFile(fileobj=raw, mode="rb") if compressed else raw
-        bounded = _BoundedStream(inner, limit + _TAR_METADATA_ALLOWANCE)
+        bounded = _BoundedStream(inner, _TAR_METADATA_ALLOWANCE)
         try:
             with tarfile.open(fileobj=bounded, mode="r|") as tar:
-                yield tar
+                yield tar, bounded
         except _TAR_FAILURES as e:
             raise invalid_content(f"'{archive.name}' is not a readable tar archive: {e}")
 
 
-def _iter_tar_members(tar: tarfile.TarFile) -> Iterator[tarfile.TarInfo]:
+def _padded_payload(size: int) -> int:
+    return -(-size // tarfile.BLOCKSIZE) * tarfile.BLOCKSIZE
+
+
+def _iter_tar_members(tar: tarfile.TarFile, bounded: _BoundedStream) -> Iterator[tarfile.TarInfo]:
     count = 0
     try:
         for member in tar:
             count += 1
             if count > MAX_ARCHIVE_ENTRIES:
                 raise invalid_content(f"Archive contains more than {MAX_ARCHIVE_ENTRIES} entries.")
+            # The header has been parsed; its payload (which the caller either copies under
+            # the content budget or skips) is about to stream through and is not metadata.
+            bounded.grant(_padded_payload(member.size))
             yield member
     except _TAR_FAILURES as e:
         raise invalid_content(f"Archive is malformed: {e}")
@@ -262,8 +277,8 @@ def validate_skill_archive(
     prefix = normalize_subpath(subpath)
     budget = _ByteBudget(limit)
     layout = _ArchiveLayout()
-    with _open_tar(Path(archive), compressed=compressed, limit=limit) as tar:
-        for member in _iter_tar_members(tar):
+    with _open_tar(Path(archive), compressed=compressed) as (tar, bounded):
+        for member in _iter_tar_members(tar, bounded):
             relative = _member_relative_path(member.name)
             is_dir = _tar_entry_kind(member)
             if relative is None:
@@ -299,8 +314,8 @@ def extract_skill_archive(
     validate_skill_archive(archive_path, max_bytes=limit, compressed=compressed, subpath=prefix)
     _require_empty_dir(dest_path)
     budget = _ByteBudget(limit)
-    with _open_tar(archive_path, compressed=compressed, limit=limit) as tar:
-        for member in _iter_tar_members(tar):
+    with _open_tar(archive_path, compressed=compressed) as (tar, bounded):
+        for member in _iter_tar_members(tar, bounded):
             relative = _member_relative_path(member.name)
             if relative is None or not is_under_subpath(relative, prefix):
                 continue

--- a/mlflow/genai/skill_content/digest.py
+++ b/mlflow/genai/skill_content/digest.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import struct
+
+from mlflow.genai.skill_content.errors import content_unreadable, invalid_content
+from mlflow.genai.skill_content.paths import collect_tree
+
+_READ_CHUNK_SIZE = 1024 * 1024
+
+
+def _u64be(value: int) -> bytes:
+    return struct.pack(">Q", value)
+
+
+def compute_tree_digest(root: str | os.PathLike[str]) -> str:
+    """
+    Compute the canonical SHA-256 content digest of a skill tree.
+
+    Regular files are visited in canonical order (see ``collect_tree``) and each contributes
+    four length-framed parts: the UTF-8 length of its POSIX relative path as an unsigned 8-byte
+    big-endian integer, the path bytes, the content length in the same encoding, and the
+    content bytes. Only paths and contents contribute, so the same tree hashes identically
+    regardless of where it was fetched from or which operating system hashed it.
+
+    Returns:
+        Lowercase 64-character hexadecimal digest.
+    """
+    hasher = hashlib.sha256()
+    for entry in collect_tree(root):
+        path_bytes = entry.path.encode("utf-8")
+        hasher.update(_u64be(len(path_bytes)))
+        hasher.update(path_bytes)
+        hasher.update(_u64be(entry.size))
+        read = 0
+        try:
+            with open(entry.local_path, "rb") as fh:
+                while chunk := fh.read(_READ_CHUNK_SIZE):
+                    hasher.update(chunk)
+                    read += len(chunk)
+        except OSError as e:
+            raise content_unreadable(entry.local_path, e)
+        if read != entry.size:
+            raise invalid_content(
+                f"File '{entry.path}' changed while it was being hashed "
+                f"(expected {entry.size} bytes, read {read})."
+            )
+    return hasher.hexdigest()

--- a/mlflow/genai/skill_content/errors.py
+++ b/mlflow/genai/skill_content/errors.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import re
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import (
+    INVALID_PARAMETER_VALUE,
+    PERMISSION_DENIED,
+    RESOURCE_DOES_NOT_EXIST,
+    TEMPORARILY_UNAVAILABLE,
+    UNAUTHENTICATED,
+)
+
+# ``user:password@`` inside a URL.
+_USERINFO_PATTERN = re.compile(r"(?<=://)[^/@\s]+@")
+# The user part of an scp-style git URL such as ``user:token@host:org/repo.git``.
+_SCP_USERINFO_PATTERN = re.compile(r"(?<![\w/])[^\s/:@]+:[^\s/@]+@(?=[\w.-]+:)")
+# Bearer / Basic tokens that transport libraries sometimes echo into messages.
+_AUTH_TOKEN_PATTERN = re.compile(r"(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}")
+
+
+def redact_credentials(text: str) -> str:
+    """Remove URL userinfo and auth tokens from ``text`` so it is safe to surface."""
+    text = _USERINFO_PATTERN.sub("***@", text)
+    text = _SCP_USERINFO_PATTERN.sub("***@", text)
+    return _AUTH_TOKEN_PATTERN.sub(r"\1 ***", text)
+
+
+def display_path(value: str) -> str:
+    """Render a path for an error message even when it holds undecodable bytes."""
+    return value.encode("utf-8", "backslashreplace").decode("utf-8")
+
+
+def content_unreadable(path: object, error: OSError) -> MlflowException:
+    """Error for skill content on disk that cannot be read; permission problems keep their code."""
+    code = PERMISSION_DENIED if isinstance(error, PermissionError) else INVALID_PARAMETER_VALUE
+    return MlflowException(
+        f"Cannot read skill content at '{display_path(str(path))}': {error.strerror or error}",
+        error_code=code,
+    )
+
+
+def invalid_content(message: str) -> MlflowException:
+    """Error for content that violates the skill content rules (paths, entry types, size)."""
+    return MlflowException(redact_credentials(message), error_code=INVALID_PARAMETER_VALUE)
+
+
+def error_code_for_http_status(status: int) -> int:
+    if status == 401:
+        return UNAUTHENTICATED
+    if status == 403:
+        return PERMISSION_DENIED
+    if status in (404, 410):
+        return RESOURCE_DOES_NOT_EXIST
+    if status >= 500 or status == 429:
+        return TEMPORARILY_UNAVAILABLE
+    return RESOURCE_DOES_NOT_EXIST
+
+
+def source_unavailable(
+    source: str, detail: str, *, error_code: int = RESOURCE_DOES_NOT_EXIST
+) -> MlflowException:
+    """
+    Error for a source that could not be fetched, preserving the underlying reason.
+
+    ``error_code`` distinguishes authentication, permission, availability, and not-found
+    failures so callers such as the CLI can map them to distinct exit statuses.
+    """
+    return MlflowException(
+        f"Failed to fetch skill content from '{redact_credentials(source)}': "
+        f"{redact_credentials(detail)}",
+        error_code=error_code,
+    )

--- a/mlflow/genai/skill_content/fetchers/__init__.py
+++ b/mlflow/genai/skill_content/fetchers/__init__.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from mlflow.entities.skill_source import SkillSourceType
+from mlflow.genai.skill_content.archive import get_max_decompressed_size
+from mlflow.genai.skill_content.errors import invalid_content
+from mlflow.genai.skill_content.fetchers.artifacts import fetch_mlflow_artifacts
+from mlflow.genai.skill_content.fetchers.git import fetch_git
+from mlflow.genai.skill_content.fetchers.zip import fetch_zip
+from mlflow.genai.skill_content.paths import assert_regular_tree, resolve_contained, tree_size
+from mlflow.genai.skill_content.sources import ResolvedSource, SourceInput, resolve_source_type
+
+
+@dataclass
+class FetchedContent:
+    """
+    Skill content materialized on the local filesystem.
+
+    ``root`` is the directory the caller should inspect or hash: the fetched tree after the
+    subpath has been applied. Remote fetches live in a temporary directory that ``cleanup``
+    removes; local sources are used in place and ``cleanup`` is a no-op for them.
+    """
+
+    root: Path
+    resolved: ResolvedSource
+    _tmpdir: tempfile.TemporaryDirectory[str] | None = field(default=None, repr=False)
+
+    def cleanup(self) -> None:
+        if self._tmpdir is not None:
+            self._tmpdir.cleanup()
+            self._tmpdir = None
+
+    def __enter__(self) -> FetchedContent:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.cleanup()
+
+
+def _fetch_remote(resolved: ResolvedSource, dest: Path, limit: int) -> Path:
+    subpath = resolved.subpath
+    if resolved.source_type == SkillSourceType.GIT:
+        return fetch_git(resolved.source, resolved.ref, dest, max_bytes=limit, subpath=subpath)
+    if resolved.source_type == SkillSourceType.OCI:
+        # The OCI registry fetcher lands in a follow-up change; the type still resolves so
+        # callers get a precise error instead of a misclassified source.
+        raise invalid_content(
+            f"OCI sources are not supported yet ('{resolved.source}'); use a Git, ZIP, MLflow "
+            "artifact, or local source."
+        )
+    if resolved.source_type == SkillSourceType.ZIP:
+        return fetch_zip(resolved.source, dest, max_bytes=limit, subpath=subpath)
+    if resolved.source_type == SkillSourceType.MLFLOW:
+        return fetch_mlflow_artifacts(resolved.source, dest, max_bytes=limit, subpath=subpath)
+    raise invalid_content(f"Source type '{resolved.source_type}' cannot be fetched.")
+
+
+def fetch_source(
+    source: SourceInput,
+    *,
+    ref: str | None = None,
+    subpath: str | None = None,
+    max_bytes: int | None = None,
+) -> FetchedContent:
+    """
+    Fetch skill content from a local path or a Git, OCI, ZIP, or MLflow artifact source.
+
+    Fetching uses the caller's own credentials (Git credential helpers, Docker config and
+    credential helpers, MLflow tracking credentials); ZIP sources must be publicly reachable.
+    The decompressed size limit bounds the content at or beneath ``subpath``: archives and
+    images extract only that part, and Git checkouts are measured there. Downloads themselves
+    are bounded by the same limit on the wire so an oversized archive is cut off early. After
+    the fetch, the subpath is resolved with containment checks and the resulting tree is
+    required to contain only regular files and directories.
+
+    Args:
+        source: Typed source, remote URL or image reference, MLflow artifact URI, or local path.
+        ref: Git branch, tag, or commit for a plain-string Git URL. Typed sources carry their own.
+        subpath: Directory within the fetched content to use as the root.
+        max_bytes: Per-call override of the shared decompressed size limit.
+
+    Returns:
+        A ``FetchedContent`` whose ``root`` is ready for inspection, hashing, or packaging.
+    """
+    resolved = resolve_source_type(source, ref=ref, subpath=subpath)
+    limit = get_max_decompressed_size(max_bytes)
+    if resolved.is_local:
+        base = Path(resolved.source)
+        if not base.is_dir():
+            raise invalid_content(f"Local skill source '{base}' is not a directory.")
+        tmpdir = None
+    else:
+        tmpdir = tempfile.TemporaryDirectory(prefix="mlflow-skill-content-")
+        dest = Path(tmpdir.name) / "content"
+        try:
+            base = _fetch_remote(resolved, dest, limit)
+        except Exception:
+            tmpdir.cleanup()
+            raise
+    try:
+        root = resolve_contained(base, resolved.subpath)
+        assert_regular_tree(root)
+        if (size := tree_size(root)) > limit:
+            raise invalid_content(
+                f"Skill content is {size} bytes, which exceeds the size limit of {limit} bytes."
+            )
+    except Exception:
+        if tmpdir is not None:
+            tmpdir.cleanup()
+        raise
+    return FetchedContent(root=root, resolved=resolved, _tmpdir=tmpdir)

--- a/mlflow/genai/skill_content/fetchers/artifacts.py
+++ b/mlflow/genai/skill_content/fetchers/artifacts.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from mlflow.artifacts import download_artifacts
+from mlflow.exceptions import MlflowException
+from mlflow.genai.skill_content.errors import invalid_content, source_unavailable
+from mlflow.genai.skill_content.paths import normalize_subpath, tree_size
+from mlflow.protos.databricks_pb2 import ErrorCode
+
+
+def fetch_mlflow_artifacts(
+    uri: str, dest: Path, *, max_bytes: int, subpath: str | None = None
+) -> Path:
+    """
+    Download the artifact directory at ``uri`` into ``dest`` using the caller's MLflow credentials.
+
+    ``uri`` is any artifact URI ``mlflow.artifacts.download_artifacts`` accepts, such as
+    ``mlflow-artifacts:/skills/code-review/<token>`` or ``runs:/<run_id>/skill``. When
+    ``subpath`` is given only that directory is downloaded, placed at ``dest/<subpath>`` so the
+    caller's containment check resolves it the same way as every other source. The returned
+    path is the base under which ``subpath`` resolves.
+    """
+    prefix = normalize_subpath(subpath)
+    dest.mkdir(parents=True, exist_ok=True)
+    if prefix is None:
+        artifact_uri = uri
+        dst = dest
+    else:
+        artifact_uri = f"{uri.rstrip('/')}/{prefix}"
+        dst = dest.joinpath(*prefix.split("/")[:-1])
+        dst.mkdir(parents=True, exist_ok=True)
+    try:
+        downloaded = Path(download_artifacts(artifact_uri=artifact_uri, dst_path=str(dst)))
+    except MlflowException as e:
+        raise source_unavailable(uri, e.message, error_code=ErrorCode.Value(e.error_code))
+    except OSError as e:
+        raise source_unavailable(uri, str(e))
+    if not downloaded.is_dir():
+        raise invalid_content(f"MLflow artifact source '{uri}' must be a directory, not a file.")
+    if (size := tree_size(downloaded)) > max_bytes:
+        raise invalid_content(
+            f"MLflow artifact content is {size} bytes, which exceeds the skill content size "
+            f"limit of {max_bytes} bytes."
+        )
+    return dest if prefix is not None else downloaded

--- a/mlflow/genai/skill_content/fetchers/git.py
+++ b/mlflow/genai/skill_content/fetchers/git.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.skill_content.errors import invalid_content, source_unavailable
+from mlflow.genai.skill_content.paths import resolve_contained, tree_size
+from mlflow.protos.databricks_pb2 import (
+    RESOURCE_DOES_NOT_EXIST,
+    TEMPORARILY_UNAVAILABLE,
+    UNAUTHENTICATED,
+)
+
+# Never let git block on an interactive credential prompt; credentials come from the caller's
+# configured helpers, SSH agent, or netrc.
+_GIT_ENV = {"GIT_TERMINAL_PROMPT": "0"}
+_GIT_TIMEOUT_SECONDS = 600
+_AUTH_MARKERS = (
+    "authentication failed",
+    "could not read username",
+    "could not read password",
+    "permission denied",
+    "publickey",
+    "terminal prompts disabled",
+)
+_AVAILABILITY_MARKERS = (
+    "could not resolve host",
+    "connection refused",
+    "connection timed out",
+    "timed out",
+    "unable to access",
+    "early eof",
+)
+
+
+def _error_code_for_git(detail: str) -> int:
+    lowered = detail.lower()
+    if any(marker in lowered for marker in _AUTH_MARKERS):
+        return UNAUTHENTICATED
+    if any(marker in lowered for marker in _AVAILABILITY_MARKERS):
+        return TEMPORARILY_UNAVAILABLE
+    return RESOURCE_DOES_NOT_EXIST
+
+
+def _force_remove(func, path, _exc) -> None:
+    # Git writes pack and object files read-only; on Windows that makes unlink fail.
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
+def _remove_git_dir(dest: Path) -> None:
+    git_dir = dest / ".git"
+    if not git_dir.exists():
+        return
+    if sys.version_info >= (3, 12):
+        shutil.rmtree(git_dir, onexc=_force_remove)
+    else:
+        shutil.rmtree(git_dir, onerror=_force_remove)
+    if git_dir.exists():
+        raise invalid_content(
+            f"Could not remove the '.git' directory from the checkout at '{dest}'."
+        )
+
+
+def fetch_git(
+    url: str, ref: str | None, dest: Path, *, max_bytes: int, subpath: str | None = None
+) -> Path:
+    """
+    Materialize the tree at ``ref`` of the repository ``url`` into ``dest``.
+
+    A shallow fetch of the single ref (or the remote ``HEAD`` when ``ref`` is omitted) keeps
+    transfer small. The ``.git`` directory is removed so only content remains and the digest
+    never sees repository internals. Submodules are not initialized; a skill is a plain
+    content tree. The size limit applies to the tree at ``subpath``.
+    """
+    try:
+        # GitPython needs the git executable at import time, so import only when fetching.
+        import git
+    except ImportError as e:
+        raise MlflowException(
+            "Fetching Git sources requires GitPython and a git executable on PATH. "
+            f"Install git and `pip install gitpython`. Original error: {e}"
+        )
+
+    dest.mkdir(parents=True, exist_ok=True)
+    repo = git.Repo.init(dest)
+    try:
+        with repo.git.custom_environment(**_GIT_ENV):
+            origin = repo.create_remote("origin", url)
+            origin.fetch(refspec=ref or "HEAD", depth=1, kill_after_timeout=_GIT_TIMEOUT_SECONDS)
+            repo.git.checkout("FETCH_HEAD")
+    except git.exc.GitCommandError as e:
+        detail = (e.stderr or str(e)).strip()
+        target = f"{url} at ref '{ref}'" if ref else url
+        raise source_unavailable(target, detail, error_code=_error_code_for_git(detail))
+    finally:
+        repo.close()
+    _remove_git_dir(dest)
+    root = resolve_contained(dest, subpath)
+    if (size := tree_size(root)) > max_bytes:
+        raise invalid_content(
+            f"Git checkout is {size} bytes, which exceeds the skill content size limit of "
+            f"{max_bytes} bytes."
+        )
+    return dest

--- a/mlflow/genai/skill_content/fetchers/zip.py
+++ b/mlflow/genai/skill_content/fetchers/zip.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import requests
+
+from mlflow.genai.skill_content.archive import extract_zip_archive
+from mlflow.genai.skill_content.errors import (
+    error_code_for_http_status,
+    invalid_content,
+    source_unavailable,
+)
+from mlflow.protos.databricks_pb2 import TEMPORARILY_UNAVAILABLE
+
+_DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+_REQUEST_TIMEOUT_SECONDS = 60
+
+
+def _no_auth(request):
+    # Supplying an auth handler stops `requests` from attaching ~/.netrc or URL credentials,
+    # while leaving proxy and CA environment handling intact.
+    return request
+
+
+def download_with_budget(url: str, target: Path, *, max_bytes: int) -> Path:
+    """
+    Stream ``url`` to ``target``, failing once more than ``max_bytes`` have been received.
+
+    No credentials are attached, not even ambient ``~/.netrc`` entries: ZIP sources are public
+    by policy. The byte budget is enforced on the wire so a hostile or oversized download is
+    cut off rather than buffered.
+    """
+    session = requests.Session()
+    try:
+        with session.get(
+            url, stream=True, timeout=_REQUEST_TIMEOUT_SECONDS, auth=_no_auth
+        ) as response:
+            if response.status_code >= 400:
+                raise source_unavailable(
+                    url,
+                    f"HTTP {response.status_code} {response.reason}",
+                    error_code=error_code_for_http_status(response.status_code),
+                )
+            declared = response.headers.get("Content-Length")
+            if declared and declared.isdigit() and int(declared) > max_bytes:
+                raise invalid_content(
+                    f"Download from '{url}' is {declared} bytes, which exceeds the skill "
+                    f"content size limit of {max_bytes} bytes."
+                )
+            received = 0
+            with open(target, "wb") as out:
+                for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE):
+                    received += len(chunk)
+                    if received > max_bytes:
+                        raise invalid_content(
+                            f"Download from '{url}' exceeds the skill content size limit of "
+                            f"{max_bytes} bytes."
+                        )
+                    out.write(chunk)
+    except requests.RequestException as e:
+        raise source_unavailable(url, str(e), error_code=TEMPORARILY_UNAVAILABLE)
+    finally:
+        session.close()
+    return target
+
+
+def fetch_zip(url: str, dest: Path, *, max_bytes: int, subpath: str | None = None) -> Path:
+    """Download the ZIP archive at ``url`` and extract it (or just ``subpath``) into ``dest``."""
+    dest.mkdir(parents=True, exist_ok=True)
+    archive = dest.parent / "source.zip"
+    download_with_budget(url, archive, max_bytes=max_bytes)
+    extract_zip_archive(archive, dest, max_bytes=max_bytes, subpath=subpath)
+    archive.unlink(missing_ok=True)
+    return dest

--- a/mlflow/genai/skill_content/fetchers/zip.py
+++ b/mlflow/genai/skill_content/fetchers/zip.py
@@ -22,15 +22,24 @@ def _no_auth(request):
     return request
 
 
+class _NoAuthSession(requests.Session):
+    """A session that never attaches credentials, on the first request or on any redirect."""
+
+    def rebuild_auth(self, prepared_request, response):
+        # The base implementation re-applies ~/.netrc credentials for the redirect target;
+        # ZIP sources are public by policy, so strip whatever the previous hop carried instead.
+        prepared_request.headers.pop("Authorization", None)
+
+
 def download_with_budget(url: str, target: Path, *, max_bytes: int) -> Path:
     """
     Stream ``url`` to ``target``, failing once more than ``max_bytes`` have been received.
 
-    No credentials are attached, not even ambient ``~/.netrc`` entries: ZIP sources are public
-    by policy. The byte budget is enforced on the wire so a hostile or oversized download is
-    cut off rather than buffered.
+    No credentials are attached on any hop of the redirect chain, not even ambient ``~/.netrc``
+    entries: ZIP sources are public by policy. The byte budget is enforced on the wire so a
+    hostile or oversized download is cut off rather than buffered.
     """
-    session = requests.Session()
+    session = _NoAuthSession()
     try:
         with session.get(
             url, stream=True, timeout=_REQUEST_TIMEOUT_SECONDS, auth=_no_auth

--- a/mlflow/genai/skill_content/paths.py
+++ b/mlflow/genai/skill_content/paths.py
@@ -10,10 +10,10 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.skill_content.errors import content_unreadable, display_path, invalid_content
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 
-# Names Windows refuses to create as regular files, with or without an extension. A tree
-# containing them cannot be materialized on every supported OS, so it is rejected everywhere.
 # Every supported filesystem caps a single name at 255 bytes; longer names cannot be written.
 MAX_PATH_SEGMENT_BYTES = 255
+# Names Windows refuses to create as regular files, with or without an extension. A tree
+# containing them cannot be materialized on every supported OS, so it is rejected everywhere.
 _WINDOWS_RESERVED_NAMES = frozenset({
     "CON",
     "PRN",
@@ -176,6 +176,48 @@ class PathCollisionGuard:
         return nfc
 
 
+class TreeLayout:
+    """
+    Tracks the files and directories of one tree so they cannot alias or shadow each other.
+
+    Shared by the archive validators and the local tree collector so a tree that passes
+    collection can always be packaged and extracted again: every segment is validated, and
+    a path may not be both a file and a directory, appear twice, or collide with another
+    after Unicode normalization or case folding, including at the directory level.
+    """
+
+    def __init__(self):
+        self._guard = PathCollisionGuard()
+        self._files: set[str] = set()
+        self._dirs: set[str] = set()
+
+    def _register_dir(self, path: str, raw_name: str) -> None:
+        if path in self._dirs:
+            return
+        if path in self._files:
+            raise invalid_content(
+                f"Entry '{display_path(raw_name)}' uses '{path}' as a directory, but it is a file."
+            )
+        self._guard.register(path)
+        self._dirs.add(path)
+
+    def add(self, relative: str, raw_name: str, *, is_dir: bool) -> str:
+        """Register a canonical relative path; returns its NFC form for files."""
+        parts = relative.split("/")
+        for depth in range(1, len(parts)):
+            self._register_dir("/".join(parts[:depth]), raw_name)
+        if is_dir:
+            self._register_dir(relative, raw_name)
+            return relative
+        if relative in self._dirs:
+            raise invalid_content(
+                f"Entry '{display_path(raw_name)}' is a file, but '{relative}' is also a directory."
+            )
+        nfc = self._guard.register(relative)
+        self._files.add(relative)
+        return nfc
+
+
 def _fail_on_walk_error(error: OSError) -> None:
     # os.walk skips a directory it cannot list unless told otherwise; a silently missing
     # subtree would change the digest and the packaged content without any error.
@@ -187,13 +229,15 @@ def collect_tree(root: str | os.PathLike[str]) -> list[TreeFile]:
     List the regular files under ``root`` in canonical digest order.
 
     Paths are POSIX, relative to ``root``, Unicode NFC-normalized, and sorted by their UTF-8
-    byte value. Symbolic links and other non-regular entries are excluded. Files whose names
-    collide after normalization or case folding make the tree ambiguous and are rejected.
+    byte value. Symbolic links and other non-regular entries are excluded. The same segment
+    and layout rules the archive validators apply are enforced here, so a tree that collects
+    successfully can always be packaged and extracted: unsafe segments, and files or
+    directories that collide after normalization or case folding, are rejected.
     """
     root_path = Path(root)
     if not root_path.is_dir():
         raise invalid_content(f"Content root '{root_path}' is not a directory.")
-    guard = PathCollisionGuard()
+    layout = TreeLayout()
     files: list[TreeFile] = []
     for dirpath, dirnames, filenames in os.walk(
         root_path, onerror=_fail_on_walk_error, followlinks=False
@@ -209,7 +253,8 @@ def collect_tree(root: str | os.PathLike[str]) -> list[TreeFile]:
                 raise content_unreadable(file_path, e)
             if not stat.S_ISREG(info.st_mode):
                 continue
-            canonical = guard.register(file_path.relative_to(root_path).as_posix())
+            relative = file_path.relative_to(root_path).as_posix()
+            canonical = layout.add(canonical_relative_path(relative), relative, is_dir=False)
             files.append(TreeFile(path=canonical, local_path=file_path, size=info.st_size))
     files.sort(key=lambda f: f.path.encode("utf-8"))
     return files

--- a/mlflow/genai/skill_content/paths.py
+++ b/mlflow/genai/skill_content/paths.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import os
+import stat
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.skill_content.errors import content_unreadable, display_path, invalid_content
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+
+# Names Windows refuses to create as regular files, with or without an extension. A tree
+# containing them cannot be materialized on every supported OS, so it is rejected everywhere.
+# Every supported filesystem caps a single name at 255 bytes; longer names cannot be written.
+MAX_PATH_SEGMENT_BYTES = 255
+_WINDOWS_RESERVED_NAMES = frozenset({
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+})
+
+
+def _validate_segment(segment: str, original: str) -> None:
+    shown = display_path(original)
+    if segment in (".", ".."):
+        raise invalid_content(f"Path '{shown}' must not contain '.' or '..' segments.")
+    if ":" in segment:
+        # Drive letters (``C:``) and NTFS alternate data streams (``file:stream``) both make a
+        # segment escape or alias the tree on Windows.
+        raise invalid_content(f"Path '{shown}' must not contain ':' in a segment.")
+    if any(ord(ch) < 32 or ch == "\x7f" for ch in segment):
+        raise invalid_content(f"Path '{shown}' must not contain control characters.")
+    try:
+        encoded = segment.encode("utf-8")
+    except UnicodeEncodeError:
+        # Archive readers map undecodable bytes to lone surrogates, which no filesystem accepts.
+        raise invalid_content(f"Path '{shown}' is not valid UTF-8.")
+    if len(encoded) > MAX_PATH_SEGMENT_BYTES:
+        raise invalid_content(
+            f"Path '{shown}' has a name longer than {MAX_PATH_SEGMENT_BYTES} bytes."
+        )
+    if segment.split(".", 1)[0].upper() in _WINDOWS_RESERVED_NAMES:
+        raise invalid_content(f"Path '{shown}' uses a reserved Windows device name.")
+
+
+def canonical_relative_path(value: str) -> str | None:
+    """
+    Validate an exact relative path and return it in canonical POSIX form.
+
+    Unlike ``normalize_subpath`` this never trims whitespace, so an archive entry named
+    ``"a.md "`` keeps its exact name and the extracted tree stays byte-identical to the tree
+    that was hashed. Returns ``None`` when the path names the root itself.
+    """
+    if "\\" in value:
+        raise invalid_content(
+            f"Path '{display_path(value)}' must use forward slashes as separators."
+        )
+    if value.startswith("/"):
+        raise invalid_content(f"Path '{display_path(value)}' must be relative to the content root.")
+    parts = [part for part in value.split("/") if part != ""]
+    for part in parts:
+        _validate_segment(part, value)
+    return "/".join(parts) if parts else None
+
+
+def normalize_subpath(subpath: str | None) -> str | None:
+    """
+    Normalize a caller-supplied path within a fetched source to a POSIX relative path.
+
+    Returns ``None`` for an empty subpath (the whole tree). Surrounding whitespace is trimmed
+    because this is user input; backslashes, absolute paths, ``.`` or ``..`` segments, drive
+    or stream colons, and Windows reserved names are rejected so a subpath can never escape
+    or alias the content root on any supported OS.
+    """
+    if subpath is None:
+        return None
+    if not isinstance(subpath, str):
+        raise invalid_content(f"Subpath must be a string, got {type(subpath).__name__}.")
+    value = subpath.strip()
+    if value == "":
+        return None
+    try:
+        return canonical_relative_path(value)
+    except MlflowException as e:
+        raise invalid_content(f"Subpath '{subpath}' is invalid: {e.message}")
+
+
+def is_under_subpath(relative: str, subpath: str | None) -> bool:
+    """Whether canonical path ``relative`` is ``subpath`` itself or lies beneath it."""
+    if subpath is None:
+        return True
+    return relative == subpath or relative.startswith(subpath + "/")
+
+
+def ensure_within(root: Path, target: Path) -> Path:
+    """Defense in depth: prove that ``target`` resolves inside ``root`` before touching it."""
+    resolved_root = root.resolve()
+    resolved_target = target.resolve()
+    if resolved_target != resolved_root and not resolved_target.is_relative_to(resolved_root):
+        raise invalid_content(f"Path '{target}' resolves outside of '{root}'.")
+    return resolved_target
+
+
+def resolve_contained(root: str | os.PathLike[str], subpath: str | None) -> Path:
+    """
+    Resolve ``subpath`` under ``root`` and prove containment.
+
+    Every segment is checked as it is traversed so a symbolic link inside the tree cannot
+    redirect the lookup outside of ``root``. The resolved path must be an existing directory.
+    """
+    root_path = Path(root)
+    if not root_path.is_dir():
+        raise invalid_content(f"Content root '{root_path}' is not a directory.")
+    normalized = normalize_subpath(subpath)
+    if normalized is None:
+        return root_path
+    current = root_path
+    for segment in normalized.split("/"):
+        current = current / segment
+        if current.is_symlink():
+            raise invalid_content(f"Subpath '{normalized}' traverses a symbolic link.")
+        if not current.exists():
+            raise MlflowException(
+                f"Subpath '{normalized}' does not exist in the fetched content.",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
+    if not current.is_dir():
+        raise invalid_content(f"Subpath '{normalized}' must point to a directory.")
+    ensure_within(root_path, current)
+    return current
+
+
+@dataclass(frozen=True)
+class TreeFile:
+    """A regular file within a skill tree, keyed by its canonical POSIX path."""
+
+    path: str
+    local_path: Path
+    size: int
+
+
+class PathCollisionGuard:
+    """
+    Rejects paths that would alias each other on some supported filesystem.
+
+    Two names collide when they are byte-identical, differ only by Unicode normalization
+    form, or differ only by letter case. Any of these would make the same tree materialize
+    differently on macOS, Linux, and Windows, so the tree is rejected as ambiguous instead.
+    """
+
+    def __init__(self):
+        self._by_nfc: dict[str, str] = {}
+        self._by_casefold: dict[str, str] = {}
+
+    def register(self, raw_path: str) -> str:
+        nfc = unicodedata.normalize("NFC", raw_path)
+        if (previous := self._by_nfc.get(nfc)) is not None:
+            if previous == raw_path:
+                raise invalid_content(f"Path '{raw_path}' appears more than once.")
+            raise invalid_content(
+                f"Paths '{previous}' and '{raw_path}' normalize to the same path '{nfc}'; "
+                "the skill tree is ambiguous."
+            )
+        folded = nfc.casefold()
+        if (previous := self._by_casefold.get(folded)) is not None:
+            raise invalid_content(
+                f"Paths '{previous}' and '{raw_path}' differ only by letter case; "
+                "the skill tree is ambiguous on case-insensitive filesystems."
+            )
+        self._by_nfc[nfc] = raw_path
+        self._by_casefold[folded] = raw_path
+        return nfc
+
+
+def collect_tree(root: str | os.PathLike[str]) -> list[TreeFile]:
+    """
+    List the regular files under ``root`` in canonical digest order.
+
+    Paths are POSIX, relative to ``root``, Unicode NFC-normalized, and sorted by their UTF-8
+    byte value. Symbolic links and other non-regular entries are excluded. Files whose names
+    collide after normalization or case folding make the tree ambiguous and are rejected.
+    """
+    root_path = Path(root)
+    if not root_path.is_dir():
+        raise invalid_content(f"Content root '{root_path}' is not a directory.")
+    guard = PathCollisionGuard()
+    files: list[TreeFile] = []
+    for dirpath, dirnames, filenames in os.walk(root_path, followlinks=False):
+        current = Path(dirpath)
+        # Do not descend into symlinked directories; os.walk lists them but must not follow.
+        dirnames[:] = sorted(d for d in dirnames if not (current / d).is_symlink())
+        for filename in filenames:
+            file_path = current / filename
+            try:
+                info = os.lstat(file_path)
+            except OSError as e:
+                raise content_unreadable(file_path, e)
+            if not stat.S_ISREG(info.st_mode):
+                continue
+            canonical = guard.register(file_path.relative_to(root_path).as_posix())
+            files.append(TreeFile(path=canonical, local_path=file_path, size=info.st_size))
+    files.sort(key=lambda f: f.path.encode("utf-8"))
+    return files
+
+
+def assert_regular_tree(root: str | os.PathLike[str]) -> None:
+    """
+    Require that ``root`` contains only directories and regular files.
+
+    Symbolic links, hard links, and special files (FIFOs, sockets, devices) are rejected. This
+    is the publication-time check applied to every fetched or extracted skill tree.
+    """
+    root_path = Path(root)
+    if root_path.is_symlink() or not root_path.is_dir():
+        raise invalid_content(f"Content root '{root_path}' must be a directory, not a link.")
+    for dirpath, dirnames, filenames in os.walk(root_path, followlinks=False):
+        current = Path(dirpath)
+        for name in dirnames + filenames:
+            entry = current / name
+            try:
+                info = os.lstat(entry)
+            except OSError as e:
+                raise content_unreadable(entry, e)
+            relative = entry.relative_to(root_path).as_posix()
+            if stat.S_ISLNK(info.st_mode):
+                raise invalid_content(
+                    f"Skill content must not contain symbolic links: '{relative}'."
+                )
+            if stat.S_ISDIR(info.st_mode):
+                continue
+            if not stat.S_ISREG(info.st_mode):
+                raise invalid_content(
+                    f"Skill content must contain only regular files and directories: '{relative}'."
+                )
+            if info.st_nlink > 1:
+                raise invalid_content(f"Skill content must not contain hard links: '{relative}'.")
+
+
+def tree_size(root: str | os.PathLike[str]) -> int:
+    """Total size in bytes of the regular files under ``root``."""
+    return sum(f.size for f in collect_tree(root))

--- a/mlflow/genai/skill_content/paths.py
+++ b/mlflow/genai/skill_content/paths.py
@@ -176,6 +176,12 @@ class PathCollisionGuard:
         return nfc
 
 
+def _fail_on_walk_error(error: OSError) -> None:
+    # os.walk skips a directory it cannot list unless told otherwise; a silently missing
+    # subtree would change the digest and the packaged content without any error.
+    raise content_unreadable(error.filename, error)
+
+
 def collect_tree(root: str | os.PathLike[str]) -> list[TreeFile]:
     """
     List the regular files under ``root`` in canonical digest order.
@@ -189,7 +195,9 @@ def collect_tree(root: str | os.PathLike[str]) -> list[TreeFile]:
         raise invalid_content(f"Content root '{root_path}' is not a directory.")
     guard = PathCollisionGuard()
     files: list[TreeFile] = []
-    for dirpath, dirnames, filenames in os.walk(root_path, followlinks=False):
+    for dirpath, dirnames, filenames in os.walk(
+        root_path, onerror=_fail_on_walk_error, followlinks=False
+    ):
         current = Path(dirpath)
         # Do not descend into symlinked directories; os.walk lists them but must not follow.
         dirnames[:] = sorted(d for d in dirnames if not (current / d).is_symlink())
@@ -217,7 +225,9 @@ def assert_regular_tree(root: str | os.PathLike[str]) -> None:
     root_path = Path(root)
     if root_path.is_symlink() or not root_path.is_dir():
         raise invalid_content(f"Content root '{root_path}' must be a directory, not a link.")
-    for dirpath, dirnames, filenames in os.walk(root_path, followlinks=False):
+    for dirpath, dirnames, filenames in os.walk(
+        root_path, onerror=_fail_on_walk_error, followlinks=False
+    ):
         current = Path(dirpath)
         for name in dirnames + filenames:
             entry = current / name

--- a/mlflow/genai/skill_content/skill_md.py
+++ b/mlflow/genai/skill_content/skill_md.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mlflow.genai.skill_content.errors import content_unreadable, invalid_content
+from mlflow.utils.validation import _validate_skill_name
+
+SKILL_MANIFEST_FILE = "SKILL.md"
+
+_FRONTMATTER_PATTERN = re.compile(r"\A---\r?\n(.*?)\r?\n---(?:\r?\n|\Z)(.*)\Z", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class SkillManifest:
+    """Content-derived metadata read from a skill directory's ``SKILL.md``."""
+
+    name: str
+    description: str | None
+    keywords: tuple[str, ...]
+    path: Path
+
+
+def parse_skill_md(content: str) -> tuple[dict[str, Any], str]:
+    """
+    Split ``SKILL.md`` content into its YAML frontmatter and markdown body.
+
+    Content without a leading ``---`` block has empty frontmatter. A frontmatter block that is
+    opened but not closed, is not valid YAML, or is not a mapping is rejected rather than
+    silently ignored, because the registry derives identity from it.
+    """
+    if not content.startswith("---"):
+        return {}, content
+    match = _FRONTMATTER_PATTERN.match(content)
+    if match is None:
+        raise invalid_content(f"{SKILL_MANIFEST_FILE} frontmatter is not closed with '---'.")
+    try:
+        metadata = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as e:
+        raise invalid_content(f"{SKILL_MANIFEST_FILE} frontmatter is not valid YAML: {e}")
+    if metadata is None:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        raise invalid_content(f"{SKILL_MANIFEST_FILE} frontmatter must be a YAML mapping.")
+    return metadata, match.group(2)
+
+
+def _extract_keywords(metadata: dict[str, Any]) -> tuple[str, ...]:
+    raw = metadata.get("keywords")
+    if raw is None and isinstance(metadata.get("metadata"), dict):
+        raw = metadata["metadata"].get("keywords")
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        raw = raw.split(",")
+    if not isinstance(raw, list):
+        raise invalid_content(
+            f"{SKILL_MANIFEST_FILE} keywords must be a list or comma-separated string."
+        )
+    keywords = []
+    for item in raw:
+        if not isinstance(item, (str, int, float)):
+            raise invalid_content(f"{SKILL_MANIFEST_FILE} keywords must be strings, got {item!r}.")
+        if value := str(item).strip():
+            keywords.append(value)
+    return tuple(keywords)
+
+
+def inspect_skill_dir(
+    root: str | os.PathLike[str], *, fallback_name: str | None = None
+) -> SkillManifest:
+    """
+    Read the content-derived fields of the skill rooted at ``root``.
+
+    The directory must contain a ``SKILL.md`` regular file. The skill name is declared in the
+    frontmatter ``name`` field; the directory name is never used because fetched content lands
+    in an arbitrary temporary directory. Import adapters that synthesize names for legacy
+    layouts may pass ``fallback_name`` explicitly. The name is validated against the Agent
+    Skills naming rules, and ``description`` and ``keywords`` are read when present.
+    """
+    root_path = Path(root)
+    manifest_path = root_path / SKILL_MANIFEST_FILE
+    if manifest_path.is_symlink() or not manifest_path.is_file():
+        raise invalid_content(f"'{root_path}' does not contain a {SKILL_MANIFEST_FILE} file.")
+    try:
+        content = manifest_path.read_text(encoding="utf-8-sig")
+    except UnicodeDecodeError as e:
+        raise invalid_content(f"{SKILL_MANIFEST_FILE} in '{root_path}' is not valid UTF-8: {e}")
+    except OSError as e:
+        raise content_unreadable(manifest_path, e)
+    metadata, _ = parse_skill_md(content)
+
+    name = metadata.get("name")
+    if name is None:
+        name = fallback_name
+    if name is None:
+        raise invalid_content(
+            f"{SKILL_MANIFEST_FILE} in '{root_path}' must declare a 'name' in its frontmatter."
+        )
+    if not isinstance(name, str):
+        raise invalid_content(f"{SKILL_MANIFEST_FILE} name must be a string, got {name!r}.")
+    _validate_skill_name(name)
+
+    description = metadata.get("description")
+    if description is not None and not isinstance(description, str):
+        raise invalid_content(f"{SKILL_MANIFEST_FILE} description must be a string.")
+
+    return SkillManifest(
+        name=name,
+        description=description,
+        keywords=_extract_keywords(metadata),
+        path=root_path,
+    )

--- a/mlflow/genai/skill_content/sources.py
+++ b/mlflow/genai/skill_content/sources.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from mlflow.entities.skill_source import GitSource, OCISource, SkillSourceType, ZipSource
+from mlflow.genai.skill_content.errors import invalid_content
+from mlflow.genai.skill_content.paths import normalize_subpath
+
+OCI_SCHEME = "oci://"
+_GIT_SCHEME = "git://"
+# ``mlflow-artifacts:/`` is the form the registry persists for MLflow-stored content. The
+# ``runs:/`` and ``models:/`` forms are accepted for fetching (introspection of content that
+# already lives in MLflow) but are never what the registry records as a version's source.
+_MLFLOW_PREFIXES = ("mlflow-artifacts:/", "runs:/", "models:/")
+_WINDOWS_DRIVE_PATTERN = re.compile(r"^[A-Za-z]:[\\/]")
+_SCP_GIT_PATTERN = re.compile(r"^[\w.-]+@[\w.-]+:")
+_UNSAFE_REF_PATTERN = re.compile(r"[\s\x00-\x1f\x7f]")
+# RFC-0008 stores `source`, `ref`, and `subpath` in String(2048) columns; fail early rather
+# than at the database.
+MAX_SOURCE_FIELD_LENGTH = 2048
+
+SourceInput = GitSource | OCISource | ZipSource | str
+
+
+@dataclass(frozen=True)
+class ResolvedSource:
+    """
+    A source pointer with its type settled.
+
+    ``source_type`` is the explicit type carried by a typed source, or the type inferred from a
+    plain string. ``source`` is the bare image reference for OCI (no ``oci://`` scheme), the
+    URL for Git and ZIP, or the artifact URI for MLflow-stored content; those are the values
+    the register flow submits. When ``is_local`` is set, ``source`` is the absolute local path
+    to upload and is never persisted; the server records where it stored the content.
+    """
+
+    source_type: SkillSourceType
+    source: str
+    ref: str | None = None
+    subpath: str | None = None
+    is_local: bool = False
+
+
+def is_local_path(source: str) -> bool:
+    """Whether a plain-string source names a local filesystem path rather than a remote pointer."""
+    if _WINDOWS_DRIVE_PATTERN.match(source):
+        return True
+    if "://" in source or source.startswith(_MLFLOW_PREFIXES):
+        return False
+    return not _SCP_GIT_PATTERN.match(source)
+
+
+def _validate_field_length(value: str, what: str) -> None:
+    if len(value) > MAX_SOURCE_FIELD_LENGTH:
+        raise invalid_content(
+            f"{what} is {len(value)} characters long; the maximum is {MAX_SOURCE_FIELD_LENGTH}."
+        )
+
+
+def _validate_remote_value(value: str, what: str) -> None:
+    if value.startswith("-"):
+        raise invalid_content(f"{what} must not start with '-': '{value}'.")
+    if _UNSAFE_REF_PATTERN.search(value):
+        raise invalid_content(f"{what} must not contain whitespace or control characters.")
+    _validate_field_length(value, what)
+
+
+def _validate_git(url: str, ref: str | None) -> None:
+    _validate_remote_value(url, "Git URL")
+    if ref is not None:
+        if not ref:
+            raise invalid_content("Git ref must not be empty.")
+        _validate_remote_value(ref, "Git ref")
+
+
+def _validate_zip(url: str) -> None:
+    _validate_remote_value(url, "ZIP URL")
+    parts = urlsplit(url)
+    if parts.scheme not in ("http", "https"):
+        raise invalid_content(f"ZIP source must be an http(s) URL, got '{url}'.")
+    if parts.username or parts.password:
+        raise invalid_content(
+            "ZIP sources are fetched without authentication and must be publicly accessible; "
+            "remove the credentials from the URL or use a Git or OCI source instead."
+        )
+
+
+def _infer_remote_type(source: str) -> tuple[SkillSourceType, str]:
+    """
+    Apply the RFC inference table to a plain string: ``oci://`` scheme, ``.git`` suffix or
+    ``git://`` scheme, ``.zip`` suffix, or an MLflow artifact URI. Anything else is ambiguous.
+    """
+    if source.startswith(OCI_SCHEME):
+        image = source.removeprefix(OCI_SCHEME)
+        if not image:
+            raise invalid_content("OCI source must include an image reference after 'oci://'.")
+        return SkillSourceType.OCI, image
+    if source.startswith(_MLFLOW_PREFIXES):
+        return SkillSourceType.MLFLOW, source
+    if source.startswith(_GIT_SCHEME):
+        return SkillSourceType.GIT, source
+    path = urlsplit(source).path
+    if path.endswith(".git") or path.endswith(".git/"):
+        return SkillSourceType.GIT, source
+    if path.endswith(".zip"):
+        return SkillSourceType.ZIP, source
+    raise invalid_content(
+        f"Cannot infer the source type of '{source}'. Pass a typed source (GitSource, "
+        "OCISource, or ZipSource) or use a URL that ends in '.git' or '.zip', or starts with "
+        "'git://' or 'oci://'."
+    )
+
+
+def resolve_source_type(
+    source: SourceInput, *, ref: str | None = None, subpath: str | None = None
+) -> ResolvedSource:
+    """
+    Settle the type, pointer, ref, and subpath of a skill source.
+
+    Typed sources keep their explicit type; ``ref`` and ``subpath`` must then be omitted since
+    the object already carries them. A plain string is classified as a local path or has its
+    remote type inferred by the RFC table; an external value that cannot be inferred is
+    rejected rather than guessed. ``mlflow`` for a local path is flow-derived, never something
+    a caller asserts. Git URLs and refs that look like command-line options, and ZIP URLs
+    that carry credentials, are rejected.
+    """
+    if isinstance(source, (GitSource, OCISource, ZipSource)):
+        if (normalized := normalize_subpath(source.subpath)) is not None:
+            _validate_field_length(normalized, "Subpath")
+        if ref is not None or subpath is not None:
+            raise invalid_content(
+                "'ref' and 'subpath' must not be passed alongside a typed source; set them on "
+                f"the {type(source).__name__} instead."
+            )
+        if isinstance(source, GitSource):
+            _validate_git(source.url, source.ref)
+            return ResolvedSource(
+                SkillSourceType.GIT,
+                source.url,
+                ref=source.ref,
+                subpath=normalize_subpath(source.subpath),
+            )
+        if isinstance(source, OCISource):
+            image = source.image.removeprefix(OCI_SCHEME)
+            if not image:
+                raise invalid_content("OCISource image reference must not be empty.")
+            _validate_remote_value(image, "OCI image reference")
+            return ResolvedSource(
+                SkillSourceType.OCI, image, subpath=normalize_subpath(source.subpath)
+            )
+        _validate_zip(source.url)
+        return ResolvedSource(
+            SkillSourceType.ZIP, source.url, subpath=normalize_subpath(source.subpath)
+        )
+
+    if not isinstance(source, str) or not source.strip():
+        raise invalid_content("Skill source must be a typed source or a non-empty string.")
+    value = source.strip()
+    normalized_subpath = normalize_subpath(subpath)
+    if normalized_subpath is not None:
+        _validate_field_length(normalized_subpath, "Subpath")
+    if is_local_path(value):
+        if ref is not None:
+            raise invalid_content("'ref' applies to Git sources only, not to a local path.")
+        return ResolvedSource(
+            SkillSourceType.MLFLOW,
+            str(Path(value).expanduser().resolve()),
+            subpath=normalized_subpath,
+            is_local=True,
+        )
+    source_type, pointer = _infer_remote_type(value)
+    if ref is not None and source_type != SkillSourceType.GIT:
+        raise invalid_content("'ref' applies to Git sources only.")
+    if source_type == SkillSourceType.GIT:
+        _validate_git(pointer, ref)
+    elif source_type == SkillSourceType.ZIP:
+        _validate_zip(pointer)
+    else:
+        _validate_remote_value(pointer, "Source")
+    return ResolvedSource(source_type, pointer, ref=ref, subpath=normalized_subpath)

--- a/tests/genai/skill_content/conftest.py
+++ b/tests/genai/skill_content/conftest.py
@@ -1,0 +1,27 @@
+import socket
+
+import pytest
+
+SKILL_MD = "---\nname: demo\ndescription: Demo skill\n---\n# Demo\n"
+BIG_FILE = b"\0" * 5000
+
+
+@pytest.fixture
+def skill_tree(tmp_path):
+    root = tmp_path / "source"
+    demo = root / "skills" / "demo"
+    demo.mkdir(parents=True)
+    (demo / "SKILL.md").write_text(SKILL_MD)
+    (demo / "scripts").mkdir()
+    (demo / "scripts" / "run.py").write_text("print('hi')\n")
+    (root / "README.md").write_text("top-level readme\n")
+    (root / "big.bin").write_bytes(BIG_FILE)
+    return root
+
+
+@pytest.fixture
+def closed_port():
+    # A port that was just bound and released, so connecting to it is refused immediately.
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]

--- a/tests/genai/skill_content/test_archive.py
+++ b/tests/genai/skill_content/test_archive.py
@@ -1,0 +1,417 @@
+import gzip
+import io
+import os
+import stat
+import tarfile
+import unicodedata
+import warnings
+import zipfile
+
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.skill_content.archive import (
+    MAX_ARCHIVE_ENTRIES,
+    extract_skill_archive,
+    extract_zip_archive,
+    get_max_decompressed_size,
+    package_skill_tree,
+    validate_skill_archive,
+    validate_zip_archive,
+)
+from mlflow.genai.skill_content.digest import compute_tree_digest
+
+_NFD = unicodedata.normalize("NFD", "café.md")
+_NFC = unicodedata.normalize("NFC", "café.md")
+
+
+def _write_tree(root, files):
+    for path, content in files.items():
+        target = root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+
+def _make_tar(path, members, *, compressed=True):
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as tar:
+        for name, kind, content in members:
+            info = tarfile.TarInfo(name=name)
+            info.type = kind
+            if kind in (tarfile.REGTYPE, tarfile.XHDTYPE, tarfile.GNUTYPE_LONGNAME):
+                info.size = len(content)
+                tar.addfile(info, io.BytesIO(content))
+            else:
+                if kind in (tarfile.SYMTYPE, tarfile.LNKTYPE):
+                    info.linkname = content.decode()
+                tar.addfile(info)
+    data = buffer.getvalue()
+    path.write_bytes(gzip.compress(data) if compressed else data)
+    return path
+
+
+def test_get_max_decompressed_size(monkeypatch):
+    assert get_max_decompressed_size() == 25 * 1024**2
+    monkeypatch.setenv("MLFLOW_SKILL_CONTENT_MAX_DECOMPRESSED_SIZE", "123")
+    assert get_max_decompressed_size() == 123
+    assert get_max_decompressed_size(7) == 7
+    with pytest.raises(MlflowException, match="must be positive"):
+        get_max_decompressed_size(0)
+
+
+def test_package_roundtrip_preserves_digest_and_is_reproducible(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    _write_tree(source, {"SKILL.md": b"---\nname: demo\n---\n", "ref/data.txt": b"1234"})
+    (source / "link.txt").symlink_to(source / "SKILL.md")
+
+    first = package_skill_tree(source, tmp_path / "a.tar.gz")
+    (source / "SKILL.md").touch()
+    second = package_skill_tree(source, tmp_path / "b.tar.gz")
+    assert first.read_bytes() == second.read_bytes()
+
+    extracted = extract_skill_archive(first, tmp_path / "out")
+    assert sorted(p.name for p in extracted.rglob("*") if p.is_file()) == ["SKILL.md", "data.txt"]
+    assert not (extracted / "link.txt").exists()
+    assert compute_tree_digest(extracted) == compute_tree_digest(source)
+    assert validate_skill_archive(first) == len(b"---\nname: demo\n---\n") + 4
+
+
+def test_package_roundtrip_keeps_exact_names_with_whitespace(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    _write_tree(source, {"a.md ": b"1", " lead.md": b"2", "d/ x ": b"3"})
+    archive = package_skill_tree(source, tmp_path / "ws.tar.gz")
+    extracted = extract_skill_archive(archive, tmp_path / "out")
+    assert sorted(
+        p.relative_to(extracted).as_posix() for p in extracted.rglob("*") if p.is_file()
+    ) == [
+        " lead.md",
+        "a.md ",
+        "d/ x ",
+    ]
+    assert compute_tree_digest(extracted) == compute_tree_digest(source)
+
+
+@pytest.mark.parametrize(
+    ("members", "message"),
+    [
+        ([("../escape.txt", tarfile.REGTYPE, b"x")], "unsafe path"),
+        ([("/abs.txt", tarfile.REGTYPE, b"x")], "unsafe path"),
+        ([("dir\\file.txt", tarfile.REGTYPE, b"x")], "unsafe path"),
+        ([("a/./b.txt", tarfile.REGTYPE, b"x")], "unsafe path"),
+        ([("C:evil.txt", tarfile.REGTYPE, b"x")], "unsafe path"),
+        ([("C:/evil.txt", tarfile.REGTYPE, b"x")], "unsafe path"),
+        ([("C:", tarfile.DIRTYPE, b"")], "unsafe path"),
+        ([("CON", tarfile.REGTYPE, b"x")], "unsafe path"),
+        ([("docs/nul.md", tarfile.REGTYPE, b"x")], "unsafe path"),
+        ([("link", tarfile.SYMTYPE, b"SKILL.md")], "not a regular file or directory"),
+        ([("hard", tarfile.LNKTYPE, b"SKILL.md")], "not a regular file or directory"),
+        ([("fifo", tarfile.FIFOTYPE, b"")], "not a regular file or directory"),
+        ([("dev", tarfile.CHRTYPE, b"")], "not a regular file or directory"),
+        ([(".", tarfile.REGTYPE, b"x")], "root entry must be a directory"),
+        ([("a.md", tarfile.REGTYPE, b"1"), ("a.md", tarfile.REGTYPE, b"2")], "more than once"),
+        (
+            [(_NFD, tarfile.REGTYPE, b"1"), (_NFC, tarfile.REGTYPE, b"2")],
+            "normalize to the same path",
+        ),
+        (
+            [("A.md", tarfile.REGTYPE, b"1"), ("a.md", tarfile.REGTYPE, b"2")],
+            "differ only by letter case",
+        ),
+        (
+            [("Dir/x", tarfile.REGTYPE, b"1"), ("dir/y", tarfile.REGTYPE, b"2")],
+            "differ only by letter case",
+        ),
+        (
+            [("x", tarfile.REGTYPE, b"1"), ("x/y", tarfile.REGTYPE, b"2")],
+            "as a directory, but it is a file",
+        ),
+        ([("x/y", tarfile.REGTYPE, b"1"), ("x", tarfile.REGTYPE, b"2")], "is also a directory"),
+        (
+            [("x", tarfile.REGTYPE, b"1"), ("x/", tarfile.DIRTYPE, b"")],
+            "as a directory, but it is a file",
+        ),
+    ],
+)
+def test_validate_skill_archive_rejects_unsafe_members(tmp_path, members, message):
+    archive = _make_tar(tmp_path / "bad.tar.gz", members)
+    with pytest.raises(MlflowException, match=message):
+        validate_skill_archive(archive)
+    with pytest.raises(MlflowException, match=message):
+        extract_skill_archive(archive, tmp_path / "out")
+    assert not any((tmp_path / "out").rglob("*"))
+
+
+def test_validate_skill_archive_accepts_dot_prefixed_and_dir_entries(tmp_path):
+    archive = _make_tar(
+        tmp_path / "ok.tar.gz",
+        [
+            ("./", tarfile.DIRTYPE, b""),
+            ("./skills/", tarfile.DIRTYPE, b""),
+            ("./skills/SKILL.md", tarfile.REGTYPE, b"abc"),
+            ("skills/", tarfile.DIRTYPE, b""),
+        ],
+    )
+    assert validate_skill_archive(archive) == 3
+    out = extract_skill_archive(archive, tmp_path / "out")
+    assert (out / "skills" / "SKILL.md").read_bytes() == b"abc"
+
+
+def test_validate_skill_archive_enforces_size_limit(tmp_path):
+    archive = _make_tar(tmp_path / "big.tar.gz", [("a.bin", tarfile.REGTYPE, b"x" * 100)])
+    assert validate_skill_archive(archive, max_bytes=100) == 100
+    with pytest.raises(MlflowException, match="exceeds the skill content size limit"):
+        validate_skill_archive(archive, max_bytes=99)
+    with pytest.raises(MlflowException, match="exceeds the skill content size limit"):
+        extract_skill_archive(archive, tmp_path / "out", max_bytes=99)
+
+
+def test_validate_skill_archive_size_limit_from_env(tmp_path, monkeypatch):
+    archive = _make_tar(tmp_path / "big.tar.gz", [("a.bin", tarfile.REGTYPE, b"x" * 100)])
+    monkeypatch.setenv("MLFLOW_SKILL_CONTENT_MAX_DECOMPRESSED_SIZE", "50")
+    with pytest.raises(MlflowException, match="limit of 50 bytes"):
+        validate_skill_archive(archive)
+
+
+@pytest.mark.parametrize("header_type", [tarfile.XHDTYPE, tarfile.GNUTYPE_LONGNAME])
+def test_validate_skill_archive_bounds_metadata_headers(tmp_path, header_type):
+    # A PAX or GNU long-name header declares its payload size and the tar parser reads the
+    # whole payload before surfacing any member; the bounded stream must stop it.
+    payload = b"\0" * (32 * 1024 * 1024)
+    archive = _make_tar(
+        tmp_path / "bomb.tar.gz",
+        [("hdr", header_type, payload), ("SKILL.md", tarfile.REGTYPE, b"x")],
+    )
+    assert archive.stat().st_size < 1024 * 1024
+    with pytest.raises(MlflowException, match="exceeds the skill content size limit"):
+        validate_skill_archive(archive, max_bytes=1024)
+
+
+def test_validate_skill_archive_enforces_entry_count(tmp_path):
+    members = [(f"f{i}", tarfile.REGTYPE, b"") for i in range(MAX_ARCHIVE_ENTRIES + 1)]
+    archive = _make_tar(tmp_path / "many.tar.gz", members)
+    with pytest.raises(MlflowException, match="more than"):
+        validate_skill_archive(archive)
+
+
+def test_validate_skill_archive_rejects_non_archive_and_corrupt_gzip(tmp_path):
+    bogus = tmp_path / "bogus.tar.gz"
+    bogus.write_bytes(b"not an archive")
+    with pytest.raises(MlflowException, match="(?i)tar archive|malformed"):
+        validate_skill_archive(bogus)
+
+    good = _make_tar(tmp_path / "good.tar.gz", [("a.bin", tarfile.REGTYPE, b"x" * 5000)])
+    data = bytearray(good.read_bytes())
+    data[len(data) // 2 : len(data) // 2 + 8] = b"\xff" * 8
+    corrupt = tmp_path / "corrupt.tar.gz"
+    corrupt.write_bytes(bytes(data))
+    with pytest.raises(MlflowException, match="(?i)tar archive|malformed"):
+        validate_skill_archive(corrupt)
+
+
+def test_extract_skill_archive_uncompressed(tmp_path):
+    archive = _make_tar(
+        tmp_path / "plain.tar", [("SKILL.md", tarfile.REGTYPE, b"x")], compressed=False
+    )
+    out = extract_skill_archive(archive, tmp_path / "out", compressed=False)
+    assert (out / "SKILL.md").read_bytes() == b"x"
+
+
+def test_extract_skill_archive_requires_empty_destination(tmp_path):
+    archive = _make_tar(tmp_path / "ok.tar.gz", [("SKILL.md", tarfile.REGTYPE, b"x")])
+    dest = tmp_path / "out"
+    dest.mkdir()
+    (dest / "existing").write_text("x")
+    with pytest.raises(MlflowException, match="must be an empty directory"):
+        extract_skill_archive(archive, dest)
+
+
+def test_extract_skill_archive_enforces_actual_bytes_not_headers(tmp_path):
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as tar:
+        info = tarfile.TarInfo(name="a.bin")
+        info.size = 10
+        tar.addfile(info, io.BytesIO(b"x" * 10))
+    archive = tmp_path / "a.tar.gz"
+    archive.write_bytes(gzip.compress(buffer.getvalue()))
+    out = extract_skill_archive(archive, tmp_path / "out", max_bytes=10)
+    assert (out / "a.bin").stat().st_size == 10
+
+
+def test_skill_archive_subpath_limits_extraction_and_budget(tmp_path):
+    archive = _make_tar(
+        tmp_path / "pkg.tar.gz",
+        [
+            ("skills/a/SKILL.md", tarfile.REGTYPE, b"abc"),
+            ("other/big.bin", tarfile.REGTYPE, b"x" * 100),
+            ("../evil", tarfile.REGTYPE, b"x"),
+        ],
+    )
+    # Entries outside the subpath are still validated for safety.
+    with pytest.raises(MlflowException, match="unsafe path"):
+        validate_skill_archive(archive, max_bytes=10, subpath="skills/a")
+
+    archive = _make_tar(
+        tmp_path / "pkg2.tar.gz",
+        [
+            ("skills/a/SKILL.md", tarfile.REGTYPE, b"abc"),
+            ("other/big.bin", tarfile.REGTYPE, b"x" * 100),
+        ],
+    )
+    with pytest.raises(MlflowException, match="exceeds the skill content size limit"):
+        validate_skill_archive(archive, max_bytes=10)
+    assert validate_skill_archive(archive, max_bytes=10, subpath="skills/a") == 3
+    out = extract_skill_archive(archive, tmp_path / "out", max_bytes=10, subpath="skills/a")
+    assert (out / "skills" / "a" / "SKILL.md").read_bytes() == b"abc"
+    assert not (out / "other").exists()
+
+
+def _make_zip(path, entries):
+    with zipfile.ZipFile(path, "w") as zf, warnings.catch_warnings():
+        # Deliberately hostile archives include duplicate names, which zipfile warns about.
+        warnings.simplefilter("ignore", UserWarning)
+        for name, content, attr in entries:
+            info = zipfile.ZipInfo(name)
+            if attr is not None:
+                info.external_attr = attr
+            zf.writestr(info, content)
+    return path
+
+
+def test_zip_roundtrip(tmp_path):
+    archive = _make_zip(
+        tmp_path / "ok.zip",
+        [
+            ("skill/", b"", None),
+            ("skill/SKILL.md", b"abc", None),
+            ("skill/a/b.txt", b"12", 0o100644 << 16),
+        ],
+    )
+    assert validate_zip_archive(archive) == 5
+    out = extract_zip_archive(archive, tmp_path / "out")
+    assert (out / "skill" / "SKILL.md").read_bytes() == b"abc"
+    assert (out / "skill" / "a" / "b.txt").read_bytes() == b"12"
+
+
+def test_zip_windows_style_directory_entry(tmp_path):
+    # Archives built on Windows mark directories with the MS-DOS attribute and no slash.
+    archive = _make_zip(tmp_path / "win.zip", [("d", b"", 0x10), ("d/f.txt", b"1", None)])
+    assert validate_zip_archive(archive) == 1
+    out = extract_zip_archive(archive, tmp_path / "out")
+    assert (out / "d").is_dir()
+    assert (out / "d" / "f.txt").read_bytes() == b"1"
+
+
+@pytest.mark.parametrize(
+    ("entries", "message"),
+    [
+        ([("../x.txt", b"x", None)], "unsafe path"),
+        ([("/abs.txt", b"x", None)], "unsafe path"),
+        ([("a\\b.txt", b"x", None)], "unsafe path"),
+        ([("C:evil.txt", b"x", None)], "unsafe path"),
+        ([("link", b"SKILL.md", (stat.S_IFLNK | 0o777) << 16)], "not a regular file or directory"),
+        ([("fifo", b"", (stat.S_IFIFO | 0o644) << 16)], "not a regular file or directory"),
+        ([("a.md", b"1", None), ("a.md", b"2", None)], "more than once"),
+        ([(_NFD, b"1", None), (_NFC, b"2", None)], "normalize to the same path"),
+        ([("A.md", b"1", None), ("a.md", b"2", None)], "differ only by letter case"),
+        ([("x", b"1", None), ("x/y", b"2", None)], "as a directory, but it is a file"),
+        ([("x/y", b"1", None), ("x", b"2", None)], "is also a directory"),
+    ],
+)
+def test_validate_zip_archive_rejects_unsafe_entries(tmp_path, entries, message):
+    archive = _make_zip(tmp_path / "bad.zip", entries)
+    with pytest.raises(MlflowException, match=message):
+        validate_zip_archive(archive)
+    with pytest.raises(MlflowException, match=message):
+        extract_zip_archive(archive, tmp_path / "out")
+
+
+def test_validate_zip_archive_size_limit_and_bad_file(tmp_path):
+    archive = _make_zip(tmp_path / "big.zip", [("a.bin", b"x" * 100, None)])
+    with pytest.raises(MlflowException, match="exceeds the skill content size limit"):
+        validate_zip_archive(archive, max_bytes=99)
+    bogus = tmp_path / "bogus.zip"
+    bogus.write_bytes(b"nope")
+    with pytest.raises(MlflowException, match="not a readable ZIP archive"):
+        validate_zip_archive(bogus)
+
+
+def test_zip_subpath_limits_extraction_and_budget(tmp_path):
+    archive = _make_zip(
+        tmp_path / "pkg.zip",
+        [("skills/a/SKILL.md", b"abc", None), ("other/big.bin", b"x" * 100, None)],
+    )
+    with pytest.raises(MlflowException, match="exceeds the skill content size limit"):
+        validate_zip_archive(archive, max_bytes=10)
+    assert validate_zip_archive(archive, max_bytes=10, subpath="skills/a") == 3
+    out = extract_zip_archive(archive, tmp_path / "out", max_bytes=10, subpath="skills/a")
+    assert (out / "skills" / "a" / "SKILL.md").read_bytes() == b"abc"
+    assert not (out / "other").exists()
+
+
+def _patch_zip_headers(path, *, encrypted=False, method=None):
+    # Flip header fields that zipfile refuses to write itself.
+    data = bytearray(path.read_bytes())
+    for signature, flag_offset, method_offset in ((b"PK\x03\x04", 6, 8), (b"PK\x01\x02", 8, 10)):
+        index = data.find(signature)
+        if encrypted:
+            data[index + flag_offset] |= 0x1
+        if method is not None:
+            data[index + method_offset : index + method_offset + 2] = method.to_bytes(2, "little")
+    path.write_bytes(bytes(data))
+    return path
+
+
+def test_zip_rejects_encrypted_entries(tmp_path):
+    archive = _patch_zip_headers(
+        _make_zip(tmp_path / "enc.zip", [("a.txt", b"x", None)]), encrypted=True
+    )
+    with pytest.raises(MlflowException, match="is encrypted"):
+        validate_zip_archive(archive)
+    with pytest.raises(MlflowException, match="is encrypted"):
+        extract_zip_archive(archive, tmp_path / "out")
+
+
+def test_zip_rejects_unsupported_compression(tmp_path):
+    deflate64 = 9
+    archive = _patch_zip_headers(
+        _make_zip(tmp_path / "d64.zip", [("a.txt", b"x", None)]), method=deflate64
+    )
+    with pytest.raises(MlflowException, match="unsupported compression method 9"):
+        validate_zip_archive(archive)
+    with pytest.raises(MlflowException, match="unsupported compression method 9"):
+        extract_zip_archive(archive, tmp_path / "out")
+
+
+def test_tar_rejects_over_long_and_non_utf8_names(tmp_path):
+    archive = _make_tar(tmp_path / "long.tar.gz", [("a" * 300 + ".md", tarfile.REGTYPE, b"x")])
+    with pytest.raises(MlflowException, match="longer than 255 bytes"):
+        validate_skill_archive(archive)
+
+    buffer = io.BytesIO()
+    with tarfile.open(
+        fileobj=buffer, mode="w", format=tarfile.GNU_FORMAT, encoding="latin-1"
+    ) as tar:
+        info = tarfile.TarInfo("na\xefve.md")
+        info.size = 1
+        tar.addfile(info, io.BytesIO(b"x"))
+    latin = tmp_path / "latin.tar.gz"
+    latin.write_bytes(gzip.compress(buffer.getvalue()))
+    with pytest.raises(MlflowException, match="not valid UTF-8") as exc:
+        extract_skill_archive(latin, tmp_path / "out")
+    exc.value.message.encode("utf-8")
+    assert not any((tmp_path / "out").rglob("*"))
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or os.geteuid() == 0, reason="permission bits are not enforced here"
+)
+def test_package_skill_tree_unreadable_file(tmp_path):
+    source = tmp_path / "src"
+    source.mkdir()
+    _write_tree(source, {"SKILL.md": b"x", "secret.txt": b"y"})
+    (source / "secret.txt").chmod(0)
+    with pytest.raises(MlflowException, match="Cannot read skill content") as exc:
+        package_skill_tree(source, tmp_path / "out.tar.gz")
+    assert exc.value.error_code == "PERMISSION_DENIED"

--- a/tests/genai/skill_content/test_archive.py
+++ b/tests/genai/skill_content/test_archive.py
@@ -184,7 +184,7 @@ def test_validate_skill_archive_bounds_metadata_headers(tmp_path, header_type):
         [("hdr", header_type, payload), ("SKILL.md", tarfile.REGTYPE, b"x")],
     )
     assert archive.stat().st_size < 1024 * 1024
-    with pytest.raises(MlflowException, match="exceeds the skill content size limit"):
+    with pytest.raises(MlflowException, match="exceeds the allowance for tar headers"):
         validate_skill_archive(archive, max_bytes=1024)
 
 
@@ -415,3 +415,25 @@ def test_package_skill_tree_unreadable_file(tmp_path):
     with pytest.raises(MlflowException, match="Cannot read skill content") as exc:
         package_skill_tree(source, tmp_path / "out.tar.gz")
     assert exc.value.error_code == "PERMISSION_DENIED"
+
+
+@pytest.mark.parametrize("operation", ["validate", "extract"])
+def test_tar_budget_counts_only_selected_content(tmp_path, operation):
+    # The content limit applies to the subtree under `subpath`; unrelated payloads elsewhere
+    # in the archive stream past without counting, while metadata stays bounded.
+    archive = _make_tar(
+        tmp_path / "package.tar.gz",
+        [
+            ("skills/demo/SKILL.md", tarfile.REGTYPE, b"x"),
+            ("unrelated/data.bin", tarfile.REGTYPE, b"\0" * (40 * 1024**2)),
+        ],
+    )
+    assert archive.stat().st_size < 1024 * 1024
+    if operation == "validate":
+        assert validate_skill_archive(archive, subpath="skills/demo") == 1
+    else:
+        dest = extract_skill_archive(archive, tmp_path / "extracted", subpath="skills/demo")
+        assert (dest / "skills" / "demo" / "SKILL.md").read_bytes() == b"x"
+        assert not (dest / "unrelated").exists()
+    with pytest.raises(MlflowException, match="exceeds the skill content size limit"):
+        validate_skill_archive(archive)

--- a/tests/genai/skill_content/test_digest.py
+++ b/tests/genai/skill_content/test_digest.py
@@ -1,0 +1,90 @@
+import hashlib
+import os
+import unicodedata
+
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.skill_content.digest import compute_tree_digest
+
+# Independently computed from the RFC serialization rule (sorted UTF-8 paths, u64 big-endian
+# length framing of path and content) for the tree in ``_KNOWN_TREE``. A coordinated change to
+# the framing or ordering in the implementation cannot pass this test silently.
+_KNOWN_TREE = {
+    "SKILL.md": b"---\nname: demo\n---\n",
+    unicodedata.normalize("NFC", "nested/café.md"): b"x",
+    "z.bin": bytes(range(8)),
+}
+_KNOWN_DIGEST = "919556464589004679eb085de455d49f75f9f5408d986f2e7cf490e3f38888d6"
+
+
+def _write_tree(root, files):
+    for path, content in files.items():
+        target = root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+
+def test_digest_known_answer(tmp_path):
+    _write_tree(tmp_path, _KNOWN_TREE)
+    digest = compute_tree_digest(tmp_path)
+    assert digest == _KNOWN_DIGEST
+    assert len(digest) == 64
+    assert digest == digest.lower()
+
+
+def test_digest_is_independent_of_creation_order(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    _write_tree(first, {"z.txt": b"z", "a/b.txt": b"ab"})
+    _write_tree(second, {"a/b.txt": b"ab", "z.txt": b"z"})
+    assert compute_tree_digest(first) == compute_tree_digest(second)
+
+
+def test_digest_framing_prevents_boundary_collisions(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    _write_tree(first, {"a": b"bc"})
+    _write_tree(second, {"ab": b"c"})
+    assert compute_tree_digest(first) != compute_tree_digest(second)
+
+
+def test_digest_uses_nfc_paths(tmp_path):
+    nfd = tmp_path / "nfd"
+    nfc = tmp_path / "nfc"
+    nfd.mkdir()
+    nfc.mkdir()
+    _write_tree(nfd, {unicodedata.normalize("NFD", "café.md"): b"x"})
+    _write_tree(nfc, {unicodedata.normalize("NFC", "café.md"): b"x"})
+    assert compute_tree_digest(nfd) == compute_tree_digest(nfc)
+
+
+def test_digest_excludes_symlinks(tmp_path):
+    _write_tree(tmp_path, {"SKILL.md": b"x"})
+    baseline = compute_tree_digest(tmp_path)
+    (tmp_path / "link.md").symlink_to(tmp_path / "SKILL.md")
+    assert compute_tree_digest(tmp_path) == baseline
+
+
+def test_digest_empty_tree(tmp_path):
+    assert compute_tree_digest(tmp_path) == hashlib.sha256().hexdigest()
+
+
+def test_digest_rejects_missing_root(tmp_path):
+    with pytest.raises(MlflowException, match="not a directory"):
+        compute_tree_digest(tmp_path / "missing")
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or os.geteuid() == 0, reason="permission bits are not enforced here"
+)
+def test_digest_unreadable_file_is_a_permission_error(tmp_path):
+    _write_tree(tmp_path, {"SKILL.md": b"x", "secret.txt": b"y"})
+    (tmp_path / "secret.txt").chmod(0)
+    with pytest.raises(MlflowException, match="Cannot read skill content") as exc:
+        compute_tree_digest(tmp_path)
+    assert exc.value.error_code == "PERMISSION_DENIED"

--- a/tests/genai/skill_content/test_errors.py
+++ b/tests/genai/skill_content/test_errors.py
@@ -1,0 +1,61 @@
+import pytest
+
+from mlflow.genai.skill_content.errors import (
+    error_code_for_http_status,
+    invalid_content,
+    redact_credentials,
+    source_unavailable,
+)
+from mlflow.protos.databricks_pb2 import UNAUTHENTICATED, ErrorCode
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("https://user:p4ss@example.com/repo.git", "https://***@example.com/repo.git"),
+        (
+            "fatal: could not read from https://tok@host/x",
+            "fatal: could not read from https://***@host/x",
+        ),
+        ("user:tok@github.com:acme/skills.git", "***@github.com:acme/skills.git"),
+        ("Authorization: Bearer abcdefghij0123456789", "Authorization: Bearer ***"),
+        ("header Basic dXNlcjpwYXNzd29yZA==", "header Basic ***"),
+        ("nothing secret here", "nothing secret here"),
+        ("git@github.com:acme/skills.git", "git@github.com:acme/skills.git"),
+    ],
+)
+def test_redact_credentials(text, expected):
+    assert redact_credentials(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (401, "UNAUTHENTICATED"),
+        (403, "PERMISSION_DENIED"),
+        (404, "RESOURCE_DOES_NOT_EXIST"),
+        (410, "RESOURCE_DOES_NOT_EXIST"),
+        (429, "TEMPORARILY_UNAVAILABLE"),
+        (500, "TEMPORARILY_UNAVAILABLE"),
+        (503, "TEMPORARILY_UNAVAILABLE"),
+        (400, "RESOURCE_DOES_NOT_EXIST"),
+    ],
+)
+def test_error_code_for_http_status(status, expected):
+    assert ErrorCode.Name(error_code_for_http_status(status)) == expected
+
+
+def test_source_unavailable_redacts_and_carries_code():
+    exc = source_unavailable(
+        "https://u:p@h/r.git", "Bearer secrettoken123", error_code=UNAUTHENTICATED
+    )
+    assert exc.error_code == "UNAUTHENTICATED"
+    assert "u:p@" not in exc.message
+    assert "secrettoken123" not in exc.message
+    assert "https://***@h/r.git" in exc.message
+
+
+def test_invalid_content_redacts():
+    exc = invalid_content("bad entry from https://u:p@h/x")
+    assert exc.error_code == "INVALID_PARAMETER_VALUE"
+    assert "u:p@" not in exc.message

--- a/tests/genai/skill_content/test_fetchers.py
+++ b/tests/genai/skill_content/test_fetchers.py
@@ -41,12 +41,18 @@ def git_repo(tmp_path, skill_tree):
 
 class _RecordingHTTPHandler(http.server.SimpleHTTPRequestHandler):
     authorizations = []
+    redirects = {}
 
     def log_message(self, *args):
         pass
 
     def do_GET(self):
         self.authorizations.append(self.headers.get("Authorization"))
+        if (target := self.redirects.get(self.path)) is not None:
+            self.send_response(302)
+            self.send_header("Location", target)
+            self.end_headers()
+            return
         super().do_GET()
 
 
@@ -54,7 +60,7 @@ class _RecordingHTTPHandler(http.server.SimpleHTTPRequestHandler):
 def http_server(tmp_path):
     serve_dir = tmp_path / "www"
     serve_dir.mkdir()
-    handler_cls = type("Handler", (_RecordingHTTPHandler,), {"authorizations": []})
+    handler_cls = type("Handler", (_RecordingHTTPHandler,), {"authorizations": [], "redirects": {}})
     handler = partial(handler_cls, directory=str(serve_dir))
     server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
     thread = threading.Thread(target=server.serve_forever, name="skill-content-http", daemon=True)
@@ -179,6 +185,22 @@ def test_fetch_zip_sends_no_credentials(http_server, skill_tree, tmp_path, monke
 
     with pytest.raises(MlflowException, match="publicly accessible"):
         fetch_source(base_url.replace("http://", "http://u:p@") + "/skills.zip")
+
+
+@pytest.mark.no_mock_requests_get
+def test_fetch_zip_redirect_never_uses_netrc(http_server, skill_tree, tmp_path, monkeypatch):
+    # `requests` re-applies netrc credentials when it rebuilds a redirected request; the
+    # public-only policy must hold on every hop, not just the first.
+    serve_dir, base_url, handler = http_server
+    shutil.make_archive(str(serve_dir / "skills"), "zip", root_dir=skill_tree)
+    handler.redirects["/redirect.zip"] = "/skills.zip"
+    netrc = tmp_path / "netrc"
+    netrc.write_text("machine 127.0.0.1 login netrc-user password netrc-pass\n")
+    monkeypatch.setenv("NETRC", str(netrc))
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1")
+    with fetch_source(f"{base_url}/redirect.zip", subpath="skills/demo") as fetched:
+        assert (fetched.root / "SKILL.md").exists()
+    assert handler.authorizations == [None, None]
 
 
 @pytest.mark.no_mock_requests_get

--- a/tests/genai/skill_content/test_fetchers.py
+++ b/tests/genai/skill_content/test_fetchers.py
@@ -1,0 +1,246 @@
+import http.server
+import shutil
+import subprocess
+import threading
+import zipfile
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+import mlflow
+from mlflow.entities.skill_source import GitSource, OCISource, SkillSourceType, ZipSource
+from mlflow.exceptions import MlflowException
+from mlflow.genai.skill_content.digest import compute_tree_digest
+from mlflow.genai.skill_content.fetchers import fetch_source
+
+from tests.genai.skill_content.conftest import SKILL_MD
+
+
+def _git(*args, cwd):
+    subprocess.check_call(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@example.com", *args],
+        cwd=cwd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+@pytest.fixture
+def git_repo(tmp_path, skill_tree):
+    repo = tmp_path / "skills.git"
+    shutil.copytree(skill_tree, repo)
+    _git("init", "-q", "-b", "main", cwd=repo)
+    _git("add", ".", cwd=repo)
+    _git("commit", "-q", "-m", "v1", cwd=repo)
+    _git("tag", "v1", cwd=repo)
+    (repo / "skills" / "demo" / "SKILL.md").write_text(SKILL_MD + "\nsecond revision\n")
+    _git("commit", "-q", "-am", "v2", cwd=repo)
+    return repo
+
+
+class _RecordingHTTPHandler(http.server.SimpleHTTPRequestHandler):
+    authorizations = []
+
+    def log_message(self, *args):
+        pass
+
+    def do_GET(self):
+        self.authorizations.append(self.headers.get("Authorization"))
+        super().do_GET()
+
+
+@pytest.fixture
+def http_server(tmp_path):
+    serve_dir = tmp_path / "www"
+    serve_dir.mkdir()
+    handler_cls = type("Handler", (_RecordingHTTPHandler,), {"authorizations": []})
+    handler = partial(handler_cls, directory=str(serve_dir))
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, name="skill-content-http", daemon=True)
+    thread.start()
+    try:
+        yield serve_dir, f"http://127.0.0.1:{server.server_address[1]}", handler_cls
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+# --- local ------------------------------------------------------------------------------------
+
+
+def test_fetch_local_path(skill_tree):
+    with fetch_source(str(skill_tree), subpath="skills/demo") as fetched:
+        assert fetched.root == skill_tree / "skills" / "demo"
+        assert fetched.resolved.is_local is True
+        assert fetched.resolved.source_type == SkillSourceType.MLFLOW
+    assert (skill_tree / "skills" / "demo" / "SKILL.md").exists()
+
+
+def test_fetch_local_path_rejects_symlink_and_missing_subpath(skill_tree):
+    with pytest.raises(MlflowException, match="does not exist"):
+        fetch_source(str(skill_tree), subpath="skills/nope")
+    (skill_tree / "skills" / "demo" / "link").symlink_to(skill_tree / "README.md")
+    with pytest.raises(MlflowException, match="symbolic links"):
+        fetch_source(str(skill_tree), subpath="skills/demo")
+
+
+def test_fetch_local_path_size_limit_applies_to_subpath(skill_tree):
+    with pytest.raises(MlflowException, match="exceeds the size limit"):
+        fetch_source(str(skill_tree), max_bytes=200)
+    with fetch_source(str(skill_tree), subpath="skills/demo", max_bytes=200) as fetched:
+        assert (fetched.root / "SKILL.md").exists()
+
+
+# --- git --------------------------------------------------------------------------------------
+
+
+def test_fetch_git_by_ref_and_head(git_repo, skill_tree):
+    source = GitSource(url=f"file://{git_repo}", ref="v1", subpath="skills/demo")
+    with fetch_source(source) as fetched:
+        temp_root = fetched.root
+        assert (fetched.root / "SKILL.md").read_text() == SKILL_MD
+        assert not (fetched.root.parent.parent / ".git").exists()
+        assert compute_tree_digest(fetched.root) == compute_tree_digest(
+            skill_tree / "skills" / "demo"
+        )
+    assert not temp_root.exists()
+
+    with fetch_source(f"file://{git_repo}", subpath="skills/demo") as fetched:
+        assert fetched.resolved.source_type == SkillSourceType.GIT
+        assert "second revision" in (fetched.root / "SKILL.md").read_text()
+
+
+def test_fetch_git_missing_ref(git_repo):
+    with pytest.raises(MlflowException, match="Failed to fetch skill content.*ref 'nope'") as exc:
+        fetch_source(GitSource(url=f"file://{git_repo}", ref="nope"))
+    assert exc.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+
+
+def test_fetch_git_size_limit_applies_to_subpath(git_repo):
+    with pytest.raises(MlflowException, match="exceeds the skill content size limit"):
+        fetch_source(GitSource(url=f"file://{git_repo}"), max_bytes=200)
+    with fetch_source(
+        GitSource(url=f"file://{git_repo}", subpath="skills/demo"), max_bytes=200
+    ) as f:
+        assert (f.root / "SKILL.md").exists()
+
+
+def test_fetch_git_rejects_option_like_ref(git_repo):
+    with pytest.raises(MlflowException, match="must not start with '-'"):
+        fetch_source(GitSource(url=f"file://{git_repo}", ref="--upload-pack=evil"))
+
+
+def test_fetch_git_redacts_credentials_and_reports_availability(closed_port):
+    url = f"https://user:s3cret-token@127.0.0.1:{closed_port}/skills.git"
+    with pytest.raises(MlflowException, match="Failed to fetch skill content") as exc_info:
+        fetch_source(url)
+    message = str(exc_info.value)
+    assert "s3cret-token" not in message
+    assert "***@127.0.0.1" in message
+    assert exc_info.value.error_code == "TEMPORARILY_UNAVAILABLE"
+
+
+# --- zip --------------------------------------------------------------------------------------
+
+
+@pytest.mark.no_mock_requests_get
+def test_fetch_zip(http_server, skill_tree):
+    serve_dir, base_url, _ = http_server
+    shutil.make_archive(str(serve_dir / "skills"), "zip", root_dir=skill_tree)
+    with fetch_source(ZipSource(url=f"{base_url}/skills.zip", subpath="skills/demo")) as fetched:
+        assert compute_tree_digest(fetched.root) == compute_tree_digest(
+            skill_tree / "skills" / "demo"
+        )
+        assert not (fetched.root.parent.parent.parent / "source.zip").exists()
+        assert not (fetched.root.parent.parent / "big.bin").exists()
+
+
+@pytest.mark.no_mock_requests_get
+def test_fetch_zip_subpath_limits_budget(http_server, skill_tree):
+    serve_dir, base_url, _ = http_server
+    shutil.make_archive(str(serve_dir / "skills"), "zip", root_dir=skill_tree)
+    with pytest.raises(MlflowException, match="exceeds the skill content size limit"):
+        fetch_source(f"{base_url}/skills.zip", max_bytes=2000)
+    with fetch_source(f"{base_url}/skills.zip", subpath="skills/demo", max_bytes=2000) as fetched:
+        assert (fetched.root / "SKILL.md").exists()
+
+
+@pytest.mark.no_mock_requests_get
+def test_fetch_zip_sends_no_credentials(http_server, skill_tree, tmp_path, monkeypatch):
+    serve_dir, base_url, handler = http_server
+    shutil.make_archive(str(serve_dir / "skills"), "zip", root_dir=skill_tree)
+    netrc = tmp_path / "netrc"
+    netrc.write_text("machine 127.0.0.1 login netrc-user password netrc-pass\n")
+    monkeypatch.setenv("NETRC", str(netrc))
+    with fetch_source(f"{base_url}/skills.zip", subpath="skills/demo"):
+        pass
+    assert handler.authorizations == [None]
+
+    with pytest.raises(MlflowException, match="publicly accessible"):
+        fetch_source(base_url.replace("http://", "http://u:p@") + "/skills.zip")
+
+
+@pytest.mark.no_mock_requests_get
+def test_fetch_zip_errors(http_server, skill_tree):
+    serve_dir, base_url, _ = http_server
+    with pytest.raises(MlflowException, match="HTTP 404") as exc:
+        fetch_source(f"{base_url}/missing.zip")
+    assert exc.value.error_code == "RESOURCE_DOES_NOT_EXIST"
+
+    with zipfile.ZipFile(serve_dir / "evil.zip", "w") as zf:
+        zf.writestr("../escape.txt", "x")
+    with pytest.raises(MlflowException, match="unsafe path"):
+        fetch_source(f"{base_url}/evil.zip")
+
+
+@pytest.mark.no_mock_requests_get
+def test_fetch_zip_unreachable(closed_port):
+    with pytest.raises(MlflowException, match="Failed to fetch skill content") as exc:
+        fetch_source(f"http://127.0.0.1:{closed_port}/skills.zip")
+    assert exc.value.error_code == "TEMPORARILY_UNAVAILABLE"
+
+
+# --- oci --------------------------------------------------------------------------------------
+
+
+def test_fetch_oci_not_supported_yet():
+    # The source type resolves so callers get a precise message, but no registry is contacted.
+    with pytest.raises(MlflowException, match="OCI sources are not supported yet"):
+        fetch_source(OCISource(image="oci://ghcr.io/acme/skills:v1"))
+    with pytest.raises(MlflowException, match="OCI sources are not supported yet"):
+        fetch_source("oci://ghcr.io/acme/skills:v1")
+
+
+# --- mlflow artifacts -------------------------------------------------------------------------
+
+
+def test_fetch_mlflow_artifacts(skill_tree):
+    with mlflow.start_run() as run:
+        mlflow.log_artifacts(str(skill_tree / "skills" / "demo"), artifact_path="skill")
+    uri = f"runs:/{run.info.run_id}/skill"
+    with fetch_source(uri) as fetched:
+        assert fetched.resolved.source_type == SkillSourceType.MLFLOW
+        assert fetched.resolved.is_local is False
+        assert compute_tree_digest(fetched.root) == compute_tree_digest(
+            skill_tree / "skills" / "demo"
+        )
+        temp_root = fetched.root
+    assert not Path(temp_root).exists()
+
+
+def test_fetch_mlflow_artifacts_subpath_downloads_only_subtree(skill_tree):
+    with mlflow.start_run() as run:
+        mlflow.log_artifacts(str(skill_tree), artifact_path="pkg")
+    uri = f"runs:/{run.info.run_id}/pkg"
+    with pytest.raises(MlflowException, match="exceeds"):
+        fetch_source(uri, max_bytes=2000)
+    with fetch_source(uri, subpath="skills/demo", max_bytes=2000) as fetched:
+        assert (fetched.root / "SKILL.md").exists()
+        assert not (fetched.root.parent.parent / "big.bin").exists()
+
+
+def test_fetch_mlflow_artifacts_missing():
+    with pytest.raises(MlflowException, match="Failed to fetch skill content") as exc:
+        fetch_source("runs:/does-not-exist/skill")
+    assert exc.value.error_code == "RESOURCE_DOES_NOT_EXIST"

--- a/tests/genai/skill_content/test_paths.py
+++ b/tests/genai/skill_content/test_paths.py
@@ -247,3 +247,25 @@ def test_unreadable_directory_is_a_permission_error(tmp_path):
             assert_regular_tree(tmp_path)
     finally:
         private.chmod(0o700)
+
+
+@pytest.mark.parametrize(
+    ("names", "message"),
+    [
+        (["data:stream"], "must not contain ':'"),
+        (["A/x", "a/y"], "differ only by letter case"),
+        (["CON"], "reserved Windows device name"),
+    ],
+)
+def test_collect_tree_applies_archive_rules(tmp_path, names, message):
+    # A tree the collector accepts must survive packaging and extraction, so the same segment
+    # and directory-alias rules the archive validators enforce apply to local trees.
+    (tmp_path / "SKILL.md").write_text("---\nname: demo\n---\n")
+    for name in names:
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("content")
+    if len(names) > 1 and (tmp_path / "A").samefile(tmp_path / "a"):
+        pytest.skip("requires a case-sensitive filesystem")
+    with pytest.raises(MlflowException, match=message):
+        collect_tree(tmp_path)

--- a/tests/genai/skill_content/test_paths.py
+++ b/tests/genai/skill_content/test_paths.py
@@ -1,0 +1,226 @@
+import os
+import unicodedata
+from pathlib import Path
+
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.skill_content.paths import (
+    PathCollisionGuard,
+    assert_regular_tree,
+    canonical_relative_path,
+    collect_tree,
+    ensure_within,
+    is_under_subpath,
+    normalize_subpath,
+    resolve_contained,
+    tree_size,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("skills/review", "skills/review"),
+        ("skills//review/", "skills/review"),
+        (" a/b ", "a/b"),
+    ],
+)
+def test_normalize_subpath_valid(raw, expected):
+    assert normalize_subpath(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "/abs/path",
+        "a/../b",
+        "../x",
+        "./a",
+        "a/./b",
+        "a\\b",
+        "..",
+        ".",
+        "C:evil.txt",
+        "C:/evil.txt",
+        "C:",
+        "a/C:x",
+        "SKILL.md:zone",
+        "CON",
+        "nul.txt",
+        "a/com1/b",
+        "dir/LPT1.md",
+        "a\x00b",
+        "a\nb",
+    ],
+)
+def test_normalize_subpath_invalid(raw):
+    with pytest.raises(MlflowException, match="Subpath"):
+        normalize_subpath(raw)
+
+
+def test_normalize_subpath_rejects_non_string():
+    with pytest.raises(MlflowException, match="must be a string"):
+        normalize_subpath(3)
+
+
+def test_canonical_relative_path_preserves_exact_names():
+    assert canonical_relative_path(" a.md ") == " a.md "
+    assert canonical_relative_path("dir/ b ") == "dir/ b "
+    assert canonical_relative_path("dir//x/") == "dir/x"
+    assert canonical_relative_path("") is None
+    with pytest.raises(MlflowException, match="forward slashes"):
+        canonical_relative_path("a\\b")
+    with pytest.raises(MlflowException, match="reserved Windows device name"):
+        canonical_relative_path("prn")
+
+
+@pytest.mark.parametrize(
+    ("relative", "subpath", "expected"),
+    [
+        ("a/b", None, True),
+        ("a/b", "a", True),
+        ("a", "a", True),
+        ("ab/c", "a", False),
+        ("b", "a", False),
+    ],
+)
+def test_is_under_subpath(relative, subpath, expected):
+    assert is_under_subpath(relative, subpath) is expected
+
+
+def test_ensure_within(tmp_path):
+    inside = tmp_path / "a" / "b"
+    assert ensure_within(tmp_path, inside) == inside.resolve()
+    assert ensure_within(tmp_path, tmp_path) == tmp_path.resolve()
+    with pytest.raises(MlflowException, match="resolves outside"):
+        ensure_within(tmp_path, tmp_path.parent / "elsewhere")
+
+
+def test_resolve_contained(tmp_path):
+    (tmp_path / "skills" / "review").mkdir(parents=True)
+    assert resolve_contained(tmp_path, None) == tmp_path
+    assert resolve_contained(tmp_path, "skills/review") == tmp_path / "skills" / "review"
+
+
+def test_resolve_contained_missing_and_file(tmp_path):
+    (tmp_path / "file.txt").write_text("x")
+    with pytest.raises(MlflowException, match="does not exist"):
+        resolve_contained(tmp_path, "nope")
+    with pytest.raises(MlflowException, match="must point to a directory"):
+        resolve_contained(tmp_path, "file.txt")
+
+
+def test_resolve_contained_rejects_symlink_traversal(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "link").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(MlflowException, match="traverses a symbolic link"):
+        resolve_contained(root, "link")
+
+
+def test_path_collision_guard():
+    guard = PathCollisionGuard()
+    assert guard.register("a/b.md") == "a/b.md"
+    with pytest.raises(MlflowException, match="appears more than once"):
+        guard.register("a/b.md")
+    with pytest.raises(MlflowException, match="differ only by letter case"):
+        guard.register("A/B.md")
+    guard.register(unicodedata.normalize("NFD", "café.md"))
+    with pytest.raises(MlflowException, match="normalize to the same path"):
+        guard.register(unicodedata.normalize("NFC", "café.md"))
+
+
+def test_collect_tree_orders_by_path_bytes_and_skips_links(tmp_path):
+    (tmp_path / "b.txt").write_bytes(b"bb")
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "z.txt").write_bytes(b"z")
+    (tmp_path / "0.txt").write_bytes(b"0")
+    (tmp_path / "link.txt").symlink_to(tmp_path / "b.txt")
+    (tmp_path / "linkdir").symlink_to(tmp_path / "a", target_is_directory=True)
+
+    files = collect_tree(tmp_path)
+
+    # Sorted by UTF-8 byte value: digits precede letters, and "a/" precedes "b".
+    assert [f.path for f in files] == ["0.txt", "a/z.txt", "b.txt"]
+    assert [f.size for f in files] == [1, 1, 2]
+    assert tree_size(tmp_path) == 4
+
+
+def _write_pair_or_skip(directory: Path, first: str, second: str) -> None:
+    (directory / first).write_bytes(b"1")
+    try:
+        (directory / second).write_bytes(b"2")
+    except FileExistsError:
+        pytest.skip("filesystem treats the two names as one file")
+    if len(list(directory.iterdir())) < 2:
+        pytest.skip("filesystem treats the two names as one file")
+
+
+def test_collect_tree_normalizes_nfc_and_rejects_collisions(tmp_path):
+    nfd_name = unicodedata.normalize("NFD", "café.txt")
+    nfc_name = unicodedata.normalize("NFC", "café.txt")
+    (tmp_path / nfd_name).write_bytes(b"1")
+    assert collect_tree(tmp_path)[0].path == nfc_name
+
+    (tmp_path / "dir").mkdir()
+    _write_pair_or_skip(tmp_path / "dir", nfd_name, nfc_name)
+    with pytest.raises(MlflowException, match="normalize to the same path"):
+        collect_tree(tmp_path)
+
+
+def test_collect_tree_rejects_case_only_collisions(tmp_path):
+    _write_pair_or_skip(tmp_path, "Readme.md", "readme.md")
+    with pytest.raises(MlflowException, match="differ only by letter case"):
+        collect_tree(tmp_path)
+
+
+def test_assert_regular_tree_accepts_plain_tree(tmp_path):
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "f.txt").write_text("x")
+    assert_regular_tree(tmp_path)
+
+
+def test_assert_regular_tree_rejects_symlink(tmp_path):
+    (tmp_path / "f.txt").write_text("x")
+    (tmp_path / "l.txt").symlink_to(tmp_path / "f.txt")
+    with pytest.raises(MlflowException, match="symbolic links"):
+        assert_regular_tree(tmp_path)
+
+
+def test_assert_regular_tree_rejects_hard_link(tmp_path):
+    (tmp_path / "f.txt").write_text("x")
+    os.link(tmp_path / "f.txt", tmp_path / "h.txt")
+    with pytest.raises(MlflowException, match="hard links"):
+        assert_regular_tree(tmp_path)
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are not supported on this platform")
+def test_assert_regular_tree_rejects_special_file(tmp_path):
+    os.mkfifo(tmp_path / "pipe")
+    with pytest.raises(MlflowException, match="only regular files and directories"):
+        assert_regular_tree(tmp_path)
+
+
+def test_assert_regular_tree_rejects_link_root(tmp_path):
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(real, target_is_directory=True)
+    with pytest.raises(MlflowException, match="not a link"):
+        assert_regular_tree(link)
+
+
+def test_canonical_relative_path_rejects_long_and_non_utf8_names():
+    with pytest.raises(MlflowException, match="longer than 255 bytes"):
+        canonical_relative_path("dir/" + "a" * 256)
+    assert canonical_relative_path("dir/" + "a" * 255) == "dir/" + "a" * 255
+    # Archive readers map undecodable bytes to lone surrogates; the message must stay printable.
+    with pytest.raises(MlflowException, match=r"na\\udcefve.md' is not valid UTF-8") as exc:
+        canonical_relative_path("na\udcefve.md")
+    exc.value.message.encode("utf-8")

--- a/tests/genai/skill_content/test_paths.py
+++ b/tests/genai/skill_content/test_paths.py
@@ -224,3 +224,26 @@ def test_canonical_relative_path_rejects_long_and_non_utf8_names():
     with pytest.raises(MlflowException, match=r"na\\udcefve.md' is not valid UTF-8") as exc:
         canonical_relative_path("na\udcefve.md")
     exc.value.message.encode("utf-8")
+
+
+def test_unreadable_directory_is_a_permission_error(tmp_path):
+    (tmp_path / "SKILL.md").write_text("---\nname: demo\n---\n")
+    private = tmp_path / "private"
+    private.mkdir()
+    (private / "required.txt").write_text("required content")
+    private.chmod(0)
+    try:
+        try:
+            list(private.iterdir())
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("directory permissions are not enforced for this user")
+        # A silently skipped subtree would change the digest without any error.
+        with pytest.raises(MlflowException, match="Cannot read skill content") as exc:
+            collect_tree(tmp_path)
+        assert exc.value.error_code == "PERMISSION_DENIED"
+        with pytest.raises(MlflowException, match="Cannot read skill content"):
+            assert_regular_tree(tmp_path)
+    finally:
+        private.chmod(0o700)

--- a/tests/genai/skill_content/test_skill_md.py
+++ b/tests/genai/skill_content/test_skill_md.py
@@ -1,0 +1,147 @@
+import os
+
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.skill_content.skill_md import (
+    SKILL_MANIFEST_FILE,
+    inspect_skill_dir,
+    parse_skill_md,
+)
+
+
+def _skill_dir(tmp_path, name, content):
+    root = tmp_path / name
+    root.mkdir()
+    (root / SKILL_MANIFEST_FILE).write_text(content, encoding="utf-8")
+    return root
+
+
+def test_parse_skill_md_with_frontmatter():
+    metadata, body = parse_skill_md("---\nname: demo\ndescription: Does things\n---\n# Body\n")
+    assert metadata == {"name": "demo", "description": "Does things"}
+    assert body == "# Body\n"
+
+
+def test_parse_skill_md_without_frontmatter():
+    assert parse_skill_md("# Just a body\n") == ({}, "# Just a body\n")
+
+
+def test_parse_skill_md_frontmatter_only():
+    metadata, body = parse_skill_md("---\nname: demo\n---")
+    assert metadata == {"name": "demo"}
+    assert body == ""
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        ("---\nname: demo\n", "not closed"),
+        ("---\nname: [\n---\nbody", "not valid YAML"),
+        ("---\n- just\n- a list\n---\nbody", "must be a YAML mapping"),
+    ],
+)
+def test_parse_skill_md_malformed(content, message):
+    with pytest.raises(MlflowException, match=message):
+        parse_skill_md(content)
+
+
+def test_inspect_skill_dir_reads_fields(tmp_path):
+    root = _skill_dir(
+        tmp_path,
+        "code-review",
+        "---\nname: code-review\ndescription: Reviews code\nkeywords: [review, quality]\n---\n",
+    )
+    manifest = inspect_skill_dir(root)
+    assert manifest.name == "code-review"
+    assert manifest.description == "Reviews code"
+    assert manifest.keywords == ("review", "quality")
+    assert manifest.path == root
+
+
+def test_inspect_skill_dir_keywords_from_string_and_nested_metadata(tmp_path):
+    root = _skill_dir(tmp_path, "a", "---\nname: a\nkeywords: ' x, y ,,z '\n---\n")
+    assert inspect_skill_dir(root).keywords == ("x", "y", "z")
+    nested = _skill_dir(tmp_path, "b", "---\nname: b\nmetadata:\n  keywords: [q]\n---\n")
+    assert inspect_skill_dir(nested).keywords == ("q",)
+
+
+def test_inspect_skill_dir_requires_declared_name(tmp_path):
+    # Fetched content lands in an arbitrary directory such as ``content``, so the directory
+    # name is never an acceptable identity.
+    root = _skill_dir(tmp_path, "content", "# no frontmatter\n")
+    with pytest.raises(MlflowException, match="must declare a 'name'"):
+        inspect_skill_dir(root)
+    manifest = inspect_skill_dir(root, fallback_name="legacy-skill")
+    assert manifest.name == "legacy-skill"
+    assert manifest.description is None
+    assert manifest.keywords == ()
+
+
+def test_inspect_skill_dir_declared_name_beats_fallback(tmp_path):
+    root = _skill_dir(tmp_path, "dir", "---\nname: declared\n---\n")
+    assert inspect_skill_dir(root, fallback_name="other").name == "declared"
+
+
+def test_inspect_skill_dir_accepts_utf8_bom(tmp_path):
+    root = tmp_path / "demo"
+    root.mkdir()
+    (root / SKILL_MANIFEST_FILE).write_bytes(b"\xef\xbb\xbf---\nname: demo\ndescription: d\n---\n")
+    manifest = inspect_skill_dir(root)
+    assert (manifest.name, manifest.description) == ("demo", "d")
+
+
+@pytest.mark.parametrize("name", ["Bad_Name", "-lead", "trail-", "a--b", "x" * 65])
+def test_inspect_skill_dir_invalid_name(tmp_path, name):
+    root = _skill_dir(tmp_path, "dir", f"---\nname: {name}\n---\n")
+    with pytest.raises(MlflowException, match="(?i)skill name"):
+        inspect_skill_dir(root)
+
+
+def test_inspect_skill_dir_missing_manifest(tmp_path):
+    with pytest.raises(MlflowException, match="does not contain a SKILL.md"):
+        inspect_skill_dir(tmp_path)
+
+
+def test_inspect_skill_dir_rejects_symlinked_manifest(tmp_path):
+    real = tmp_path / "real.md"
+    real.write_text("---\nname: demo\n---\n")
+    root = tmp_path / "demo"
+    root.mkdir()
+    (root / SKILL_MANIFEST_FILE).symlink_to(real)
+    with pytest.raises(MlflowException, match="does not contain a SKILL.md"):
+        inspect_skill_dir(root)
+
+
+def test_inspect_skill_dir_rejects_invalid_utf8(tmp_path):
+    root = tmp_path / "demo"
+    root.mkdir()
+    (root / SKILL_MANIFEST_FILE).write_bytes(b"---\nname: demo\n---\n\xff\xfe")
+    with pytest.raises(MlflowException, match="not valid UTF-8"):
+        inspect_skill_dir(root)
+
+
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        ("---\nname: 42\n---\n", "name must be a string"),
+        ("---\nname: demo\ndescription: [a]\n---\n", "description must be a string"),
+        ("---\nname: demo\nkeywords: {a: b}\n---\n", "keywords must be a list"),
+        ("---\nname: demo\nkeywords: [[nested]]\n---\n", "keywords must be strings"),
+    ],
+)
+def test_inspect_skill_dir_field_type_errors(tmp_path, content, message):
+    root = _skill_dir(tmp_path, "demo", content)
+    with pytest.raises(MlflowException, match=message):
+        inspect_skill_dir(root)
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or os.geteuid() == 0, reason="permission bits are not enforced here"
+)
+def test_inspect_skill_dir_unreadable_manifest(tmp_path):
+    root = _skill_dir(tmp_path, "demo", "---\nname: demo\n---\n")
+    (root / SKILL_MANIFEST_FILE).chmod(0)
+    with pytest.raises(MlflowException, match="Cannot read skill content") as exc:
+        inspect_skill_dir(root)
+    assert exc.value.error_code == "PERMISSION_DENIED"

--- a/tests/genai/skill_content/test_sources.py
+++ b/tests/genai/skill_content/test_sources.py
@@ -1,0 +1,179 @@
+from pathlib import Path
+
+import pytest
+
+from mlflow.entities.skill_source import GitSource, OCISource, SkillSourceType, ZipSource
+from mlflow.exceptions import MlflowException
+from mlflow.genai.skill_content.sources import (
+    ResolvedSource,
+    is_local_path,
+    resolve_source_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("./skills/review", True),
+        ("skills/review", True),
+        ("/abs/skills", True),
+        ("C:\\skills\\review", True),
+        ("https://example.com/repo.git", False),
+        ("oci://ghcr.io/acme/skills:v1", False),
+        ("git@github.com:acme/skills.git", False),
+        ("mlflow-artifacts:/skills/review/abc", False),
+        ("runs:/abc/skill", False),
+    ],
+)
+def test_is_local_path(source, expected):
+    assert is_local_path(source) is expected
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_type", "expected_value"),
+    [
+        (
+            "https://github.com/acme/skills.git",
+            SkillSourceType.GIT,
+            "https://github.com/acme/skills.git",
+        ),
+        ("git@github.com:acme/skills.git", SkillSourceType.GIT, "git@github.com:acme/skills.git"),
+        ("git://host/repo", SkillSourceType.GIT, "git://host/repo"),
+        ("oci://ghcr.io/acme/skills:v1", SkillSourceType.OCI, "ghcr.io/acme/skills:v1"),
+        (
+            "https://example.com/skills.zip?x=1",
+            SkillSourceType.ZIP,
+            "https://example.com/skills.zip?x=1",
+        ),
+        (
+            "mlflow-artifacts:/skills/review/t1",
+            SkillSourceType.MLFLOW,
+            "mlflow-artifacts:/skills/review/t1",
+        ),
+        ("runs:/run1/skill", SkillSourceType.MLFLOW, "runs:/run1/skill"),
+    ],
+)
+def test_resolve_source_type_infers_from_string(source, expected_type, expected_value):
+    resolved = resolve_source_type(source)
+    assert resolved.source_type == expected_type
+    assert resolved.source == expected_value
+    assert resolved.is_local is False
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "https://example.com/acme/skills",
+        "https://example.com/archive.tar.gz",
+        "ssh://git@host/repo",
+        "git+https://host/repo",
+        "user@host:path/without/suffix",
+        "oci://",
+    ],
+)
+def test_resolve_source_type_ambiguous_strings_are_rejected(source):
+    # Only the RFC inference table applies: ``.git`` suffix, ``git://``, ``oci://``, ``.zip``.
+    with pytest.raises(MlflowException, match="Cannot infer|must include an image reference"):
+        resolve_source_type(source)
+
+
+def test_resolve_source_type_typed_sources():
+    git = resolve_source_type(GitSource(url="https://h/r", ref="v1", subpath="skills/a/"))
+    assert git == ResolvedSource(SkillSourceType.GIT, "https://h/r", ref="v1", subpath="skills/a")
+
+    oci = resolve_source_type(OCISource(image="oci://ghcr.io/acme/p:v1", subpath="s"))
+    assert (oci.source_type, oci.source, oci.subpath) == (
+        SkillSourceType.OCI,
+        "ghcr.io/acme/p:v1",
+        "s",
+    )
+
+    zipped = resolve_source_type(ZipSource(url="https://h/a"))
+    assert (zipped.source_type, zipped.source, zipped.subpath) == (
+        SkillSourceType.ZIP,
+        "https://h/a",
+        None,
+    )
+
+
+def test_resolve_source_type_typed_source_rejects_extra_kwargs():
+    with pytest.raises(MlflowException, match="must not be passed alongside a typed source"):
+        resolve_source_type(GitSource(url="https://h/r"), ref="main")
+
+
+def test_resolve_source_type_local_path(tmp_path):
+    resolved = resolve_source_type(str(tmp_path), subpath="a//b")
+    assert resolved.is_local is True
+    assert resolved.source_type == SkillSourceType.MLFLOW
+    assert Path(resolved.source) == tmp_path.resolve()
+    assert resolved.subpath == "a/b"
+    with pytest.raises(MlflowException, match="'ref' applies to Git sources only"):
+        resolve_source_type(str(tmp_path), ref="main")
+
+
+def test_resolve_source_type_ref_only_for_git():
+    with pytest.raises(MlflowException, match="'ref' applies to Git sources only"):
+        resolve_source_type("https://example.com/skills.zip", ref="v1")
+    resolved = resolve_source_type("https://example.com/skills.git", ref="v1", subpath="x")
+    assert (resolved.ref, resolved.subpath) == ("v1", "x")
+
+
+@pytest.mark.parametrize(
+    ("source", "ref", "message"),
+    [
+        ("-oProxyCommand=x/repo.git", None, "must not start with '-'"),
+        ("https://h/r.git", "--upload-pack=evil", "must not start with '-'"),
+        ("https://h/r.git", "main branch", "whitespace"),
+        ("https://h/r.git", "", "must not be empty"),
+    ],
+)
+def test_resolve_source_type_rejects_option_like_git_values(source, ref, message):
+    with pytest.raises(MlflowException, match=message):
+        resolve_source_type(GitSource(url=source, ref=ref))
+    if source.startswith("-"):
+        # A bare string starting with '-' is a local path, so git never sees it.
+        assert resolve_source_type(source).is_local is True
+    else:
+        with pytest.raises(MlflowException, match=message):
+            resolve_source_type(source, ref=ref)
+
+
+@pytest.mark.parametrize(
+    ("url", "message"),
+    [
+        ("https://user:pw@example.com/skills.zip", "publicly accessible"),
+        ("https://token@example.com/skills.zip", "publicly accessible"),
+        ("ftp://example.com/skills.zip", "http\\(s\\) URL"),
+    ],
+)
+def test_resolve_source_type_zip_public_only(url, message):
+    with pytest.raises(MlflowException, match=message):
+        resolve_source_type(url)
+    with pytest.raises(MlflowException, match=message):
+        resolve_source_type(ZipSource(url=url))
+
+
+@pytest.mark.parametrize("source", ["", "   ", None, 5])
+def test_resolve_source_type_rejects_empty(source):
+    with pytest.raises(MlflowException, match="non-empty string"):
+        resolve_source_type(source)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"source": "https://h/r.git", "subpath": "a/" * 1025}, "Subpath is 2049 characters"),
+        ({"source": "https://h/r.git", "ref": "v" * 2049}, "Git ref is 2049 characters"),
+        ({"source": "https://h/" + "a" * 2040 + ".git"}, "Git URL is 2054 characters"),
+        ({"source": "https://h/r.git", "ref": "v\x011"}, "control characters"),
+    ],
+)
+def test_resolve_source_type_enforces_storage_bounds(kwargs, message):
+    # RFC-0008 persists source, ref, and subpath in String(2048) columns.
+    with pytest.raises(MlflowException, match=message):
+        resolve_source_type(**kwargs)
+
+
+def test_resolve_source_type_typed_subpath_bound():
+    with pytest.raises(MlflowException, match="Subpath is 2049 characters"):
+        resolve_source_type(GitSource(url="https://h/r.git", subpath="a/" * 1025))


### PR DESCRIPTION
### Related Issues/PRs

Relates to #22833 and https://github.com/mlflow/rfcs/pull/26 (RFC-0008: MVP Skill Registry).

Builds on #25353, merged into `skill-registry-rfc-0008`, which provides the typed source classes and `_validate_skill_name` this library imports. The OCI registry fetcher is a separate draft, #25744, stacked on this PR.

### What changes are proposed in this pull request?

Adds the private `mlflow.genai.skill_content` package: one tested client implementation for everything in the skill registry that touches skill *content* rather than registry metadata. The later registration, import, introspection, and pull stories all call into it, so content is fetched, checked, and fingerprinted the same way everywhere.

- `digest.py`: the canonical SHA-256 tree digest from the RFC. POSIX relative paths, Unicode NFC, bytewise ordering, unsigned 8-byte big-endian length framing of each path and content, non-regular files excluded. The same tree hashes identically on every OS and regardless of where it was fetched from.
- `skill_md.py`: strict `SKILL.md` frontmatter parsing for `name`, `description`, and `keywords`. Malformed or unclosed frontmatter fails rather than being ignored. The name must be declared in the file, since fetched content lands in an arbitrary temporary directory; import adapters that synthesize names for legacy layouts pass an explicit `fallback_name`.
- `paths.py`: subpath normalization and containment-checked resolution that refuses to traverse symlinks, plus the publication check that rejects symbolic links, hard links, and special files. Drive and stream colons, Windows reserved names, and paths that collide after Unicode normalization or case folding are rejected everywhere, so a tree is accepted or refused the same way on macOS, Linux, and Windows.
- `archive.py`: reproducible gzip-tar packaging of exactly the hashed tree, and validation and extraction for tar and ZIP archives. Unsafe paths and entry types are rejected, entry names survive extraction exactly so the stored tree is what was hashed, file/directory shadowing is refused, tar parsing is streamed over a byte-counting reader so oversized PAX and GNU long-name headers cannot bypass the size limit, and `subpath` acts as a prefix filter so only the requested subtree is extracted and budgeted.
- `sources.py`: typed sources keep their explicit type for later REST submission; plain strings use inference only as a fallback, limited to the RFC table (`.git` suffix, `git://`, `oci://`, `.zip`, MLflow artifact URIs), and ambiguous values fail. `mlflow` and `assembled` stay flow-derived, per RFC amendment mlflow/rfcs#44. Git URLs and refs that look like command-line options, and ZIP URLs that carry credentials, are rejected.
- `fetchers/`: Git (shallow fetch of one ref, no submodules, `.git` removed and verified gone), ZIP (public URLs, streamed with a byte budget, no credentials attached, not even `~/.netrc`), and MLflow artifact sources, plus local folders, all behind one `fetch_source` contract. `oci://` sources resolve to their type but raise a clear "not supported yet" error until #25744 lands. Underlying source errors are preserved with credentials redacted and carry distinct `UNAUTHENTICATED`, `PERMISSION_DENIED`, `TEMPORARILY_UNAVAILABLE`, and `RESOURCE_DOES_NOT_EXIST` codes.
- `MLFLOW_SKILL_CONTENT_MAX_DECOMPRESSED_SIZE` (default 25 MiB) is the single configuration path for the size limit. It bounds the content at or beneath `subpath` (archives extract only that part and Git checkouts are measured there) and each download on the wire.

Nothing is re-exported from `mlflow.genai`, so the public API inventory is unchanged.

One choice worth reviewer attention: the package lives at `mlflow/genai/skill_content/` to stay clear of the `mlflow/genai/skills/` package proposed in #21725.

### How is this PR tested?

- [x] New unit/integration tests

206 tests under `tests/genai/skill_content/`: a digest known-answer literal plus determinism across creation order and OS, framing collision resistance, NFC equivalence, and symlink exclusion; frontmatter edge cases; the subpath and containment matrix including drive-letter and reserved-name paths; tar and ZIP archives with traversal, absolute, backslash, symlink, hard link, FIFO, and device entries, duplicate and colliding names, file/directory shadowing, metadata-header bombs, and size and entry-count limits, encrypted and unsupported-compression ZIP entries, and over-long or non-UTF-8 names; source type inference and typed-source retention with RFC storage bounds; unreadable files surfacing as `PERMISSION_DENIED` and typed-source retention; and end-to-end fetches against a local git repo, a local HTTP server for ZIP (including a netrc-suppression check), and `runs:/` artifacts. Credential redaction is asserted on a failing Git URL.

The ZIP tests carry `@pytest.mark.no_mock_requests_get` because the genai test suite mocks `requests.get` by default.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

Foundational client library on the `skill-registry-rfc-0008` feature branch; the user-facing release note will accompany the umbrella feature when it merges to `master`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`

Skill Registry foundations (`mlflow/genai/skill_content`). No existing component label fits precisely.

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release


