### PR TITLE
fix: Skip initial table creation when database already has tables (closes #19943)

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -84,8 +84,11 @@ def _is_empty_database(engine):
 
 
 def _initialize_tables(engine):
-    _logger.info("Creating initial MLflow database tables...")
-    InitialBase.metadata.create_all(engine)
+    if _is_empty_database(engine):
+        _logger.info("Creating initial MLflow database tables...")
+        InitialBase.metadata.create_all(engine)
+    else:
+        _logger.info("Database is not empty; skipping initial table creation.")
     _upgrade_db(engine)
 
 


### PR DESCRIPTION
## What

When upgrading from MLflow 3.7.0 to 3.8.x, running `mlflow db upgrade` fails with `Table 'secrets' already exists`. This happens because `_initialize_tables` attempts to create all initial tables even when the database already contains some tables from a previous partial migration, and then Alembic migrations try to create the same tables again.

## Fix

Modify `_initialize_tables` to only create initial tables when the database is empty (i.e., only contains Alembic bookkeeping tables). If the database already has any user tables, skip initial table creation and directly run Alembic migrations. This prevents duplicate table creation and allows the upgrade to proceed.

Closes #19943