### PR TITLE
fix: validate SQL trace rollup reads after raw gaps

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -4437,6 +4437,15 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 served = serve_rollup_read(session, plan) if plan is not None else None
 
             if served is not None:
+                raw_points = []
+                if not sql_grouped_merge:
+                    range_aggregations = raw_aggregations_for_plan(plan)
+                    raw_points = (
+                        raw_range_points(served.raw_ranges, range_aggregations)
+                        if served.raw_ranges
+                        else []
+                    )
+
                 if not rollup_read_is_current(session, plan, served.served_day_starts_ms):
                     _logger.debug(
                         "SQL trace rollup routing selected the full raw path for view=%s "
@@ -4451,12 +4460,6 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                     # database's string collation, including global ordering and limiting.
                     data_points = served.data_points
                 elif plan.bucketed:
-                    range_aggregations = raw_aggregations_for_plan(plan)
-                    raw_points = (
-                        raw_range_points(served.raw_ranges, range_aggregations)
-                        if served.raw_ranges
-                        else []
-                    )
                     # Match the single-query raw path: order by time bucket (then grouping
                     # dimensions) and apply the global max_results after merging rollup and raw
                     # contributions.
@@ -4464,12 +4467,6 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                         [*served.data_points, *raw_points], max_results
                     )
                 else:
-                    range_aggregations = raw_aggregations_for_plan(plan)
-                    raw_points = (
-                        raw_range_points(served.raw_ranges, range_aggregations)
-                        if served.raw_ranges
-                        else []
-                    )
                     data_points = merge_unbucketed_data_points(
                         plan, served.data_points, raw_points, max_results
                     )

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_trace_rollups.py
@@ -1509,6 +1509,51 @@ def test_rebuild_queued_after_rollup_read_invalidates_mixed_result(
         assert not rollup_read_is_current(session, plan, served.served_day_starts_ms)
 
 
+def test_raw_gap_is_read_before_final_invalidation_check(store: SqlAlchemyStore, monkeypatch):
+    exp_id = _seed(store)
+    _insert_trace_metric_rollup(
+        store,
+        exp_id,
+        DAY_A_START,
+        TraceMetricKey.TRACE_COUNT,
+        GroupingSet.GLOBAL.value,
+        sample_count=2,
+    )
+
+    from mlflow.store.tracking import sqlalchemy_store as store_module
+
+    end_time_ms = DAY_B_START + 10_000
+    raw_gap = [(DAY_B_START, end_time_ms)]
+    full_range = [(DAY_A_START, end_time_ms)]
+    events = []
+    original_query_metrics = store_module.query_metrics
+
+    def capture_raw_read(*args, **kwargs):
+        events.append(("raw", kwargs["time_ranges_ms"]))
+        return original_query_metrics(*args, **kwargs)
+
+    def invalidate_after_raw_gap(*args, **kwargs):
+        events.append(("validity", None))
+        return False
+
+    monkeypatch.setattr(store_module, "query_metrics", capture_raw_read)
+    monkeypatch.setattr(store_module, "rollup_read_is_current", invalidate_after_raw_gap)
+    _set_enabled(monkeypatch, True)
+
+    _query(
+        store,
+        exp_id,
+        MetricViewType.TRACES,
+        TraceMetricKey.TRACE_COUNT,
+        _COUNT,
+        None,
+        start=DAY_A_START,
+        end=end_time_ms,
+    )
+
+    assert events == [("raw", raw_gap), ("validity", None), ("raw", full_range)]
+
+
 def test_rollup_snapshot_configures_repeatable_read(monkeypatch):
     _set_enabled(monkeypatch, True)
     calls = []


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25239 and addresses the late review finding in https://github.com/mlflow/mlflow/pull/25239#discussion_r3926258658.

### What changes are proposed in this pull request?

Move non-SQL-grouped raw-gap reads before the final rollup rebuild-queue validity check.

On MSSQL under `REPEATABLE READ`, a rebuild-queue row is a possible phantom. Previously, a rebuild could be queued after the final check but before the raw-gap query, allowing stale rollup data to be merged with newer raw data. The new order is:

1. Read the selected rollup contribution.
2. Read any non-grouped raw gaps.
3. Recheck whether a served rollup day was invalidated.
4. If invalidated, discard the mixed result and execute one authoritative full-range raw query.

The SQL-grouped path is unchanged because it already reads its rollup and raw-gap contributions together in one SQL query.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added a regression test, parameterized across workspace-enabled and workspace-disabled stores, that verifies the raw-gap read occurs before the final validity check and that a failed check triggers the full raw fallback.

Affected test suites: 359 passed, 2 skipped.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

This is a contained concurrency correction to the SQL trace rollup feature introduced by #25239 on the RFC feature branch.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
