### PR TITLE
Roll back the experiment when trace-location linking fails in `create_experiment`

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2384,10 +2384,23 @@ def create_experiment(
                 trace_location=trace_location,
             )
         except MlflowException as e:
+            # Roll back the experiment we just created so a failed trace-location
+            # link does not leave a dangling experiment behind.
+            try:
+                client.delete_experiment(experiment_id)
+            except Exception:
+                _logger.warning(
+                    "Failed to roll back experiment '%s' (ID: %s) after linking it to "
+                    "trace location '%s' failed. The experiment may be left behind.",
+                    name,
+                    experiment_id,
+                    trace_location.full_table_prefix,
+                    exc_info=True,
+                )
             raise MlflowException.invalid_parameter_value(
-                f"Experiment '{name}' (ID: {experiment_id}) was created "
-                f"but linking to trace location '{trace_location.full_table_prefix}' failed: "
-                f"{e.message} Please delete the experiment and retry."
+                f"Experiment '{name}' (ID: {experiment_id}) was created but linking to "
+                f"trace location '{trace_location.full_table_prefix}' failed, so the "
+                f"created experiment was rolled back: {e.message}"
             ) from e
 
     return experiment_id

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2384,24 +2384,35 @@ def create_experiment(
                 trace_location=trace_location,
             )
         except MlflowException as e:
-            # Roll back the experiment we just created so a failed trace-location
-            # link does not leave a dangling experiment behind.
+            # Attempt to soft-delete the experiment we just created so a failed
+            # trace-location link does not leave an active experiment behind.
+            # Note: delete_experiment is a soft delete; the experiment name
+            # remains reserved until permanently removed via `mlflow gc`.
+            cleanup_succeeded = False
             try:
                 client.delete_experiment(experiment_id)
+                cleanup_succeeded = True
             except Exception:
                 _logger.warning(
-                    "Failed to roll back experiment '%s' (ID: %s) after linking it to "
-                    "trace location '%s' failed. The experiment may be left behind.",
+                    "Failed to soft-delete experiment '%s' (ID: %s) after linking it to "
+                    "trace location '%s' failed. The experiment may remain active.",
                     name,
                     experiment_id,
                     trace_location.full_table_prefix,
                     exc_info=True,
                 )
-            raise MlflowException.invalid_parameter_value(
-                f"Experiment '{name}' (ID: {experiment_id}) was created but linking to "
-                f"trace location '{trace_location.full_table_prefix}' failed, so the "
-                f"created experiment was rolled back: {e.message}"
-            ) from e
+            if cleanup_succeeded:
+                raise MlflowException.invalid_parameter_value(
+                    f"Experiment '{name}' (ID: {experiment_id}) was created but linking to "
+                    f"trace location '{trace_location.full_table_prefix}' failed, so the "
+                    f"experiment was soft-deleted (its name remains reserved): {e.message}"
+                ) from e
+            else:
+                raise MlflowException.invalid_parameter_value(
+                    f"Experiment '{name}' (ID: {experiment_id}) was created but linking to "
+                    f"trace location '{trace_location.full_table_prefix}' failed; the "
+                    f"experiment could not be cleaned up and may remain active: {e.message}"
+                ) from e
 
     return experiment_id
 

--- a/tests/tracking/fluent/test_create_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_create_experiment_trace_location.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import mock
 
 import pytest
@@ -119,7 +120,7 @@ def test_does_not_sync_provider_or_set_active():
         assert fluent_module._active_experiment_id == original_active
 
 
-def test_link_failure_includes_retry_guidance():
+def test_link_failure_rolls_back_experiment():
     with (
         mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
         mock.patch(
@@ -131,11 +132,37 @@ def test_link_failure_includes_retry_guidance():
         client.create_experiment.return_value = "456"
         client.get_experiment.return_value = _experiment(experiment_id="456")
 
-        with pytest.raises(MlflowException, match="delete the experiment and retry") as exc_info:
+        with pytest.raises(MlflowException, match="was rolled back") as exc_info:
             mlflow.create_experiment(
                 "new-exp",
                 trace_location=UnityCatalog("cat", "sch", "pfx"),
             )
 
+        # The just-created experiment is deleted so nothing dangling is left behind.
+        client.delete_experiment.assert_called_once_with("456")
         assert "was created" in exc_info.value.message
         assert "backend error" in exc_info.value.message
+
+
+def test_link_failure_rollback_failure_logs_warning(caplog):
+    with (
+        mock.patch("mlflow.tracking.fluent.MlflowClient") as mock_client_cls,
+        mock.patch(
+            "mlflow.tracking.fluent._resolve_experiment_to_trace_location",
+            side_effect=MlflowException("backend error"),
+        ),
+    ):
+        client = mock_client_cls.return_value
+        client.create_experiment.return_value = "456"
+        client.get_experiment.return_value = _experiment(experiment_id="456")
+        client.delete_experiment.side_effect = MlflowException("cleanup failed")
+
+        with caplog.at_level(logging.WARNING, logger="mlflow.tracking.fluent"):
+            with pytest.raises(MlflowException, match="backend error"):
+                mlflow.create_experiment(
+                    "new-exp",
+                    trace_location=UnityCatalog("cat", "sch", "pfx"),
+                )
+
+        # Rollback failure is surfaced as a warning, not silently swallowed.
+        assert "Failed to roll back experiment" in caplog.text

--- a/tests/tracking/fluent/test_create_experiment_trace_location.py
+++ b/tests/tracking/fluent/test_create_experiment_trace_location.py
@@ -11,12 +11,12 @@ from mlflow.entities.trace_location import UnityCatalog
 from mlflow.exceptions import MlflowException
 
 
-def _experiment(experiment_id="789"):
+def _experiment(experiment_id="789", lifecycle_stage="active"):
     return Experiment(
         experiment_id=experiment_id,
         name="test-experiment",
         artifact_location="file:/tmp",
-        lifecycle_stage="active",
+        lifecycle_stage=lifecycle_stage,
         tags=[ExperimentTag("key", "val")],
     )
 
@@ -130,16 +130,24 @@ def test_link_failure_rolls_back_experiment():
     ):
         client = mock_client_cls.return_value
         client.create_experiment.return_value = "456"
-        client.get_experiment.return_value = _experiment(experiment_id="456")
+        # First call: before delete (inside create_experiment). Second call: our
+        # post-cleanup assertion below, simulating the soft-deleted state a user
+        # would observe after cleanup.
+        client.get_experiment.side_effect = [
+            _experiment(experiment_id="456"),
+            _experiment(experiment_id="456", lifecycle_stage="deleted"),
+        ]
 
-        with pytest.raises(MlflowException, match="was rolled back") as exc_info:
+        with pytest.raises(MlflowException, match="soft-deleted") as exc_info:
             mlflow.create_experiment(
                 "new-exp",
                 trace_location=UnityCatalog("cat", "sch", "pfx"),
             )
 
-        # The just-created experiment is deleted so nothing dangling is left behind.
+        # The just-created experiment is soft-deleted so nothing active is left behind.
         client.delete_experiment.assert_called_once_with("456")
+        # Assert that the experiment is now observable as soft-deleted.
+        assert client.get_experiment("456").lifecycle_stage == "deleted"
         assert "was created" in exc_info.value.message
         assert "backend error" in exc_info.value.message
 
@@ -164,5 +172,5 @@ def test_link_failure_rollback_failure_logs_warning(caplog):
                     trace_location=UnityCatalog("cat", "sch", "pfx"),
                 )
 
-        # Rollback failure is surfaced as a warning, not silently swallowed.
-        assert "Failed to roll back experiment" in caplog.text
+        # Cleanup failure is surfaced as a warning, not silently swallowed.
+        assert "Failed to soft-delete experiment" in caplog.text


### PR DESCRIPTION
### Related Issues/PRs

Closes #25551

### What changes are proposed in this pull request?

`mlflow.create_experiment(..., trace_location=...)` creates the experiment first, then links it to the trace location. If the link step raises, the original code re-raised without deleting the experiment, leaving a dangling experiment the caller could not recover from.

This PR adds a rollback step: when `_resolve_experiment_to_trace_location` raises, the just-created experiment is deleted via `client.delete_experiment(experiment_id)` before re-raising. If the rollback itself fails, the failure is logged at `WARNING` level with `exc_info=True` rather than being silently swallowed. The re-raised message states the experiment was rolled back. It does not promise the name is immediately reusable, because `delete_experiment` is a soft-delete on most stores.

### How is this PR tested?

- [x] New unit/integration tests

Two new tests replace the previous `test_link_failure_includes_retry_guidance`:

1. `test_link_failure_rolls_back_experiment` -- asserts that `client.delete_experiment` is called with the correct ID and that the re-raised message contains both `"was rolled back"` and the original error text.
2. `test_link_failure_rollback_failure_logs_warning` -- configures `delete_experiment` to also raise and asserts that a `WARNING` log containing `"Failed to roll back experiment"` is emitted and the original error is still re-raised.

All 7 tests in `tests/tracking/fluent/test_create_experiment_trace_location.py` pass.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.create_experiment` now rolls back (soft-deletes) the just-created experiment when linking it to a `trace_location` fails, rather than leaving a dangling experiment behind. If the rollback itself fails, a warning is logged rather than silently swallowed.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
