### PR TITLE
Cherry-pick span link UI + i18n to branch-3.16 (#25573, #25580)

### DIFF
--- a/mlflow/server/js/scripts/componentId-registry.js
+++ b/mlflow/server/js/scripts/componentId-registry.js
@@ -1795,6 +1795,10 @@ module.exports = {
   "mlflow.model_trace_explorer.header_details.tag-session-id": "",
   "mlflow.model_trace_explorer.linked_prompts.prompt_link": "",
   "mlflow.model_trace_explorer.span_link": "",
+  "mlflow.model_trace_explorer.span_link.attributes_toggle": "",
+  "mlflow.model_trace_explorer.span_link.card": "",
+  "mlflow.model_trace_explorer.span_link.id": "",
+  "mlflow.model_trace_explorer.span_link.id_tooltip": "",
   "mlflow.model_trace_explorer.span_link.tooltip": "",
   "mlflow.model_trace_explorer.timeline.gateway_trace_link": "",
 
@@ -2351,6 +2355,7 @@ module.exports = {
   "shared.model-trace-explorer.span-cost-hovercard.input-cost.tag": "",
   "shared.model-trace-explorer.span-cost-hovercard.output-cost.tag": "",
   "shared.model-trace-explorer.span-cost-hovercard.total-cost.tag": "",
+  "shared.model-trace-explorer.span-link-count": "",
   "shared.model-trace-explorer.span-model-badge": "",
   "shared.model-trace-explorer.span-name-tag": "",
   "shared.model-trace-explorer.span-name-tooltip": "",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2495,6 +2495,10 @@
     "defaultMessage": "None",
     "description": "Cell value when there's no content"
   },
+  "8GlhpA": {
+    "defaultMessage": "No attributes",
+    "description": "Empty state shown when a span link has no attributes"
+  },
   "8GmtjT": {
     "defaultMessage": "Clear the search",
     "description": "Link text to clear the search filter on the V2 dataset records list"
@@ -6582,6 +6586,10 @@
   "Op12zG": {
     "defaultMessage": "Assess trace",
     "description": "Accessible label and tooltip for assessing a trace"
+  },
+  "OpP4RM": {
+    "defaultMessage": "Attributes",
+    "description": "Label for the attributes section of a span link"
   },
   "Ortr1x": {
     "defaultMessage": "<link>Add user feedback</link> to traces so real failures stand out",
@@ -11511,6 +11519,10 @@
     "defaultMessage": "To use other providers, create an AI Gateway endpoint and select it.",
     "description": "Hint explaining how to use other providers via Gateway"
   },
+  "ht/qId": {
+    "defaultMessage": "See more",
+    "description": "Button that expands the span link attributes to show all of them"
+  },
   "hv0wlb": {
     "defaultMessage": "Select or create review queues",
     "description": "Add to review queue: destination dropdown label"
@@ -12050,6 +12062,10 @@
   "jkeYf8": {
     "defaultMessage": "Unpin group",
     "description": "A tooltip for the pin icon button in the runs table next to the pinned run group"
+  },
+  "jlGW/p": {
+    "defaultMessage": "Linked span",
+    "description": "Label for the span referenced by a same-trace span link"
   },
   "jo4LfR": {
     "defaultMessage": "Pending",
@@ -13507,6 +13523,10 @@
     "defaultMessage": "Metric",
     "description": "Run page > Overview > Metrics table > Key column header"
   },
+  "pkhZzA": {
+    "defaultMessage": "Span ID",
+    "description": "Label for the span ID of a cross-trace span link"
+  },
   "pl1bdY": {
     "defaultMessage": "Registered Models",
     "description": "Text for link back to models page under the header on the model version\n             view page"
@@ -14154,6 +14174,10 @@
   "sEheG0": {
     "defaultMessage": "Key Name",
     "description": "Key name label"
+  },
+  "sFqnju": {
+    "defaultMessage": "Trace ID",
+    "description": "Label for the trace ID of a cross-trace span link"
   },
   "sGXhV4": {
     "defaultMessage": "Welcome to MLflow",
@@ -14855,6 +14879,10 @@
     "defaultMessage": "This column contains all models logged or evaluated by the run. Click into an individual run to see more detailed information about all models associated with it.",
     "description": "A descriptive tooltip for the \"Models\" column header in the runs table on the MLflow experiment detail page"
   },
+  "vVsrrj": {
+    "defaultMessage": "See less",
+    "description": "Button that collapses the span link attributes back to the first few"
+  },
   "vWf6fP": {
     "defaultMessage": "Processing",
     "description": "Processing indicator while Assistant is streaming a response"
@@ -15218,6 +15246,10 @@
   "wx0s66": {
     "defaultMessage": "Select a provider and model to configure API key",
     "description": "Message when no provider selected for API key form"
+  },
+  "wxlu/9": {
+    "defaultMessage": "Jump to linked span",
+    "description": "Button that navigates to the span referenced by a span link"
   },
   "wxq/qM": {
     "defaultMessage": "Set as baseline",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -4979,6 +4979,10 @@
     "defaultMessage": "{count, plural, one {1 trace selected} other {# traces selected}}",
     "description": "Label showing number of traces selected"
   },
+  "IQOP18": {
+    "defaultMessage": "Copy span ID",
+    "description": "Tooltip for copying a linked span ID"
+  },
   "ISy30V": {
     "defaultMessage": "Are you sure you want to delete the dataset \"{name}\"? This action cannot be undone.",
     "description": "Body for the V2 evaluation dataset delete confirmation modal"
@@ -7922,6 +7926,10 @@
   "UScoKM": {
     "defaultMessage": "No questions defined for this experiment yet.",
     "description": "Manage review questions: empty state"
+  },
+  "UW6FuF": {
+    "defaultMessage": "Copy trace ID",
+    "description": "Tooltip for copying a linked trace ID"
   },
   "UWHfmZ": {
     "defaultMessage": "Group:",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -44,6 +44,7 @@ import {
   getTraceCost,
   convertOtelAttributesToMap,
   decodeLinkTraceId,
+  getTraceHref,
   isSessionLevelAssessment,
   createTraceV4SerializedLocation,
   parseTraceV4SerializedLocation,
@@ -1440,6 +1441,15 @@ describe('decodeLinkTraceId', () => {
   it('should return an empty string for nullish input', () => {
     expect(decodeLinkTraceId(undefined)).toBe('');
     expect(decodeLinkTraceId(null)).toBe('');
+  });
+});
+
+describe('getTraceHref', () => {
+  it('uses only the canonical trace ID query parameter', () => {
+    const href = getTraceHref('tr-linked', MOCK_TRACE_INFO_V3);
+
+    expect(href).toContain('traceId=tr-linked');
+    expect(href).not.toContain('selectedEvaluationId');
   });
 });
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -687,10 +687,7 @@ export const getTraceHref = (traceId: string, traceInfo: ModelTrace['info'] | un
   }
 
   if (!experimentId) return undefined;
-  const params = new URLSearchParams({
-    selectedEvaluationId: traceId,
-    traceId,
-  });
+  const params = new URLSearchParams({ traceId });
   return `${getExperimentPageTracesTabRoute(experimentId)}?${params.toString()}`;
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerBadge.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerBadge.tsx
@@ -1,7 +1,14 @@
 import { useDesignSystemTheme } from '@databricks/design-system';
 
-export function ModelTraceExplorerBadge({ count }: { count: number }) {
+export function ModelTraceExplorerBadge({
+  count,
+  variant = 'danger',
+}: {
+  count: number;
+  variant?: 'danger' | 'neutral';
+}) {
   const { theme } = useDesignSystemTheme();
+  const isNeutral = variant === 'neutral';
 
   return (
     <div
@@ -11,13 +18,19 @@ export function ModelTraceExplorerBadge({ count }: { count: number }) {
         justifyContent: 'center',
         borderRadius: theme.typography.fontSizeBase,
         height: theme.typography.fontSizeBase,
-        backgroundColor: theme.colors.actionDangerPrimaryBackgroundDefault,
+        backgroundColor: isNeutral
+          ? theme.colors.backgroundSecondary
+          : theme.colors.actionDangerPrimaryBackgroundDefault,
         padding: theme.spacing.xs,
         marginLeft: theme.spacing.xs,
         boxSizing: 'border-box',
       }}
     >
-      <span css={{ color: theme.colors.actionPrimaryTextDefault, fontSize: 11 }}>{count}</span>
+      <span
+        css={{ color: isNeutral ? theme.colors.textSecondary : theme.colors.actionPrimaryTextDefault, fontSize: 11 }}
+      >
+        {count}
+      </span>
     </div>
   );
 }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/RoutingUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/RoutingUtils.tsx
@@ -16,6 +16,7 @@ import React, { useCallback, useMemo } from 'react';
 import {
   generatePath,
   useParams as useParamsDirect,
+  useHref as useHrefDirect,
   Link as LinkDirect,
   useLocation as useLocationDirect,
   BrowserRouter,
@@ -228,6 +229,8 @@ const useParams = useParamsDirect;
 
 const useLocation = useLocationDirect;
 
+const useHref = (to: To) => useHrefDirect(prefixRouteWithWorkspaceForTo(to));
+
 const Link = React.forwardRef<
   HTMLAnchorElement,
   ComponentProps<typeof LinkDirect> & { disableWorkspacePrefix?: boolean; componentId: string }
@@ -256,4 +259,4 @@ export const createMLflowRoutePath = (routePath: string) => {
   return routePath;
 };
 
-export { generatePath, useParams, Link, useLocation, BrowserRouter };
+export { generatePath, useParams, Link, useLocation, useHref, BrowserRouter };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTrace.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTrace.types.ts
@@ -75,6 +75,7 @@ export type ModelTraceSpanV2 = {
   outputs?: any;
   attributes?: Record<string, any>;
   events?: ModelTraceEvent[];
+  links?: ModelTraceSpanLink[];
   /* metadata for ui usage logging */
   type?: ModelSpanType;
 };
@@ -95,6 +96,7 @@ export type ModelTraceSpanV3 = {
   };
   attributes: Record<string, any>;
   events?: ModelTraceEvent[];
+  links?: ModelTraceSpanLink[];
   /* metadata for ui usage logging */
   type?: ModelSpanType;
 };
@@ -114,6 +116,7 @@ export type ModelTraceSpanV4 = {
   }>;
   status: { code: ModelSpanStatusCode };
   events?: ModelTraceEvent[];
+  links?: ModelTraceSpanLink[];
   /* metadata for ui usage logging */
   type?: ModelSpanType;
 };
@@ -126,6 +129,12 @@ export type ModelTraceEvent = {
   timestamp?: number;
   time_unix_nano?: number;
   attributes?: Record<string, any>;
+};
+
+export type ModelTraceSpanLink = {
+  trace_id: string;
+  span_id: string;
+  attributes?: Record<string, any> | null;
 };
 
 export type ModelTraceData = {
@@ -345,7 +354,8 @@ export interface SpanCostInfo {
 /**
  * Represents a single node in the model trace tree.
  */
-export interface ModelTraceSpanNode extends TimelineTreeNode, Pick<ModelTraceSpan, 'attributes' | 'type' | 'events'> {
+export interface ModelTraceSpanNode
+  extends TimelineTreeNode, Pick<ModelTraceSpan, 'attributes' | 'type' | 'events' | 'links'> {
   assessments: Assessment[];
   inputs?: any;
   outputs?: any;
@@ -361,7 +371,7 @@ export interface ModelTraceSpanNode extends TimelineTreeNode, Pick<ModelTraceSpa
   tokenUsage?: SpanTokenUsage;
 }
 
-export type ModelTraceExplorerTab = 'content' | 'attributes' | 'events';
+export type ModelTraceExplorerTab = 'content' | 'attributes' | 'events' | 'links';
 
 /** The top-level view tabs in the trace panel. */
 export type ModelTraceExplorerView = 'detail' | 'prompts' | 'custom';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorer.utils.test.tsx
@@ -417,6 +417,33 @@ describe('getMatchesFromSpan', () => {
 
     expect(getMatchesFromSpan(spanNode, 'no-match')).toHaveLength(0);
   });
+
+  it('finds matches in span link attributes', () => {
+    const spanNode: ModelTraceSpanNode = {
+      key: 'test',
+      title: 'test',
+      attributes: {},
+      links: [
+        {
+          trace_id: 'tr-linked',
+          span_id: 'linked-span',
+          attributes: { relationship: 'triggered_by' },
+        },
+      ],
+      start: 0,
+      end: 1,
+      type: ModelSpanType.UNKNOWN,
+      assessments: [],
+      traceId: 'test',
+    };
+
+    expect(getMatchesFromSpan(spanNode, 'relationship')).toEqual([
+      expect.objectContaining({ section: 'links', key: 'link-0-relationship', isKeyMatch: true }),
+    ]);
+    expect(getMatchesFromSpan(spanNode, 'triggered')).toEqual([
+      expect.objectContaining({ section: 'links', key: 'link-0-relationship', isKeyMatch: false }),
+    ]);
+  });
 });
 
 describe('normalizeConversation', () => {
@@ -625,6 +652,15 @@ describe('isModelTraceChatTool', () => {
 });
 
 describe('normalizeNewSpanData', () => {
+  it('preserves span links', () => {
+    const links = [{ trace_id: 'tr-linked', span_id: 'linked-span', attributes: { relationship: 'follows_from' } }];
+    const span = { ...MOCK_V3_SPANS[0], links };
+
+    const normalized = normalizeNewSpanData(span, 0, 0, [], {}, 'tr-current');
+
+    expect(normalized.links).toEqual(links);
+  });
+
   it('should process messages and tools if not contained in attributes', () => {
     const modifiedChatInput = {
       ...MOCK_CHAT_TOOL_CALL_SPAN,
@@ -1463,6 +1499,29 @@ describe('convertOtelAttributesToMap', () => {
       span_id: '1',
       events: [{ attributes: { converted: 'value' } }],
     });
+  });
+
+  it('should decode span links and their attributes', () => {
+    const modelTraceSpan = {
+      span_id: '1',
+      links: [
+        {
+          trace_id: 'AQIDBAUGBwgJCgsMDQ4PEA==',
+          span_id: 'AQIDBAUGBwg=',
+          attributes: [{ key: 'relationship', value: { string_value: 'follows_from' } }],
+        },
+      ],
+    } as any;
+
+    const result = convertOtelAttributesToMap(modelTraceSpan);
+
+    expect(result.links).toEqual([
+      {
+        trace_id: 'tr-0102030405060708090a0b0c0d0e0f10',
+        span_id: '0102030405060708',
+        attributes: { relationship: 'follows_from' },
+      },
+    ]);
   });
 
   // Regression: chat inputs/outputs (mlflow.spanInputs / mlflow.spanOutputs) arrive

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorer.utils.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lodash';
 
 import Utils from '../../../../common/utils/Utils';
+import { decodeLinkTraceId } from '../ModelTraceExplorer.utils';
 
 import type {
   SearchMatch,
@@ -34,6 +35,8 @@ import type {
   Assessment,
   RetrieverDocument,
   ModelTraceEvent,
+  ModelTraceSpanLink,
+  ModelTraceExplorerTab,
 } from './ModelTrace.types';
 import { ModelSpanType, ModelIconType, MLFLOW_TRACE_SCHEMA_VERSION_KEY, type SpanCostInfo } from './ModelTrace.types';
 import { ModelTraceExplorerIcon } from './ModelTraceExplorerIcon';
@@ -221,6 +224,39 @@ export const getMatchesFromEvent = (span: ModelTraceSpanNode, searchFilter: stri
   return matches;
 };
 
+export const getLinkFieldKey = (index: number, field: string): string => {
+  return `link-${index}-${field}`;
+};
+
+const getMatchesFromLinks = (span: ModelTraceSpanNode, searchFilter: string): SearchMatch[] => {
+  const links = span.links;
+  if (!links) {
+    return [];
+  }
+
+  const matches: SearchMatch[] = [];
+  links.forEach((link, index) => {
+    const attributes = link.attributes;
+    if (!attributes || Object.keys(attributes).length === 0) return;
+
+    Object.entries(attributes).forEach(([attributeKey, attributeValue]) => {
+      const key = getLinkFieldKey(index, attributeKey);
+      const isKeyMatch = attributeKey.toLowerCase().includes(searchFilter);
+      if (isKeyMatch) {
+        matches.push({ span, section: 'links', key, isKeyMatch: true, matchIndex: 0 });
+      }
+
+      const value = JSON.stringify(attributeValue, null, 2).toLowerCase();
+      const numValueMatches = value.split(searchFilter).length - 1;
+      for (let i = 0; i < numValueMatches; i++) {
+        matches.push({ span, section: 'links', key, isKeyMatch: false, matchIndex: i });
+      }
+    });
+  });
+
+  return matches;
+};
+
 /**
  * This function extracts all the matches from a span based on the search filter,
  * and appends some necessary metadata that is necessary for the jump-to-search
@@ -240,11 +276,16 @@ export const getMatchesFromSpan = (span: ModelTraceSpanNode, searchFilter: strin
     outputs: span?.outputs,
     attributes: span?.attributes,
     events: span?.events,
+    links: span?.links,
   };
 
-  map(sections, (section: any, label: 'inputs' | 'outputs' | 'attributes' | 'events') => {
+  map(sections, (section: any, label: 'inputs' | 'outputs' | 'attributes' | 'events' | 'links') => {
     if (label === 'events') {
       matches.push(...getMatchesFromEvent(span, searchFilter));
+      return;
+    }
+    if (label === 'links') {
+      matches.push(...getMatchesFromLinks(span, searchFilter));
       return;
     }
 
@@ -525,6 +566,7 @@ export const normalizeNewSpanData = (
     (value) => tryDeserializeAttribute(value),
   );
   const events = span.events;
+  const links = span.links;
   const start = (Number(getModelTraceSpanStartTime(span)) - rootStartTime) / 1000;
   const end = (Number(getModelTraceSpanEndTime(span) ?? rootEndTime) - rootStartTime) / 1000;
 
@@ -546,6 +588,7 @@ export const normalizeNewSpanData = (
     outputs,
     attributes,
     events,
+    links,
     chatMessageFormat: messageFormat,
     chatMessages,
     chatTools,
@@ -1108,9 +1151,7 @@ export const normalizeConversation = (input: any, messageFormat?: string): Model
 
 export { prettyPrintChatMessage, prettyPrintToolCall };
 
-export const getDefaultActiveTab = (
-  selectedNode: ModelTraceSpanNode | undefined,
-): 'content' | 'attributes' | 'events' => {
+export const getDefaultActiveTab = (selectedNode: ModelTraceSpanNode | undefined): ModelTraceExplorerTab => {
   if (isNil(selectedNode)) {
     return 'content';
   }
@@ -1164,6 +1205,13 @@ export const convertOtelAttributesToMap = (modelTraceSpan: ModelTraceSpan): Mode
     );
   };
 
+  const convertLink = (link: ModelTraceSpanLink): ModelTraceSpanLink => ({
+    ...link,
+    trace_id: decodeLinkTraceId(link.trace_id),
+    span_id: decodeSpanId(link.span_id, true),
+    ...(link.attributes && { attributes: convertAttributes(link.attributes) }),
+  });
+
   return {
     ...modelTraceSpan,
     ...(modelTraceSpan.attributes && { attributes: convertAttributes(modelTraceSpan.attributes) }),
@@ -1173,6 +1221,7 @@ export const convertOtelAttributesToMap = (modelTraceSpan: ModelTraceSpan): Mode
         attributes: convertAttributes(event.attributes),
       })),
     }),
+    ...(modelTraceSpan.links && { links: modelTraceSpan.links.map(convertLink) }),
   };
 };
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorerDetailView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorerDetailView.tsx
@@ -129,6 +129,7 @@ export const ModelTraceExplorerDetailView = ({
 
   const {
     rootNode,
+    nodeMap,
     activeTab,
     setActiveTab,
     showGraph,
@@ -167,12 +168,11 @@ export const ModelTraceExplorerDetailView = ({
 
   // The shared useModelTraceSearch hook drives node selection and tab activation together via a
   // single setSelectedNodeAndTab callback. v2's view state keeps these as separate setters, so
-  // bridge them here. The shared tab union carries 'chat' and 'links' tabs that v2 does not
-  // surface separately, so fold those onto 'content'.
+  // bridge them here. The shared tab union carries a separate chat tab that v2 renders as content.
   const setSearchSelectedNodeAndTab = useCallback(
     (node: ModelTraceSpanNode, tab: SharedModelTraceExplorerTab) => {
       setSelectedNode(node);
-      setActiveTab(tab === 'chat' || tab === 'links' ? 'content' : tab);
+      setActiveTab(tab === 'chat' ? 'content' : tab);
     },
     [setSelectedNode, setActiveTab],
   );
@@ -309,12 +309,25 @@ export const ModelTraceExplorerDetailView = ({
     }
   }, [isSearchVisible, setSearchFilter]);
 
-  const onSelectNode = (node?: ModelTraceSpanNode) => {
-    setSelectedNode(node);
-    if (isString(node?.key)) {
-      onSelectSpan?.(node?.key);
-    }
-  };
+  const onSelectNode = useCallback(
+    (node?: ModelTraceSpanNode) => {
+      setSelectedNode(node);
+      if (isString(node?.key)) {
+        onSelectSpan?.(node.key);
+      }
+    },
+    [onSelectSpan, setSelectedNode],
+  );
+
+  const handleSelectLinkedSpan = useCallback(
+    (spanId: string) => {
+      const linkedSpan = nodeMap[spanId];
+      if (linkedSpan) {
+        onSelectNode(linkedSpan);
+      }
+    },
+    [nodeMap, onSelectNode],
+  );
 
   useLayoutEffect(() => {
     const list = values(getTimelineTreeNodesMap(filteredTreeNodes, DEFAULT_EXPAND_DEPTH)).map((node) => node.key);
@@ -511,6 +524,7 @@ export const ModelTraceExplorerDetailView = ({
             activeMatch={matchData.match}
             activeTab={activeTab}
             setActiveTab={setActiveTab}
+            onSelectSpan={handleSelectLinkedSpan}
           />
         }
         rightMinWidth={RIGHT_PANE_MIN_WIDTH}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorerViewStateContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/ModelTraceExplorerViewStateContext.tsx
@@ -202,7 +202,9 @@ export const ModelTraceExplorerViewStateProvider = ({
 
   useEffect(() => {
     const defaultActiveTab = getDefaultActiveTab(selectedNode);
-    setActiveTab(defaultActiveTab);
+    setActiveTab((currentTab) =>
+      currentTab === 'links' && (selectedNode?.links?.length ?? 0) > 0 ? currentTab : defaultActiveTab,
+    );
   }, [selectedNode]);
 
   const value = useMemo(

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerLinksTab.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerLinksTab.test.tsx
@@ -1,0 +1,248 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { HashRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+
+import { DesignSystemProvider } from '@databricks/design-system';
+import { IntlProvider } from '@databricks/i18n';
+
+import { QueryClient, QueryClientProvider } from '../../../query-client/queryClient';
+import { MOCK_SPAN_LINKS } from '../../ModelTraceExplorer.test-utils';
+import type { ModelTraceSpanNode } from '../ModelTrace.types';
+import { ModelSpanType } from '../ModelTrace.types';
+import { ModelTraceExplorerLinksTab } from './ModelTraceExplorerLinksTab';
+
+const mockClipboardCopy = jest.fn();
+
+jest.mock('use-clipboard-copy', () => ({
+  useClipboard: () => ({ copy: mockClipboardCopy }),
+}));
+
+const mockUseSpanLinkHrefs = jest.fn((traceIds: string[]) => {
+  const hrefs: Record<string, string> = {};
+  for (const traceId of traceIds) {
+    hrefs[traceId] = `/experiments/1/traces?traceId=${traceId}`;
+  }
+  return hrefs;
+});
+
+jest.mock('../../hooks/useSpanLinkHref', () => ({
+  useSpanLinkHrefs: (traceIds: string[]) => mockUseSpanLinkHrefs(traceIds),
+}));
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient();
+  return (
+    <IntlProvider locale="en">
+      <DesignSystemProvider>
+        <QueryClientProvider client={queryClient}>
+          <HashRouter>{children}</HashRouter>
+        </QueryClientProvider>
+      </DesignSystemProvider>
+    </IntlProvider>
+  );
+};
+
+const createSpan = (overrides: Partial<ModelTraceSpanNode> = {}): ModelTraceSpanNode => ({
+  key: 'span-with-links',
+  title: 'Span with links',
+  start: 0,
+  end: 1000,
+  attributes: {},
+  type: ModelSpanType.FUNCTION,
+  assessments: [],
+  traceId: 'tr-current',
+  ...overrides,
+});
+
+describe('ModelTraceExplorerLinksTab', () => {
+  afterEach(() => {
+    window.localStorage.removeItem('mlflow.activeWorkspace');
+    mockClipboardCopy.mockClear();
+    mockUseSpanLinkHrefs.mockImplementation((traceIds: string[]) => {
+      const hrefs: Record<string, string> = {};
+      for (const traceId of traceIds) {
+        hrefs[traceId] = `/experiments/1/traces?traceId=${traceId}`;
+      }
+      return hrefs;
+    });
+  });
+
+  it('renders link details in simple cards', () => {
+    const span = createSpan({ links: MOCK_SPAN_LINKS });
+
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByText('abc123de')).toBeInTheDocument();
+    expect(screen.getByText('789xyz00')).toBeInTheDocument();
+    expect(screen.queryByText(MOCK_SPAN_LINKS[0].trace_id)).not.toBeInTheDocument();
+    expect(screen.queryByText(MOCK_SPAN_LINKS[1].trace_id)).not.toBeInTheDocument();
+    expect(screen.getByText('aabbccdd')).toBeInTheDocument();
+    expect(screen.getByText('11223344')).toBeInTheDocument();
+    expect(screen.queryByText(MOCK_SPAN_LINKS[0].span_id)).not.toBeInTheDocument();
+    expect(screen.getAllByText('Trace ID')).toHaveLength(2);
+    expect(screen.getAllByText('Span ID')).toHaveLength(2);
+    expect(screen.getByText('relationship')).toBeInTheDocument();
+  });
+
+  it('links to a resolved trace', () => {
+    const span = createSpan({ links: [MOCK_SPAN_LINKS[0]] });
+
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByRole('link', { name: 'Jump to linked span' })).toHaveAttribute(
+      'href',
+      `#/experiments/1/traces?traceId=${MOCK_SPAN_LINKS[0].trace_id}`,
+    );
+    expect(screen.getByRole('link', { name: 'Jump to linked span' })).toHaveAttribute('target', '_blank');
+  });
+
+  it('preserves the active workspace in a linked trace URL', () => {
+    window.localStorage.setItem('mlflow.activeWorkspace', 'workspace-a');
+    const span = createSpan({ links: [MOCK_SPAN_LINKS[0]] });
+
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByRole('link', { name: 'Jump to linked span' })).toHaveAttribute(
+      'href',
+      `#/experiments/1/traces?traceId=${MOCK_SPAN_LINKS[0].trace_id}&workspace=workspace-a`,
+    );
+  });
+
+  it('copies the full linked trace and span IDs from their pills', async () => {
+    const span = createSpan({ links: [MOCK_SPAN_LINKS[0]] });
+
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, {
+      wrapper: Wrapper,
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'abc123de' }));
+    expect(mockClipboardCopy).toHaveBeenLastCalledWith(MOCK_SPAN_LINKS[0].trace_id);
+
+    await userEvent.click(screen.getByRole('button', { name: 'aabbccdd' }));
+    expect(mockClipboardCopy).toHaveBeenLastCalledWith(MOCK_SPAN_LINKS[0].span_id);
+  });
+
+  it('selects a linked span in the current trace without opening a new tab', async () => {
+    const onSelectSpan = jest.fn();
+    const linkedSpanId = 'linked-span';
+    const linkedSpan = createSpan({
+      key: linkedSpanId,
+      title: 'Retrieve order context',
+      type: ModelSpanType.RETRIEVER,
+    });
+    const span = createSpan({
+      links: [{ trace_id: 'tr-current', span_id: linkedSpanId }],
+    });
+
+    render(
+      <ModelTraceExplorerLinksTab
+        activeSpan={span}
+        searchFilter=""
+        activeMatch={null}
+        onSelectSpan={onSelectSpan}
+        spanNodes={{ [linkedSpanId]: linkedSpan }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.queryByText('Trace ID')).not.toBeInTheDocument();
+    expect(screen.queryByText('current')).not.toBeInTheDocument();
+    expect(screen.getByText('Retrieve order context')).toBeInTheDocument();
+    expect(screen.queryByText(linkedSpanId)).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Jump to linked span' }));
+
+    expect(onSelectSpan).toHaveBeenCalledWith(linkedSpanId);
+  });
+
+  it('disables same-trace navigation when the linked span is unavailable', () => {
+    const span = createSpan({
+      links: [{ trace_id: 'tr-current', span_id: 'missing-span' }],
+    });
+
+    render(
+      <ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} onSelectSpan={jest.fn()} />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByRole('button', { name: 'Jump to linked span' })).toBeDisabled();
+  });
+
+  it('shows the first three attributes and expands the rest', async () => {
+    const span = createSpan({
+      links: [
+        {
+          trace_id: 'tr-linked',
+          span_id: 'linked-span',
+          attributes: { first: 1, second: 2, third: 3, fourth: 4 },
+        },
+      ],
+    });
+
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByText('first')).toBeInTheDocument();
+    expect(screen.getByText('third')).toBeInTheDocument();
+    expect(screen.queryByText('fourth')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'See more' }));
+
+    expect(screen.getByText('fourth')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'See less' }));
+    expect(screen.queryByText('fourth')).not.toBeInTheDocument();
+  });
+
+  it('shows an active search match beyond the first three attributes', () => {
+    const span = createSpan({
+      links: [
+        {
+          trace_id: 'tr-linked',
+          span_id: 'linked-span',
+          attributes: { first: 1, second: 2, third: 3, fourth: 4 },
+        },
+      ],
+    });
+
+    render(
+      <ModelTraceExplorerLinksTab
+        activeSpan={span}
+        searchFilter="fourth"
+        activeMatch={{ span, section: 'links', key: 'link-0-fourth', isKeyMatch: true, matchIndex: 0 }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText('fourth')).toBeInTheDocument();
+  });
+
+  it('renders an unresolved trace with a disabled jump button', () => {
+    mockUseSpanLinkHrefs.mockReturnValue({});
+    const span = createSpan({ links: [MOCK_SPAN_LINKS[0]] });
+
+    render(<ModelTraceExplorerLinksTab activeSpan={span} searchFilter="" activeMatch={null} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByText('abc123de')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Jump to linked span' })).toBeDisabled();
+  });
+
+  it('renders nothing when a span has no links', () => {
+    const { container } = render(
+      <ModelTraceExplorerLinksTab activeSpan={createSpan()} searchFilter="" activeMatch={null} />,
+      { wrapper: Wrapper },
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -1,0 +1,270 @@
+import { isNil } from 'lodash';
+import { useMemo, useState } from 'react';
+
+import { Button, Card, NewWindowIcon, Tag, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+
+import type { ModelTraceSpanLink, ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
+import { getIconTypeForSpan, getLinkFieldKey, getSpanExceptionCount } from '../ModelTraceExplorer.utils';
+import { ModelTraceExplorerIcon } from '../ModelTraceExplorerIcon';
+import { ModelTraceExplorerFieldRenderer } from '../field-renderers/ModelTraceExplorerFieldRenderer';
+import { useSpanLinkHrefs } from '../../hooks/useSpanLinkHref';
+import { useCopyController } from '../../../copy/useCopyController';
+import { useHref } from '../../RoutingUtils';
+
+const MAX_VISIBLE_ATTRIBUTES = 3;
+
+const CopyableIdTag = ({ id, copyTooltip }: { id: string; copyTooltip: string }): JSX.Element => {
+  const { copy, tooltipMessage, tooltipOpen, handleTooltipOpenChange } = useCopyController(id, copyTooltip);
+
+  return (
+    <Tooltip
+      componentId="mlflow.model_trace_explorer.span_link.id_tooltip"
+      content={tooltipMessage}
+      open={tooltipOpen}
+      onOpenChange={handleTooltipOpenChange}
+    >
+      <Tag
+        componentId="mlflow.model_trace_explorer.span_link.id"
+        color="default"
+        onClick={copy}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            copy();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        css={{ alignSelf: 'flex-start', cursor: 'pointer', margin: 0, maxWidth: 96 }}
+      >
+        <Typography.Text size="sm" color="secondary" css={{ fontFamily: 'monospace', whiteSpace: 'nowrap' }}>
+          {id.replace(/^tr-/, '').slice(0, 8)}
+        </Typography.Text>
+      </Tag>
+    </Tooltip>
+  );
+};
+
+const SpanLinkEntry = ({
+  link,
+  index,
+  href,
+  searchFilter,
+  activeMatch,
+  isActiveMatchSpan,
+  isSameTrace,
+  linkedSpan,
+  onSelectSpan,
+}: {
+  link: ModelTraceSpanLink;
+  index: number;
+  href: string | undefined;
+  searchFilter: string;
+  activeMatch: SearchMatch | null;
+  isActiveMatchSpan: boolean;
+  isSameTrace: boolean;
+  linkedSpan?: ModelTraceSpanNode;
+  onSelectSpan?: () => void;
+}): JSX.Element => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const routedHref = useHref(href ?? '');
+  const [showAllAttributes, setShowAllAttributes] = useState(false);
+  const attributeEntries = link.attributes ? Object.entries(link.attributes) : [];
+  const hasHiddenAttributes = attributeEntries.length > MAX_VISIBLE_ATTRIBUTES;
+  const activeMatchEntry = attributeEntries.find(
+    ([key]) => isActiveMatchSpan && activeMatch?.section === 'links' && activeMatch.key === getLinkFieldKey(index, key),
+  );
+  const collapsedAttributeEntries = attributeEntries.slice(0, MAX_VISIBLE_ATTRIBUTES);
+  if (activeMatchEntry && !collapsedAttributeEntries.includes(activeMatchEntry)) {
+    collapsedAttributeEntries.push(activeMatchEntry);
+  }
+  const visibleAttributeEntries = showAllAttributes ? attributeEntries : collapsedAttributeEntries;
+  const jumpButtonCss = {
+    whiteSpace: 'nowrap' as const,
+    '&:not(:hover):not(:focus-visible)': {
+      borderColor: `${theme.colors.borderDecorative} !important`,
+    },
+  };
+  const openButton = isSameTrace ? (
+    <Button
+      componentId="mlflow.model_trace_explorer.span_link"
+      size="small"
+      css={jumpButtonCss}
+      disabled={!linkedSpan || !onSelectSpan}
+      onClick={onSelectSpan}
+    >
+      Jump to linked span
+    </Button>
+  ) : (
+    <Button
+      componentId="mlflow.model_trace_explorer.span_link"
+      size="small"
+      href={href ? routedHref : undefined}
+      target="_blank"
+      disabled={!href}
+      endIcon={<NewWindowIcon css={{ fontSize: 12 }} />}
+      css={jumpButtonCss}
+    >
+      Jump to linked span
+    </Button>
+  );
+
+  return (
+    <Card
+      componentId="mlflow.model_trace_explorer.span_link.card"
+      css={{
+        boxSizing: 'border-box',
+        marginBottom: theme.spacing.sm,
+        padding: theme.spacing.md,
+        width: '100%',
+      }}
+      disableHover
+    >
+      <div
+        css={{
+          alignItems: 'flex-start',
+          display: 'grid',
+          gap: theme.spacing.md,
+          gridTemplateColumns: 'minmax(0, 1fr) auto',
+        }}
+      >
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm, minWidth: 0 }}>
+          {!isSameTrace && (
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+              <Typography.Hint>Trace ID</Typography.Hint>
+              <CopyableIdTag
+                id={link.trace_id}
+                copyTooltip={intl.formatMessage({
+                  defaultMessage: 'Copy trace ID',
+                  description: 'Tooltip for copying a linked trace ID',
+                })}
+              />
+            </div>
+          )}
+          {linkedSpan ? (
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+              <Typography.Hint>Linked span</Typography.Hint>
+              <div css={{ alignItems: 'center', display: 'flex', gap: theme.spacing.sm, minWidth: 0 }}>
+                <ModelTraceExplorerIcon
+                  type={getIconTypeForSpan(linkedSpan.type ?? '')}
+                  hasException={getSpanExceptionCount(linkedSpan) > 0}
+                />
+                <Typography.Text css={{ overflowWrap: 'anywhere' }}>{linkedSpan.title}</Typography.Text>
+              </div>
+            </div>
+          ) : (
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+              <Typography.Hint>Span ID</Typography.Hint>
+              <CopyableIdTag
+                id={link.span_id}
+                copyTooltip={intl.formatMessage({
+                  defaultMessage: 'Copy span ID',
+                  description: 'Tooltip for copying a linked span ID',
+                })}
+              />
+            </div>
+          )}
+        </div>
+        {openButton}
+      </div>
+      <div
+        css={{
+          borderTop: `1px solid ${theme.colors.borderDecorative}`,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.sm,
+          marginTop: theme.spacing.md,
+          paddingTop: theme.spacing.md,
+        }}
+      >
+        <Typography.Hint>Attributes</Typography.Hint>
+        {attributeEntries.length > 0 ? (
+          <>
+            {visibleAttributeEntries.map(([key, value]) => (
+              <ModelTraceExplorerFieldRenderer
+                key={key}
+                title={key}
+                data={JSON.stringify(value, null, 2)}
+                renderMode="default"
+                searchFilter={searchFilter}
+                activeMatch={activeMatch}
+                containsActiveMatch={
+                  isActiveMatchSpan &&
+                  activeMatch?.section === 'links' &&
+                  activeMatch.key === getLinkFieldKey(index, key)
+                }
+              />
+            ))}
+            {hasHiddenAttributes && (
+              <Button
+                componentId="mlflow.model_trace_explorer.span_link.attributes_toggle"
+                size="small"
+                type="link"
+                css={{ alignSelf: 'flex-start' }}
+                onClick={() => setShowAllAttributes((value) => !value)}
+              >
+                {showAllAttributes ? 'See less' : 'See more'}
+              </Button>
+            )}
+          </>
+        ) : (
+          <Typography.Hint>No attributes</Typography.Hint>
+        )}
+      </div>
+    </Card>
+  );
+};
+
+export const ModelTraceExplorerLinksTab = ({
+  activeSpan,
+  searchFilter,
+  activeMatch,
+  onSelectSpan,
+  spanNodes = {},
+}: {
+  activeSpan: ModelTraceSpanNode;
+  searchFilter: string;
+  activeMatch: SearchMatch | null;
+  onSelectSpan?: (spanId: string) => void;
+  spanNodes?: Record<string, ModelTraceSpanNode>;
+}): JSX.Element | null => {
+  const { theme } = useDesignSystemTheme();
+  const { links } = activeSpan;
+  const isActiveMatchSpan = !isNil(activeMatch) && activeMatch.span.key === activeSpan.key;
+  const traceIds = useMemo(() => (links ?? []).map((link) => link.trace_id), [links]);
+  const hrefMap = useSpanLinkHrefs(traceIds);
+
+  if (!links?.length) {
+    return null;
+  }
+
+  return (
+    <div
+      css={{
+        paddingLeft: theme.spacing.md + theme.spacing.xs,
+        paddingRight: theme.spacing.md + theme.spacing.xs,
+        paddingTop: theme.spacing.md,
+      }}
+    >
+      {links.map((link, index) => {
+        const isSameTrace = link.trace_id === activeSpan.traceId;
+        return (
+          <SpanLinkEntry
+            key={`${link.trace_id}-${link.span_id}-${index}`}
+            link={link}
+            index={index}
+            href={hrefMap[link.trace_id]}
+            searchFilter={searchFilter}
+            activeMatch={activeMatch}
+            isActiveMatchSpan={isActiveMatchSpan}
+            isSameTrace={isSameTrace}
+            linkedSpan={isSameTrace ? spanNodes[link.span_id] : undefined}
+            onSelectSpan={isSameTrace && onSelectSpan ? () => onSelectSpan(link.span_id) : undefined}
+          />
+        );
+      })}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerLinksTab.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerLinksTab.tsx
@@ -2,7 +2,7 @@ import { isNil } from 'lodash';
 import { useMemo, useState } from 'react';
 
 import { Button, Card, NewWindowIcon, Tag, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
-import { useIntl } from '@databricks/i18n';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
 
 import type { ModelTraceSpanLink, ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
 import { getIconTypeForSpan, getLinkFieldKey, getSpanExceptionCount } from '../ModelTraceExplorer.utils';
@@ -95,7 +95,10 @@ const SpanLinkEntry = ({
       disabled={!linkedSpan || !onSelectSpan}
       onClick={onSelectSpan}
     >
-      Jump to linked span
+      <FormattedMessage
+        defaultMessage="Jump to linked span"
+        description="Button that navigates to the span referenced by a span link"
+      />
     </Button>
   ) : (
     <Button
@@ -107,7 +110,10 @@ const SpanLinkEntry = ({
       endIcon={<NewWindowIcon css={{ fontSize: 12 }} />}
       css={jumpButtonCss}
     >
-      Jump to linked span
+      <FormattedMessage
+        defaultMessage="Jump to linked span"
+        description="Button that navigates to the span referenced by a span link"
+      />
     </Button>
   );
 
@@ -133,7 +139,12 @@ const SpanLinkEntry = ({
         <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm, minWidth: 0 }}>
           {!isSameTrace && (
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Hint>Trace ID</Typography.Hint>
+              <Typography.Hint>
+                <FormattedMessage
+                  defaultMessage="Trace ID"
+                  description="Label for the trace ID of a cross-trace span link"
+                />
+              </Typography.Hint>
               <CopyableIdTag
                 id={link.trace_id}
                 copyTooltip={intl.formatMessage({
@@ -145,7 +156,12 @@ const SpanLinkEntry = ({
           )}
           {linkedSpan ? (
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Hint>Linked span</Typography.Hint>
+              <Typography.Hint>
+                <FormattedMessage
+                  defaultMessage="Linked span"
+                  description="Label for the span referenced by a same-trace span link"
+                />
+              </Typography.Hint>
               <div css={{ alignItems: 'center', display: 'flex', gap: theme.spacing.sm, minWidth: 0 }}>
                 <ModelTraceExplorerIcon
                   type={getIconTypeForSpan(linkedSpan.type ?? '')}
@@ -156,7 +172,12 @@ const SpanLinkEntry = ({
             </div>
           ) : (
             <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-              <Typography.Hint>Span ID</Typography.Hint>
+              <Typography.Hint>
+                <FormattedMessage
+                  defaultMessage="Span ID"
+                  description="Label for the span ID of a cross-trace span link"
+                />
+              </Typography.Hint>
               <CopyableIdTag
                 id={link.span_id}
                 copyTooltip={intl.formatMessage({
@@ -179,7 +200,9 @@ const SpanLinkEntry = ({
           paddingTop: theme.spacing.md,
         }}
       >
-        <Typography.Hint>Attributes</Typography.Hint>
+        <Typography.Hint>
+          <FormattedMessage defaultMessage="Attributes" description="Label for the attributes section of a span link" />
+        </Typography.Hint>
         {attributeEntries.length > 0 ? (
           <>
             {visibleAttributeEntries.map(([key, value]) => (
@@ -205,12 +228,27 @@ const SpanLinkEntry = ({
                 css={{ alignSelf: 'flex-start' }}
                 onClick={() => setShowAllAttributes((value) => !value)}
               >
-                {showAllAttributes ? 'See less' : 'See more'}
+                {showAllAttributes ? (
+                  <FormattedMessage
+                    defaultMessage="See less"
+                    description="Button that collapses the span link attributes back to the first few"
+                  />
+                ) : (
+                  <FormattedMessage
+                    defaultMessage="See more"
+                    description="Button that expands the span link attributes to show all of them"
+                  />
+                )}
               </Button>
             )}
           </>
         ) : (
-          <Typography.Hint>No attributes</Typography.Hint>
+          <Typography.Hint>
+            <FormattedMessage
+              defaultMessage="No attributes"
+              description="Empty state shown when a span link has no attributes"
+            />
+          </Typography.Hint>
         )}
       </div>
     </Card>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerRightPaneTabs.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/right-pane/ModelTraceExplorerRightPaneTabs.tsx
@@ -8,6 +8,7 @@ import { FormattedMessage } from '@databricks/i18n';
 import { ModelTraceExplorerAttributesTab } from './ModelTraceExplorerAttributesTab';
 import { ModelTraceExplorerContentTab } from './ModelTraceExplorerContentTab';
 import { ModelTraceExplorerEventsTab } from './ModelTraceExplorerEventsTab';
+import { ModelTraceExplorerLinksTab } from './ModelTraceExplorerLinksTab';
 import { ModelTraceExplorerRightPaneHeader } from './ModelTraceExplorerRightPaneHeader';
 import { SimplifiedAssessmentView } from './SimplifiedAssessmentView';
 import type { ModelTrace, ModelTraceExplorerTab, ModelTraceSpanNode, SearchMatch } from '../ModelTrace.types';
@@ -28,6 +29,7 @@ function ModelTraceExplorerRightPaneTabsImpl({
   activeMatch,
   activeTab,
   setActiveTab,
+  onSelectSpan,
 }: {
   activeSpan: ModelTraceSpanNode | undefined;
   modelTraceInfo?: ModelTrace['info'];
@@ -35,6 +37,7 @@ function ModelTraceExplorerRightPaneTabsImpl({
   activeMatch: SearchMatch | null;
   activeTab: ModelTraceExplorerTab;
   setActiveTab: (tab: ModelTraceExplorerTab) => void;
+  onSelectSpan?: (spanId: string) => void;
 }): JSX.Element {
   const { theme } = useDesignSystemTheme();
   const {
@@ -45,6 +48,7 @@ function ModelTraceExplorerRightPaneTabsImpl({
     readOnly: displayReadOnlyAssessments,
     isTraceInitialLoading,
     subscribeToHighlightEvent,
+    nodeMap,
   } = useModelTraceExplorerViewState();
   const [paneWidth, setPaneWidth] = useState(500);
   const rightPaneHorizontalPadding = theme.spacing.md + theme.spacing.xs;
@@ -74,6 +78,8 @@ function ModelTraceExplorerRightPaneTabsImpl({
   const exceptionCount = getSpanExceptionCount(activeSpan);
   const hasException = exceptionCount > 0;
   const hasEvents = (activeSpan.events?.length ?? 0) > 0 || hasException;
+  const linkCount = activeSpan.links?.length ?? 0;
+  const hasLinks = linkCount > 0;
   const hasContent = getDefaultActiveTab({ ...activeSpan, events: [] }) === 'content';
 
   const tabContent = (
@@ -123,6 +129,11 @@ function ModelTraceExplorerRightPaneTabsImpl({
             Events {hasException && <ModelTraceExplorerBadge count={exceptionCount} />}
           </Tabs.Trigger>
         )}
+        {hasLinks && (
+          <Tabs.Trigger value="links">
+            Links <ModelTraceExplorerBadge count={linkCount} variant="neutral" />
+          </Tabs.Trigger>
+        )}
         {displayReadOnlyAssessments && (
           <Tabs.Trigger value="assessments">
             <FormattedMessage
@@ -145,6 +156,17 @@ function ModelTraceExplorerRightPaneTabsImpl({
       {hasEvents && (
         <Tabs.Content css={contentStyle} value="events">
           <ModelTraceExplorerEventsTab activeSpan={activeSpan} searchFilter={searchFilter} activeMatch={activeMatch} />
+        </Tabs.Content>
+      )}
+      {hasLinks && (
+        <Tabs.Content css={contentStyle} value="links">
+          <ModelTraceExplorerLinksTab
+            activeSpan={activeSpan}
+            searchFilter={searchFilter}
+            activeMatch={activeMatch}
+            onSelectSpan={onSelectSpan}
+            spanNodes={nodeMap}
+          />
         </Tabs.Content>
       )}
       {displayReadOnlyAssessments && (

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/timeline-tree/TimelineTreeNode.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/timeline-tree/TimelineTreeNode.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import { screen } from '@testing-library/react';
 import { render } from '@databricks/web-shared/test-utils/render';
 import userEvent from '@testing-library/user-event';
@@ -15,6 +15,10 @@ import {
   type TimelineTreeMetric,
   useModelTraceExplorerPreferences,
 } from '../ModelTraceExplorerPreferencesContext';
+import {
+  ModelTraceExplorerViewStateContext,
+  useModelTraceExplorerViewState,
+} from '../ModelTraceExplorerViewStateContext';
 import { MOCK_TRACE } from '../../ModelTraceExplorer.test-utils';
 import { parseModelTraceToTree } from '../ModelTraceExplorer.utils';
 import { QueryClient, QueryClientProvider } from '../../../query-client/queryClient';
@@ -54,8 +58,30 @@ const MetricPreferencesOverride = ({
   );
 };
 
-const TestWrapper = ({ node = TEST_NODE, metrics }: { node?: ModelTraceSpanNode; metrics?: TimelineTreeMetric[] }) => {
-  const [selectedKey, setSelectedKey] = useState<string | number>(node.key);
+const ViewStateOverride = ({ children }: { children: React.ReactNode }) => {
+  const viewState = useModelTraceExplorerViewState();
+  const [activeTab, setActiveTab] = useState(viewState.activeTab);
+
+  return (
+    <ModelTraceExplorerViewStateContext.Provider value={{ ...viewState, activeTab, setActiveTab }}>
+      {children}
+      <span data-testid="active-tab">{activeTab}</span>
+    </ModelTraceExplorerViewStateContext.Provider>
+  );
+};
+
+const TestWrapper = ({
+  node = TEST_NODE,
+  metrics,
+  initialSelectedKey = node.key,
+  onSelect,
+}: {
+  node?: ModelTraceSpanNode;
+  metrics?: TimelineTreeMetric[];
+  initialSelectedKey?: string | number;
+  onSelect?: (node: ModelTraceSpanNode) => void;
+}) => {
+  const [selectedKey, setSelectedKey] = useState<string | number>(initialSelectedKey);
   const [expandedKeys, setExpandedKeys] = useState<Set<string | number>>(new Set([]));
   const [queryClient] = useState(() => new QueryClient());
 
@@ -67,7 +93,10 @@ const TestWrapper = ({ node = TEST_NODE, metrics }: { node?: ModelTraceSpanNode;
       setExpandedKeys={setExpandedKeys}
       traceStartTime={0}
       traceEndTime={0}
-      onSelect={(selectedNode) => setSelectedKey(selectedNode.key)}
+      onSelect={(selectedNode) => {
+        setSelectedKey(selectedNode.key);
+        onSelect?.(selectedNode);
+      }}
       linesToRender={[]}
     />
   );
@@ -78,11 +107,13 @@ const TestWrapper = ({ node = TEST_NODE, metrics }: { node?: ModelTraceSpanNode;
         <IntlProvider locale="en">
           <DesignSystemProvider>
             <ModelTraceExplorerPreferencesProvider>
-              {metrics ? (
-                <MetricPreferencesOverride metrics={metrics}>{timelineTreeNode}</MetricPreferencesOverride>
-              ) : (
-                timelineTreeNode
-              )}
+              <ViewStateOverride>
+                {metrics ? (
+                  <MetricPreferencesOverride metrics={metrics}>{timelineTreeNode}</MetricPreferencesOverride>
+                ) : (
+                  timelineTreeNode
+                )}
+              </ViewStateOverride>
             </ModelTraceExplorerPreferencesProvider>
           </DesignSystemProvider>
         </IntlProvider>
@@ -161,5 +192,28 @@ describe('TimelineTreeNode', () => {
 
     await userEvent.click(parentExpandButton);
     expect(screen.getAllByTestId(/timeline-tree-node/)).toHaveLength(1);
+  });
+
+  it('shows a neutral link count indicator that opens the links tab', async () => {
+    const onSelect = jest.fn();
+    const nodeWithLinks: ModelTraceSpanNode = {
+      ...METRICS_NODE,
+      links: [{ trace_id: 'tr-linked', span_id: 'linked-span' }],
+    };
+    render(<TestWrapper node={nodeWithLinks} initialSelectedKey="another-span" onSelect={onSelect} />);
+
+    expect(screen.getByTestId('active-tab')).toHaveTextContent('content');
+    expect(screen.getByTestId(`span-link-tag-${nodeWithLinks.key}`)).toHaveTextContent('1');
+
+    await userEvent.click(screen.getByTestId(`span-link-tag-${nodeWithLinks.key}`));
+
+    expect(screen.getByTestId('active-tab')).toHaveTextContent('links');
+    expect(onSelect).toHaveBeenCalledWith(nodeWithLinks);
+  });
+
+  it('does not show a link indicator when the span has no links', () => {
+    render(<TestWrapper node={METRICS_NODE} />);
+
+    expect(screen.queryByTestId(`span-link-tag-${METRICS_NODE.key}`)).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/timeline-tree/TimelineTreeNode.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/v2/timeline-tree/TimelineTreeNode.tsx
@@ -98,7 +98,7 @@ export const TimelineTreeNode = ({
   const { theme } = useDesignSystemTheme();
   const { timelineTreeMetrics } = useModelTraceExplorerPreferences();
   const hasChildren = (node.children ?? []).length > 0;
-  const { setAssessmentsPaneExpanded } = useModelTraceExplorerViewState();
+  const { setActiveTab, setAssessmentsPaneExpanded } = useModelTraceExplorerViewState();
 
   const isActive = selectedKey === node.key;
   const activeChildIndex = getActiveChildIndex(node, String(selectedKey));
@@ -316,6 +316,22 @@ export const TimelineTreeNode = ({
                         <Typography.Text css={{ marginLeft: theme.spacing.xs }}>
                           {node.assessments.length}
                         </Typography.Text>
+                      </Tag>
+                    )}
+                    {(node.links?.length ?? 0) > 0 && (
+                      <Tag
+                        color="teal"
+                        data-testid={`span-link-tag-${node.key}`}
+                        componentId="shared.model-trace-explorer.span-link-count"
+                        css={{
+                          margin: 0,
+                          marginLeft: theme.spacing.xs,
+                          borderRadius: theme.borders.borderRadiusSm,
+                        }}
+                        onClick={() => setActiveTab('links')}
+                      >
+                        <LinkIcon css={{ fontSize: theme.typography.fontSizeSm - 1 }} />
+                        <Typography.Text css={{ marginLeft: theme.spacing.xs }}>{node.links?.length}</Typography.Text>
                       </Tag>
                     )}
                     {inlineMetric && (


### PR DESCRIPTION
Cherry-picks the span-link trace-explorer UI feature onto `branch-3.16` for the 3.16.0 release.

- #25573 — Add span link UI to redesigned trace explorer (`rn/bug-fix`, labeled `3.16.0`)
- #25580 — Localize span link UI strings in the redesigned trace explorer (`rn/none`, follow-up to #25573)

Both applied clean (`-x`, no conflicts); original authors + DCO sign-offs preserved. Frontend-only (JS/TS + `en.json`) — no dependency/lockfile changes. Applied in merge order (#25573 then #25580, since #25580 localizes strings added by #25573).