### PR TITLE
Default to `DatabricksSDKModelsArtifactRepository` for UC

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1142,7 +1142,7 @@ _MLFLOW_IN_CAPTURE_MODULE_PROCESS = _BooleanEnvironmentVariable(
 #: eliminate models exfiltration risk associated with temporary scoped token generation used in
 #: existing model artifact repo classes.
 MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC = _BooleanEnvironmentVariable(
-    "MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC", False
+    "MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC", True
 )
 
 #: Disable Databricks SDK for run artifacts. We enable this by default since we want to

--- a/mlflow/utils/_unity_catalog_utils.py
+++ b/mlflow/utils/_unity_catalog_utils.py
@@ -19,8 +19,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
     EmitModelVersionLineageRequest,
     EmitModelVersionLineageResponse,
-    IsDatabricksSdkModelsArtifactRepositoryEnabledRequest,
-    IsDatabricksSdkModelsArtifactRepositoryEnabledResponse,
     ModelVersionLineageInfo,
     SseEncryptionAlgorithm,
     TemporaryCredentials,
@@ -445,29 +443,9 @@ def split_uc_model_name(full_name: str) -> tuple[str, str, str]:
 
 
 def is_databricks_sdk_models_artifact_repository_enabled(host_creds):
-    # Return early if the environment variable is set to use the SDK models artifact repository
-    if MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC.defined:
-        return MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC.get()
-
-    endpoint, method = _METHOD_TO_INFO[IsDatabricksSdkModelsArtifactRepositoryEnabledRequest]
-    req_body = message_to_json(IsDatabricksSdkModelsArtifactRepositoryEnabledRequest())
-    response_proto = IsDatabricksSdkModelsArtifactRepositoryEnabledResponse()
-
-    try:
-        resp = call_endpoint(
-            host_creds=host_creds,
-            endpoint=endpoint,
-            method=method,
-            json_body=req_body,
-            response_proto=response_proto,
-        )
-        return resp.is_databricks_sdk_models_artifact_repository_enabled
-    except Exception as e:
-        _logger.warning(
-            "Failed to confirm if DatabricksSDKModelsArtifactRepository should be used; "
-            f"falling back to default. Error: {e}"
-        )
-    return False
+    # The DatabricksSDKModelsArtifactRepository is used by default. Users can opt out by explicitly
+    # setting MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC to false.
+    return MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC.get()
 
 
 def emit_model_version_lineage(host_creds, name, version, entities, direction):

--- a/tests/store/artifact/test_databricks_sdk_models_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_sdk_models_artifact_repo.py
@@ -1,5 +1,4 @@
 import io
-from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -253,15 +252,15 @@ def test_mlflow_use_databricks_sdk_model_artifacts_repo_for_uc(tmp_path, monkeyp
         )
 
 
-def test_mlflow_use_databricks_sdk_model_artifacts_repo_for_uc_seg(tmp_path, monkeypatch):
+def test_mlflow_use_databricks_sdk_model_artifacts_repo_for_uc_default(tmp_path, monkeypatch):
+    # The SDK models artifact repository is used by default when the env var is not set.
+    monkeypatch.delenv("MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC", raising=False)
     monkeypatch.setenv("DATABRICKS_HOST", "my-host")
     monkeypatch.setenv("DATABRICKS_TOKEN", "my-token")
     with mock.patch(
         "mlflow.utils._unity_catalog_utils.call_endpoint",
         side_effect=[
-            SimpleNamespace(is_databricks_sdk_models_artifact_repository_enabled=True),
             Exception("lineage emission fails"),
-            SimpleNamespace(is_databricks_sdk_models_artifact_repository_enabled=True),
         ],
     ):
         uc_repo = UnityCatalogModelsArtifactRepository("models:/a.b.c/1", "databricks-uc")


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Make the Databricks SDK models artifact repository the default for Unity Catalog by having `MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC` default to `True`. Users can opt out by explicitly setting the variable to `false`.

### How is this PR tested?

Manual tests:
1. Registering / loading models from UCMR
2. Delta sharing

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`DatabricksSDKModelsArtifactRepository` is now used by default for Unity Catalog model artifacts. Set `MLFLOW_USE_DATABRICKS_SDK_MODEL_ARTIFACTS_REPO_FOR_UC=false` to opt out.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release