### PR TITLE
Skip non-PR (issue) references in `update_changelog.py`

### DIFF
--- a/dev/update_changelog.py
+++ b/dev/update_changelog.py
@@ -154,7 +154,11 @@ def _fetch_pr_chunk_graphql(pr_numbers: list[int]) -> list[PullRequest]:
         if fatal_errors := [e for e in data["errors"] if e.get("type") != "NOT_FOUND"]:
             raise Exception(f"GraphQL errors: {fatal_errors}")
         for error in data["errors"]:
-            print(f"Warning: {error.get('message', 'Unknown error')} (not a PR, skipping)")
+            path = ".".join(str(p) for p in error.get("path", []))
+            print(
+                f"Warning: skipping unresolved reference [{path}]: "
+                f"{error.get('message', 'Unknown error')}"
+            )
 
     # Extract PR data from response and create PullRequest objects
     repository_data = data["data"]["repository"]

--- a/dev/update_changelog.py
+++ b/dev/update_changelog.py
@@ -147,7 +147,14 @@ def _fetch_pr_chunk_graphql(pr_numbers: list[int]) -> list[PullRequest]:
     resp.raise_for_status()
     data = resp.json()
     if "errors" in data:
-        raise Exception(f"GraphQL errors: {data['errors']}")
+        # A NOT_FOUND error is returned when a referenced number is an issue rather
+        # than a PR (e.g. an issue number in a commit message). GitHub still returns
+        # the remaining PRs in the same response, so skip those with a warning and
+        # only raise on genuinely unexpected errors.
+        if fatal_errors := [e for e in data["errors"] if e.get("type") != "NOT_FOUND"]:
+            raise Exception(f"GraphQL errors: {fatal_errors}")
+        for error in data["errors"]:
+            print(f"Warning: {error.get('message', 'Unknown error')} (not a PR, skipping)")
 
     # Extract PR data from response and create PullRequest objects
     repository_data = data["data"]["repository"]


### PR DESCRIPTION
### Related Issues/PRs

Relates to the MLflow 3.16.0 release. `dev/update_changelog.py` aborted while generating the 3.16.0 changelog because the commit range referenced an issue number, not a PR.

### What changes are proposed in this pull request?

`dev/update_changelog.py` fetches PR metadata for the release commit range with a single batched GraphQL query. When one of the referenced numbers is an **issue** rather than a PR (e.g. an issue number written as `(#24763)` in a commit message), GitHub returns a `NOT_FOUND` error for that one node while still returning every other PR in the same response. The script raised on the mere presence of an `errors` key, aborting the entire changelog run.

This treats `NOT_FOUND` as a skippable non-PR reference (warn and continue) and only raises on genuinely unexpected GraphQL errors. The existing per-PR `else` branch already handles the resulting missing node, so no downstream change is needed.

```python
if "errors" in data:
    if fatal_errors := [e for e in data["errors"] if e.get("type") != "NOT_FOUND"]:
        raise Exception(f"GraphQL errors: {fatal_errors}")
    for error in data["errors"]:
        print(f"Warning: {error.get('message', 'Unknown error')} (not a PR, skipping)")
```

This code path has been unchanged since 2025-06-03; prior release ranges happened to reference only PRs, so it was never hit until 3.16.0.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Ran `dev/update_changelog.py` for the 3.16.0 range (which includes commit `d4aa4ec9ca` referencing issue `#24763`); it now warns and skips the non-PR reference instead of aborting, and produces the complete CHANGELOG section.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] No.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
