### PR TITLE
Support span links for Unity Catalog traces

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -24,9 +24,10 @@ from mlflow.entities.span_status import SpanStatus, SpanStatusCode
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracing.attachments import Attachment
-from mlflow.tracing.constant import TRACE_ID_V4_PREFIX, TRACE_REQUEST_ID_PREFIX, SpanAttributeKey
+from mlflow.tracing.constant import TRACE_REQUEST_ID_PREFIX, SpanAttributeKey
 from mlflow.tracing.utils import (
     build_otel_context,
+    construct_trace_id_v4,
     decode_id,
     dump_span_attribute_value,
     encode_span_id,
@@ -46,6 +47,25 @@ from mlflow.tracing.utils.otlp import (
 from mlflow.tracing.utils.processor import apply_span_processors
 
 _logger = logging.getLogger(__name__)
+
+
+def _normalize_link_trace_id(link_trace_id: str, source_trace_id: str | None) -> str | None:
+    if not isinstance(link_trace_id, str):
+        raise MlflowException.invalid_parameter_value("Link trace ID must be a string.")
+    source_location, _ = parse_trace_id_v4(source_trace_id)
+    link_location, trace_id = parse_trace_id_v4(link_trace_id)
+    if link_location:
+        return link_trace_id if link_location == source_location else None
+    return construct_trace_id_v4(source_location, trace_id) if source_location else link_trace_id
+
+
+def _link_from_otel_link(otel_link, source_trace_id: str | None) -> Link:
+    link_trace_id = f"tr-{otel_link.context.trace_id:032x}"
+    return Link(
+        trace_id=_normalize_link_trace_id(link_trace_id, source_trace_id),
+        span_id=f"{otel_link.context.span_id:016x}",
+        attributes=dict(otel_link.attributes) if otel_link.attributes else None,
+    )
 
 
 # Not using enum as we want to allow custom span type string.
@@ -121,24 +141,9 @@ class Span:
         self._attachments: dict[str, Attachment] = {}
         request_id = self._attributes.get(SpanAttributeKey.REQUEST_ID)
         otel_links = getattr(otel_span, "links", ())
-        if request_id and request_id.startswith(TRACE_ID_V4_PREFIX):
-            if otel_links:
-                _logger.warning(
-                    "Span links are not currently supported for Unity Catalog traces. "
-                    "%d link(s) on span '%s' will be dropped.",
-                    len(otel_links),
-                    otel_span.name,
-                )
-            self._links: list["Link"] = []
-        else:
-            self._links: list["Link"] = [
-                Link(
-                    trace_id=f"tr-{otel_link.context.trace_id:032x}",
-                    span_id=f"{otel_link.context.span_id:016x}",
-                    attributes=dict(otel_link.attributes) if otel_link.attributes else None,
-                )
-                for otel_link in otel_links
-            ]
+        self._links: list["Link"] = [
+            _link_from_otel_link(otel_link, request_id) for otel_link in otel_links
+        ]
 
     @cached_property
     def trace_id(self) -> str:
@@ -513,17 +518,9 @@ class Span:
         else:
             otel_resource = _OTelResource.get_empty()
 
-        links = []
-        if location_id:
-            if otel_proto_span.links:
-                _logger.warning(
-                    "Span links are not currently supported for Unity Catalog traces. "
-                    "%d link(s) on span '%s' will be dropped.",
-                    len(otel_proto_span.links),
-                    otel_proto_span.name,
-                )
-        else:
-            links = [Link.from_otel_proto(proto_link) for proto_link in otel_proto_span.links]
+        links = [Link.from_otel_proto(proto_link) for proto_link in otel_proto_span.links]
+        for link in links:
+            link.trace_id = _normalize_link_trace_id(link.trace_id, mlflow_trace_id)
 
         otel_span = OTelReadableSpan(
             name=otel_proto_span.name,
@@ -676,24 +673,9 @@ class LiveSpan(Span):
         self._attributes.set(SpanAttributeKey.REQUEST_ID, trace_id)
         self._attributes.set(SpanAttributeKey.SPAN_TYPE, span_type)
         otel_links = getattr(otel_span, "links", ())
-        if trace_id.startswith(TRACE_ID_V4_PREFIX):
-            if otel_links:
-                _logger.warning(
-                    "Span links are not currently supported for Unity Catalog traces. "
-                    "%d link(s) on span '%s' will be dropped.",
-                    len(otel_links),
-                    otel_span.name,
-                )
-            self._links: list["Link"] = []
-        else:
-            self._links: list["Link"] = [
-                Link(
-                    trace_id=f"tr-{otel_link.context.trace_id:032x}",
-                    span_id=f"{otel_link.context.span_id:016x}",
-                    attributes=dict(otel_link.attributes) if otel_link.attributes else None,
-                )
-                for otel_link in otel_links
-            ]
+        self._links: list["Link"] = [
+            _link_from_otel_link(otel_link, trace_id) for otel_link in otel_links
+        ]
         # Track the original span name for deduplication purposes during span logging.
         # Why: When traces contain multiple spans with identical names (e.g., multiple "LLM"
         # or "query" spans), it's difficult for users to distinguish between them in the UI
@@ -1040,20 +1022,18 @@ class LiveSpan(Span):
                 INVALID_PARAMETER_VALUE,
             )
 
-        # Span links are not supported for Unity Catalog (V4) traces. Warn and skip rather than
-        # silently normalizing the V4 trace ID to raw OTel hex (see #25080); this matches how
-        # V4-trace links are dropped at span construction.
-        if link.trace_id is not None and link.trace_id.startswith(TRACE_ID_V4_PREFIX):
-            _logger.warning(
-                "Span links are not currently supported for Unity Catalog traces. "
-                "The link to trace '%s' will be skipped.",
-                link.trace_id,
-            )
-            return
-
         # Validate and forward to the underlying OTel span so external exporters can see links
         try:
-            link_trace_id_hex = parse_trace_id_v4(link.trace_id)[1].removeprefix(
+            normalized_trace_id = _normalize_link_trace_id(link.trace_id, self.trace_id)
+            if normalized_trace_id is None:
+                _logger.warning(
+                    "Cross-location span links are not supported. The link from trace '%s' "
+                    "to trace '%s' will be skipped.",
+                    self.trace_id,
+                    link.trace_id,
+                )
+                return
+            link_trace_id_hex = parse_trace_id_v4(normalized_trace_id)[1].removeprefix(
                 TRACE_REQUEST_ID_PREFIX
             )
             trace_id_int = decode_id(link_trace_id_hex)
@@ -1071,7 +1051,7 @@ class LiveSpan(Span):
 
         self._links.append(
             Link(
-                trace_id=link.trace_id,
+                trace_id=normalized_trace_id,
                 span_id=link.span_id,
                 attributes=dict(link.attributes) if link.attributes else None,
             )

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -506,6 +506,12 @@ class Span:
             if location_id
             else generate_mlflow_trace_id_from_otel_trace_id(trace_id)
         )
+        serialized_request_id = dump_span_attribute_value(mlflow_trace_id)
+        if preserve_request_id:
+            serialized_request_id = serialized_attributes.get(
+                SpanAttributeKey.REQUEST_ID, serialized_request_id
+            )
+        request_id = json.loads(serialized_request_id)
 
         # Convert proto Resource to OTel SDK Resource if provided.
         # We avoid _OTelResource.create() which has significant overhead from
@@ -520,7 +526,7 @@ class Span:
 
         links = [Link.from_otel_proto(proto_link) for proto_link in otel_proto_span.links]
         for link in links:
-            link.trace_id = _normalize_link_trace_id(link.trace_id, mlflow_trace_id)
+            link.trace_id = _normalize_link_trace_id(link.trace_id, request_id)
 
         otel_span = OTelReadableSpan(
             name=otel_proto_span.name,
@@ -531,13 +537,7 @@ class Span:
             # we need to dump the attribute value to be consistent with span.set_attribute behavior
             attributes={
                 **serialized_attributes,
-                SpanAttributeKey.REQUEST_ID: (
-                    serialized_attributes.get(
-                        SpanAttributeKey.REQUEST_ID, dump_span_attribute_value(mlflow_trace_id)
-                    )
-                    if preserve_request_id
-                    else dump_span_attribute_value(mlflow_trace_id)
-                ),
+                SpanAttributeKey.REQUEST_ID: serialized_request_id,
             },
             status=OTelStatus(status_code, otel_proto_span.status.message or None),
             events=[

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -601,8 +601,11 @@ def test_span_from_otel_proto_with_location():
     request_id = mlflow_span.get_attribute("mlflow.traceRequestId")
     assert request_id == expected_trace_id
 
-    # Links are skipped for v4 UC traces
-    assert len(mlflow_span.links) == 0
+    assert len(mlflow_span.links) == 1
+    assert (
+        mlflow_span.links[0].trace_id == "trace:/catalog.schema/tr-aabbccddeeff00112233445566778899"
+    )
+    assert mlflow_span.links[0].span_id == "1122334455667788"
 
 
 def test_span_from_otel_proto_with_pre_encoded_request_id():
@@ -995,10 +998,10 @@ def test_add_link_rejects_invalid_ids():
         assert len(span.links) == 0
 
 
-def test_add_link_skips_v4_trace_id():
+def test_add_link_skips_cross_location_v4_trace_id():
     from mlflow.entities.link import Link
 
-    trace_id = "tr-12345"
+    trace_id = "trace:/other.schema/12345"
     tracer = _get_tracer("test")
     with tracer.start_as_current_span("test_span") as otel_span:
         span = create_mlflow_span(otel_span, trace_id=trace_id)
@@ -1006,12 +1009,38 @@ def test_add_link_skips_v4_trace_id():
         with mock.patch("mlflow.entities.span._logger.warning") as mock_warning:
             span.add_link(Link(trace_id="trace:/catalog.schema/abc123", span_id="aabbccddeeff0011"))
 
-        # V4/UC trace links are not supported: skipped, not normalized or stored.
         assert len(span.links) == 0
         assert len(otel_span.links) == 0
         mock_warning.assert_called_once()
-        assert "Unity Catalog" in mock_warning.call_args.args[0]
-        assert mock_warning.call_args.args[1] == "trace:/catalog.schema/abc123"
+        assert "Cross-location" in mock_warning.call_args.args[0]
+
+
+@pytest.mark.parametrize("link_trace_id", ["abc123", "tr-abc123"])
+def test_add_link_qualifies_unlocated_trace_id_for_uc_trace(link_trace_id):
+    from mlflow.entities.link import Link
+
+    trace_id = "trace:/catalog.schema/12345"
+    tracer = _get_tracer("test")
+    with tracer.start_as_current_span("test_span") as otel_span:
+        span = create_mlflow_span(otel_span, trace_id=trace_id)
+        span.add_link(Link(trace_id=link_trace_id, span_id="aabbccddeeff0011"))
+
+        assert span.links[0].trace_id == f"trace:/catalog.schema/{link_trace_id}"
+        assert len(otel_span.links) == 1
+
+
+def test_add_link_accepts_same_location_v4_trace_id():
+    from mlflow.entities.link import Link
+
+    trace_id = "trace:/catalog.schema/12345"
+    linked_trace_id = "trace:/catalog.schema/abc123"
+    tracer = _get_tracer("test")
+    with tracer.start_as_current_span("test_span") as otel_span:
+        span = create_mlflow_span(otel_span, trace_id=trace_id)
+        span.add_link(Link(trace_id=linked_trace_id, span_id="aabbccddeeff0011"))
+
+        assert span.links[0].trace_id == linked_trace_id
+        assert len(otel_span.links) == 1
 
 
 def test_span_seeds_links_from_otel_span():
@@ -1034,6 +1063,26 @@ def test_span_seeds_links_from_otel_span():
     assert immutable_span.links[0].trace_id == "tr-aabbccddeeff00112233445566778899"
     assert immutable_span.links[0].span_id == "aabbccddeeff0011"
     assert immutable_span.links[0].attributes == {"type": "causal"}
+
+
+def test_live_span_preserves_native_otel_links_for_uc_trace():
+    otel_link = trace_api.Link(
+        context=trace_api.SpanContext(
+            trace_id=0xAABBCCDDEEFF00112233445566778899,
+            span_id=0xAABBCCDDEEFF0011,
+            is_remote=False,
+            trace_flags=trace_api.TraceFlags(1),
+        ),
+        attributes={"type": "causal"},
+    )
+    tracer = _get_tracer("test")
+    with tracer.start_as_current_span("test_span", links=[otel_link]) as otel_span:
+        span = create_mlflow_span(otel_span, trace_id="trace:/catalog.schema/12345")
+
+    assert len(span.links) == 1
+    assert span.links[0].trace_id == "trace:/catalog.schema/tr-aabbccddeeff00112233445566778899"
+    assert span.links[0].span_id == "aabbccddeeff0011"
+    assert span.links[0].attributes == {"type": "causal"}
 
 
 def test_span_to_dict_with_links():
@@ -1115,7 +1164,7 @@ def test_span_links_otel_proto_roundtrip():
     assert rt.links[0].span_id == link_span_bytes
 
 
-def test_span_skips_links_for_v4_traces():
+def test_span_preserves_links_for_v4_traces():
     otel_link = trace_api.Link(
         context=trace_api.SpanContext(
             trace_id=0xAABBCCDDEEFF00112233445566778899,
@@ -1136,7 +1185,8 @@ def test_span_skips_links_for_v4_traces():
 
     span = Span(otel_span)
     assert span.trace_id == v4_trace_id
-    assert len(span.links) == 0
+    assert len(span.links) == 1
+    assert span.links[0].trace_id == "trace:/catalog.schema/tr-aabbccddeeff00112233445566778899"
 
 
 def test_span_links_property_returns_deep_copy():

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -649,13 +649,25 @@ def test_span_from_otel_proto_can_preserve_request_id_for_round_trip():
     otel_proto.end_time_unix_nano = 2000000000
     otel_proto.status.code = OTelProtoStatus.STATUS_CODE_OK
 
+    link_trace_id = bytes.fromhex("aabbccddeeff00112233445566778899")
+    proto_link = otel_proto.links.add()
+    proto_link.trace_id = link_trace_id
+    proto_link.span_id = bytes.fromhex("1122334455667788")
+
     attr = otel_proto.attributes.add()
     attr.key = "mlflow.traceRequestId"
-    _set_otel_proto_anyvalue(attr.value, "tr-abc123")
+    _set_otel_proto_anyvalue(
+        attr.value, "trace:/catalog.schema/12345678901234567890123456789012"
+    )
 
     mlflow_span = Span.from_otel_proto(otel_proto, preserve_request_id=True)
 
-    assert mlflow_span.trace_id == "tr-abc123"
+    assert mlflow_span.trace_id == "trace:/catalog.schema/12345678901234567890123456789012"
+    assert (
+        mlflow_span.links[0].trace_id
+        == "trace:/catalog.schema/tr-aabbccddeeff00112233445566778899"
+    )
+    assert mlflow_span.to_otel_proto().links[0].trace_id == link_trace_id
 
 
 def test_otel_roundtrip_conversion(sample_otel_span_for_conversion):
@@ -1027,6 +1039,9 @@ def test_add_link_qualifies_unlocated_trace_id_for_uc_trace(link_trace_id):
 
         assert span.links[0].trace_id == f"trace:/catalog.schema/{link_trace_id}"
         assert len(otel_span.links) == 1
+
+        proto_link = span.to_immutable_span().to_otel_proto().links[0]
+        assert proto_link.trace_id.hex() == link_trace_id.removeprefix("tr-").zfill(32)
 
 
 def test_add_link_accepts_same_location_v4_trace_id():

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -656,16 +656,13 @@ def test_span_from_otel_proto_can_preserve_request_id_for_round_trip():
 
     attr = otel_proto.attributes.add()
     attr.key = "mlflow.traceRequestId"
-    _set_otel_proto_anyvalue(
-        attr.value, "trace:/catalog.schema/12345678901234567890123456789012"
-    )
+    _set_otel_proto_anyvalue(attr.value, "trace:/catalog.schema/12345678901234567890123456789012")
 
     mlflow_span = Span.from_otel_proto(otel_proto, preserve_request_id=True)
 
     assert mlflow_span.trace_id == "trace:/catalog.schema/12345678901234567890123456789012"
     assert (
-        mlflow_span.links[0].trace_id
-        == "trace:/catalog.schema/tr-aabbccddeeff00112233445566778899"
+        mlflow_span.links[0].trace_id == "trace:/catalog.schema/tr-aabbccddeeff00112233445566778899"
     )
     assert mlflow_span.to_otel_proto().links[0].trace_id == link_trace_id
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR enables span links for traces stored in Unity Catalog.

It preserves native OpenTelemetry links, qualifies bare and `tr-` link targets with the source UC location, accepts explicit V4 targets from the same location, and skips cross-location links so traces from different UC locations are never conflated.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Test results:

- `uv run pytest tests/entities/test_span.py` — 60 passed
- Ruff lint and formatting checks passed for `mlflow/entities/span.py` and `tests/entities/test_span.py`
- Logged UC-backed traces to `yuki_watanabe_test.default` and verified that one same-trace link and one cross-trace link persisted and were returned by the SDK

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Unity Catalog-backed traces now preserve and expose span links whose targets are in the same UC trace location.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: A release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: A release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
