### PR TITLE
Localize span link UI strings in the redesigned trace explorer

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2495,6 +2495,10 @@
     "defaultMessage": "None",
     "description": "Cell value when there's no content"
   },
+  "8GlhpA": {
+    "defaultMessage": "No attributes",
+    "description": "Empty state shown when a span link has no attributes"
+  },
   "8GmtjT": {
     "defaultMessage": "Clear the search",
     "description": "Link text to clear the search filter on the V2 dataset records list"
@@ -6582,6 +6586,10 @@
   "Op12zG": {
     "defaultMessage": "Assess trace",
     "description": "Accessible label and tooltip for assessing a trace"
+  },
+  "OpP4RM": {
+    "defaultMessage": "Attributes",
+    "description": "Label for the attributes section of a span link"
   },
   "Ortr1x": {
     "defaultMessage": "<link>Add user feedback</link> to traces so real failures stand out",
@@ -11511,6 +11519,10 @@
     "defaultMessage": "To use other providers, create an AI Gateway endpoint and select it.",
     "description": "Hint explaining how to use other providers via Gateway"
   },
+  "ht/qId": {
+    "defaultMessage": "See more",
+    "description": "Button that expands the span link attributes to show all of them"
+  },
   "hv0wlb": {
     "defaultMessage": "Select or create review queues",
     "description": "Add to review queue: destination dropdown label"
@@ -12050,6 +12062,10 @@
   "jkeYf8": {
     "defaultMessage": "Unpin group",
     "description": "A tooltip for the pin icon button in the runs table next to the pinned run group"
+  },
+  "jlGW/p": {
+    "defaultMessage": "Linked span",
+    "description": "Label for the span referenced by a same-trace span link"
   },
   "jo4LfR": {
     "defaultMessage": "Pending",
@@ -13507,6 +13523,10 @@
     "defaultMessage": "Metric",
     "description": "Run page > Overview > Metrics table > Key column header"
   },
+  "pkhZzA": {
+    "defaultMessage": "Span ID",
+    "description": "Label for the span ID of a cross-trace span link"
+  },
   "pl1bdY": {
     "defaultMessage": "Registered Models",
     "description": "Text for link back to models page under the header on the model version\n             view page"
@@ -14154,6 +14174,10 @@
   "sEheG0": {
     "defaultMessage": "Key Name",
     "description": "Key name label"
+  },
+  "sFqnju": {
+    "defaultMessage": "Trace ID",
+    "description": "Label for the trace ID of a cross-trace span link"
   },
   "sGXhV4": {
     "defaultMessage": "Welcome to MLflow",
@@ -14855,6 +14879,10 @@
     "defaultMessage": "This column contains all models logged or evaluated by the run. Click into an individual run to see more detailed information about all models associated with it.",
     "description": "A descriptive tooltip for the \"Models\" column header in the runs table on the MLflow experiment detail page"
   },
+  "vVsrrj": {
+    "defaultMessage": "See less",
+    "description": "Button that collapses the span link attributes back to the first few"
+  },
   "vWf6fP": {
     "defaultMessage": "Processing",
     "description": "Processing indicator while Assistant is streaming a response"
@@ -15218,6 +15246,10 @@
   "wx0s66": {
     "defaultMessage": "Select a provider and model to configure API key",
     "description": "Message when no provider selected for API key form"
+  },
+  "wxlu/9": {
+    "defaultMessage": "Jump to linked span",
+    "description": "Button that navigates to the span referenced by a span link"
   },
   "wxq/qM": {
     "defaultMessage": "Set as baseline",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -2,7 +2,7 @@ import { isNil } from 'lodash';
 import { useMemo, useState } from 'react';
 
 import { Button, Card, NewWindowIcon, Tag, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
-import { useIntl } from '@databricks/i18n';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
 
 import type { ModelTraceSpanLink, ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
 import { getIconTypeForSpan, getLinkFieldKey, getSpanExceptionCount } from '../ModelTraceExplorer.utils';
@@ -95,7 +95,10 @@ const SpanLinkEntry = ({
       disabled={!linkedSpan || !onSelectSpan}
       onClick={onSelectSpan}
     >
-      Jump to linked span
+      <FormattedMessage
+        defaultMessage="Jump to linked span"
+        description="Button that navigates to the span referenced by a span link"
+      />
     </Button>
   ) : (
     <Button
@@ -107,7 +110,10 @@ const SpanLinkEntry = ({
       endIcon={<NewWindowIcon css={{ fontSize: 12 }} />}
       css={jumpButtonCss}
     >
-      Jump to linked span
+      <FormattedMessage
+        defaultMessage="Jump to linked span"
+        description="Button that navigates to the span referenced by a span link"
+      />
     </Button>
   );
 
@@ -133,7 +139,12 @@ const SpanLinkEntry = ({
         <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm, minWidth: 0 }}>
           {!isSameTrace && (
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Hint>Trace ID</Typography.Hint>
+              <Typography.Hint>
+                <FormattedMessage
+                  defaultMessage="Trace ID"
+                  description="Label for the trace ID of a cross-trace span link"
+                />
+              </Typography.Hint>
               <CopyableIdTag
                 id={link.trace_id}
                 copyTooltip={intl.formatMessage({
@@ -145,7 +156,12 @@ const SpanLinkEntry = ({
           )}
           {linkedSpan ? (
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Hint>Linked span</Typography.Hint>
+              <Typography.Hint>
+                <FormattedMessage
+                  defaultMessage="Linked span"
+                  description="Label for the span referenced by a same-trace span link"
+                />
+              </Typography.Hint>
               <div css={{ alignItems: 'center', display: 'flex', gap: theme.spacing.sm, minWidth: 0 }}>
                 <ModelTraceExplorerIcon
                   type={getIconTypeForSpan(linkedSpan.type ?? '')}
@@ -156,7 +172,12 @@ const SpanLinkEntry = ({
             </div>
           ) : (
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Hint>Span ID</Typography.Hint>
+              <Typography.Hint>
+                <FormattedMessage
+                  defaultMessage="Span ID"
+                  description="Label for the span ID of a cross-trace span link"
+                />
+              </Typography.Hint>
               <CopyableIdTag
                 id={link.span_id}
                 copyTooltip={intl.formatMessage({
@@ -179,7 +200,9 @@ const SpanLinkEntry = ({
           paddingTop: theme.spacing.md,
         }}
       >
-        <Typography.Hint>Attributes</Typography.Hint>
+        <Typography.Hint>
+          <FormattedMessage defaultMessage="Attributes" description="Label for the attributes section of a span link" />
+        </Typography.Hint>
         {attributeEntries.length > 0 ? (
           <>
             {visibleAttributeEntries.map(([key, value]) => (
@@ -205,12 +228,27 @@ const SpanLinkEntry = ({
                 css={{ alignSelf: 'flex-start' }}
                 onClick={() => setShowAllAttributes((value) => !value)}
               >
-                {showAllAttributes ? 'See less' : 'See more'}
+                {showAllAttributes ? (
+                  <FormattedMessage
+                    defaultMessage="See less"
+                    description="Button that collapses the span link attributes back to the first few"
+                  />
+                ) : (
+                  <FormattedMessage
+                    defaultMessage="See more"
+                    description="Button that expands the span link attributes to show all of them"
+                  />
+                )}
               </Button>
             )}
           </>
         ) : (
-          <Typography.Hint>No attributes</Typography.Hint>
+          <Typography.Hint>
+            <FormattedMessage
+              defaultMessage="No attributes"
+              description="Empty state shown when a span link has no attributes"
+            />
+          </Typography.Hint>
         )}
       </div>
     </Card>


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25573

Follow-up to #25573, which added the span link UI to the redesigned (v2) trace explorer. That PR rendered several of the Links tab's user-facing labels as hardcoded English, while the sibling tab components (e.g. `ModelTraceExplorerAttributesTab`, `ModelTraceExplorerEventsTab`) wrap their strings in `FormattedMessage`.

### What changes are proposed in this pull request?

Wrap the hardcoded, user-facing strings in `ModelTraceExplorerLinksTab.tsx` in `FormattedMessage` so they are extracted into the message catalog and localized like the rest of the trace explorer:

- `Jump to linked span` (both the same-trace and cross-trace buttons)
- `Trace ID`, `Span ID`, `Linked span` labels
- `Attributes` / `No attributes` section labels
- `See more` / `See less` attribute toggle

The default message catalog (`en.json`) is regenerated via `yarn i18n`. No behavior changes — only the string wrapping. The copy tooltips in the same file were already localized in #25573 and are unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The existing `ModelTraceExplorerLinksTab.test.tsx` and `TimelineTreeNode.test.tsx` suites pass unchanged (they query by rendered text/role, which `FormattedMessage` produces identically under `IntlProvider locale="en"`). `yarn lint`, `yarn prettier:check`, `yarn type-check`, and `yarn i18n:check` all pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release