### PR TITLE
Fix token totals for grouped trace sessions

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v4/components/TracesV4PageContent.tsx
@@ -436,6 +436,9 @@ export const TracesV4PageContent = ({ experimentId }: TracesV4PageContentProps) 
             renderRunName={renderRunName}
             onHideColumn={handleHideColumn}
             isGroupedBySession={controller.isGroupedBySession}
+            // Session-level aggregates (e.g. token totals) may be incomplete when off-page traces
+            // exist — suppress them for the same reason onToggleBulkRows is disabled above.
+            sessionsMayBeIncomplete={controller.isGroupedBySession && (page.hasNext || page.hasPrev)}
             onReorderColumn={columnOrder.reorderColumn}
             // Toolbar slots (built by useTracesV4ToolbarSlots) + banner slot
             searchValue={searchInput.input}

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TraceCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TraceCell.tsx
@@ -607,38 +607,71 @@ export const TraceDurationCell: React.MemoExoticComponent<(props: { trace: Model
   },
 );
 
+type TokenUsage = {
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+};
+
+const TokenUsageCell = ({ usage }: { usage: TokenUsage }): JSX.Element => {
+  const { theme } = useDesignSystemTheme();
+  if (!usage.total_tokens) {
+    return <EmptyValue />;
+  }
+  const parts = [
+    usage.input_tokens !== undefined ? `Input ${usage.input_tokens}` : undefined,
+    usage.output_tokens !== undefined ? `Output ${usage.output_tokens}` : undefined,
+  ].filter(Boolean);
+  const content = (
+    <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.sm, maxWidth: '100%' }}>
+      <TokenIcon css={{ color: theme.colors.textSecondary, fontSize: CELL_ICON_SIZE }} />
+      <span css={truncateCss}>{usage.total_tokens}</span>
+    </span>
+  );
+  if (parts.length === 0) {
+    return content;
+  }
+  return (
+    <Tooltip
+      componentId={`${COMPONENT_ID}.cell.tokens-tooltip`}
+      content={<WrappedTooltipText>{parts.join(' · ')}</WrappedTooltipText>}
+      maxWidth={CELL_OVERLAY_MAX_WIDTH}
+    >
+      {content}
+    </Tooltip>
+  );
+};
+
 /** Total token count in a tag, with an input/output breakdown on hover. */
 export const TraceTokensCell: React.MemoExoticComponent<(props: { trace: ModelTraceInfoV3 }) => JSX.Element> = memo(
   function TraceTokensCell({ trace }: { trace: ModelTraceInfoV3 }) {
-    const { theme } = useDesignSystemTheme();
     // `getTraceTokenUsage` can return undefined when the metadata JSON is unparseable — guard so a
     // malformed row renders "-" instead of throwing.
-    const usage = getTraceTokenUsage(trace) ?? {};
-    if (!usage.total_tokens) {
-      return <EmptyValue />;
-    }
-    const parts = [
-      usage.input_tokens !== undefined ? `Input ${usage.input_tokens}` : undefined,
-      usage.output_tokens !== undefined ? `Output ${usage.output_tokens}` : undefined,
-    ].filter(Boolean);
-    const content = (
-      <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.sm, maxWidth: '100%' }}>
-        <TokenIcon css={{ color: theme.colors.textSecondary, fontSize: CELL_ICON_SIZE }} />
-        <span css={truncateCss}>{usage.total_tokens}</span>
-      </span>
-    );
-    if (parts.length === 0) {
-      return content;
-    }
-    return (
-      <Tooltip
-        componentId={`${COMPONENT_ID}.cell.tokens-tooltip`}
-        content={<WrappedTooltipText>{parts.join(' · ')}</WrappedTooltipText>}
-        maxWidth={CELL_OVERLAY_MAX_WIDTH}
-      >
-        {content}
-      </Tooltip>
-    );
+    return <TokenUsageCell usage={getTraceTokenUsage(trace) ?? {}} />;
+  },
+);
+
+/** Session token count, aggregated across all traces in the collapsed session header. */
+export const SessionTokensCell: React.MemoExoticComponent<(props: { traces: ModelTraceInfoV3[] }) => JSX.Element> = memo(
+  function SessionTokensCell({ traces }: { traces: ModelTraceInfoV3[] }) {
+    const usage = traces.reduce<TokenUsage>((totals, trace) => {
+      const traceUsage = getTraceTokenUsage(trace) ?? {};
+      return {
+        input_tokens:
+          totals.input_tokens === undefined && traceUsage.input_tokens === undefined
+            ? undefined
+            : (totals.input_tokens ?? 0) + (traceUsage.input_tokens ?? 0),
+        output_tokens:
+          totals.output_tokens === undefined && traceUsage.output_tokens === undefined
+            ? undefined
+            : (totals.output_tokens ?? 0) + (traceUsage.output_tokens ?? 0),
+        total_tokens:
+          totals.total_tokens === undefined && traceUsage.total_tokens === undefined
+            ? undefined
+            : (totals.total_tokens ?? 0) + (traceUsage.total_tokens ?? 0),
+      };
+    }, {});
+    return <TokenUsageCell usage={usage} />;
   },
 );
 

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TraceCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TraceCell.tsx
@@ -652,8 +652,8 @@ export const TraceTokensCell: React.MemoExoticComponent<(props: { trace: ModelTr
 );
 
 /** Session token count, aggregated across all traces in the collapsed session header. */
-export const SessionTokensCell: React.MemoExoticComponent<(props: { traces: ModelTraceInfoV3[] }) => JSX.Element> = memo(
-  function SessionTokensCell({ traces }: { traces: ModelTraceInfoV3[] }) {
+export const SessionTokensCell: React.MemoExoticComponent<(props: { traces: ModelTraceInfoV3[] }) => JSX.Element> =
+  memo(function SessionTokensCell({ traces }: { traces: ModelTraceInfoV3[] }) {
     const usage = traces.reduce<TokenUsage>((totals, trace) => {
       const traceUsage = getTraceTokenUsage(trace) ?? {};
       return {
@@ -672,8 +672,7 @@ export const SessionTokensCell: React.MemoExoticComponent<(props: { traces: Mode
       };
     }, {});
     return <TokenUsageCell usage={usage} />;
-  },
-);
+  });
 
 /** Total cost in USD in a tag, with an input/output breakdown on hover. */
 export const TraceCostCell: React.MemoExoticComponent<(props: { trace: ModelTraceInfoV3 }) => JSX.Element> = memo(

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.test.tsx
@@ -239,6 +239,20 @@ describe('TracesTable', () => {
     expect(screen.getByText('request for s1-turn-2')).toBeInTheDocument();
   });
 
+  test('sums token usage in a grouped session header', async () => {
+    const traces = [makeSessionTrace('s1-turn-1', 's1'), makeSessionTrace('s1-turn-2', 's1')];
+    await renderWithProviders(
+      <TracesTable {...baseProps({ traces, visibleColumns: ['tokens'], isGroupedBySession: true })} />,
+    );
+
+    // The standard fixture gives each turn 15 tokens. A collapsed session must show their sum,
+    // rather than leaving the Tokens header cell blank.
+    expect(screen.getByText('30')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Expand session s1' }));
+    expect(screen.getAllByText('15')).toHaveLength(2);
+  });
+
   test('passes all child traces to an extra column session renderer', async () => {
     const traces = [makeSessionTrace('s1-turn-1', 's1'), makeSessionTrace('s1-turn-2', 's1')];
     const renderSessionCell = jest.fn((sessionTraces: typeof traces) => (

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
@@ -298,6 +298,11 @@ export interface TracesTableProps {
   previewLineClamp?: number;
   /** Reorders columns when a user drags one header onto another; absent → headers aren't draggable. */
   onReorderColumn?: (activeColumn: string, targetColumn: string) => void;
+  /** When true, session-level column aggregates (e.g. token totals) are suppressed because the
+   * visible page may not contain all traces for every session. Set when isGroupedBySession is true
+   * and there are multiple pages of results (hasNext || hasPrev). Mirrors the onToggleBulkRows
+   * suppression pattern: rather than show a silently-partial number, we show nothing. */
+  sessionsMayBeIncomplete?: boolean;
 }
 
 interface GroupedTraceRows {
@@ -356,6 +361,7 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
     isGroupedBySession = false,
     previewLineClamp = 1,
     onReorderColumn,
+    sessionsMayBeIncomplete = false,
   }: TracesTableProps) {
     const { theme } = useDesignSystemTheme();
     const intl = useIntl();
@@ -937,7 +943,12 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
                                           ? flexRender(firstCell.column.columnDef.cell, firstCell.getContext())
                                           : header.column.id === 'state' && lastCell
                                             ? flexRender(lastCell.column.columnDef.cell, lastCell.getContext())
-                                            : (sessionCellRenderers.get(header.column.id)?.(tracesInSession) ?? null)}
+                                            // Suppress product-owned aggregates when the page may not
+                                            // contain all traces for this session — a partial total is
+                                            // more confusing than a blank. Mirrors onToggleBulkRows.
+                                            : sessionsMayBeIncomplete
+                                              ? null
+                                              : (sessionCellRenderers.get(header.column.id)?.(tracesInSession) ?? null)}
                                 </TableCell>
                               );
                             })}
@@ -1131,7 +1142,9 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
                                         ? flexRender(firstCell.column.columnDef.cell, firstCell.getContext())
                                         : header.column.id === 'state' && lastCell
                                           ? flexRender(lastCell.column.columnDef.cell, lastCell.getContext())
-                                          : (sessionCellRenderers.get(header.column.id)?.(tracesInSession) ?? null)}
+                                          : sessionsMayBeIncomplete
+                                            ? null
+                                            : (sessionCellRenderers.get(header.column.id)?.(tracesInSession) ?? null)}
                               </TableCell>
                             );
                           })}

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTable.tsx
@@ -943,10 +943,10 @@ export const TracesTable: React.MemoExoticComponent<(props: TracesTableProps) =>
                                           ? flexRender(firstCell.column.columnDef.cell, firstCell.getContext())
                                           : header.column.id === 'state' && lastCell
                                             ? flexRender(lastCell.column.columnDef.cell, lastCell.getContext())
-                                            // Suppress product-owned aggregates when the page may not
-                                            // contain all traces for this session — a partial total is
-                                            // more confusing than a blank. Mirrors onToggleBulkRows.
-                                            : sessionsMayBeIncomplete
+                                            : // Suppress product-owned aggregates when the page may not
+                                              // contain all traces for this session — a partial total is
+                                              // more confusing than a blank. Mirrors onToggleBulkRows.
+                                              sessionsMayBeIncomplete
                                               ? null
                                               : (sessionCellRenderers.get(header.column.id)?.(tracesInSession) ?? null)}
                                 </TableCell>

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TracesTableView, type TracesTableViewProps, type TracesTableViewState } from './TracesTableView';
 import { useBulkTraceSelection } from './hooks/useBulkTraceSelection';
-import { makeTraces } from './test-utils/mockTraces';
+import { makeSessionTrace, makeTraces } from './test-utils/mockTraces';
 import { renderWithProviders } from './test-utils/renderWithProviders';
 
 const baseProps = (over: Partial<TracesTableViewProps> = {}): TracesTableViewProps => ({
@@ -107,6 +107,20 @@ describe('TracesTableView', () => {
     await renderWithProviders(<TracesTableView {...baseProps({ viewState: 'ready' })} />);
     expect(screen.getByRole('columnheader', { name: /Time/ })).toBeInTheDocument();
     expect(screen.getByText(/Rows per page/)).toBeInTheDocument();
+  });
+
+  test('forwards sessionsMayBeIncomplete so paginated grouped sessions hide partial aggregates', async () => {
+    const traces = [makeSessionTrace('s1-turn-1', 's1'), makeSessionTrace('s1-turn-2', 's1')];
+    const grouped = { traces, visibleColumns: ['tokens' as const], isGroupedBySession: true };
+
+    const { unmount } = await renderWithProviders(
+      <TracesTableView {...baseProps({ ...grouped, sessionsMayBeIncomplete: true })} />,
+    );
+    expect(screen.queryByText('30')).not.toBeInTheDocument();
+    unmount();
+
+    await renderWithProviders(<TracesTableView {...baseProps({ ...grouped, sessionsMayBeIncomplete: false })} />);
+    expect(screen.getByText('30')).toBeInTheDocument();
   });
 
   test('customEmptyState short-circuits the viewState region but keeps the toolbar', async () => {

--- a/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/TracesTableView.tsx
@@ -71,6 +71,8 @@ export interface TracesTableViewProps {
   columnHeaderActions?: Readonly<Partial<Record<string, TraceColumnHeaderAction>>>;
   /** Groups traces with a session id into collapsible session rows — forwarded to the table. */
   isGroupedBySession?: boolean;
+  /** Blanks session-level column aggregates when the page may not hold every trace of a session — forwarded to the table. */
+  sessionsMayBeIncomplete?: boolean;
   /** Maximum lines shown by input and output previews before truncation. Defaults to one line. */
   previewLineClamp?: number;
   onReorderColumn?: (activeColumn: string, targetColumn: string) => void;
@@ -211,6 +213,7 @@ export const TracesTableView: React.FC<TracesTableViewProps> = (props: TracesTab
       onHideColumn={props.onHideColumn}
       columnHeaderActions={props.columnHeaderActions}
       isGroupedBySession={props.isGroupedBySession}
+      sessionsMayBeIncomplete={props.sessionsMayBeIncomplete}
       previewLineClamp={props.previewLineClamp}
       onReorderColumn={props.onReorderColumn}
     />

--- a/mlflow/server/js/src/shared/web-shared/traces-table/columns.tsx
+++ b/mlflow/server/js/src/shared/web-shared/traces-table/columns.tsx
@@ -1,5 +1,5 @@
 import { FormattedMessage, type IntlShape } from '@databricks/i18n';
-import type { CellContext, ColumnDef } from '@tanstack/react-table';
+import type { CellContext } from '@tanstack/react-table';
 import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
 import { COLUMN_SIZES } from './constants';
 import { TRACE_COLUMN_LABELS } from './columnLabels';
@@ -19,6 +19,7 @@ import {
   TraceTagsCell,
   TraceMetadataCell,
   TraceTokensCell,
+  SessionTokensCell,
   TraceUserCell,
 } from './TraceCell';
 
@@ -57,7 +58,7 @@ export const openLabel = (intl: IntlShape, traceId: string, column: string): str
 
 // A column def whose `id` is a known TraceColumnId (TanStack widens `id` to `string`; narrowing it
 // here lets the visibility lookups stay cast-free and gives an exhaustiveness check on the list).
-type StandardColumnDef = ColumnDef<ModelTraceInfoV3> & { id: TraceColumnId };
+type StandardColumnDef = TraceTableColumn & { id: TraceColumnId };
 
 /**
  * One ColumnDef per TraceColumnId, at module scope (never rebuilt per render — the load-bearing perf
@@ -172,6 +173,7 @@ export const STANDARD_COLUMNS: StandardColumnDef[] = [
     ...COLUMN_SIZES.tokens,
     header: () => <FormattedMessage {...TRACE_COLUMN_LABELS.tokens} />,
     cell: (ctx) => <TraceTokensCell trace={ctx.row.original} />,
+    renderSessionCell: (traces) => <SessionTokensCell traces={traces} />,
   },
   {
     id: 'cost',


### PR DESCRIPTION
### Related Issues/PRs

Closes #25607

### What changes are proposed in this pull request?

Adds the missing session-summary renderer for the standard Tokens column in the V4 Traces table. The renderer sums the available input, output, and total token counts across child traces and reuses the existing token presentation.

Adds a grouped-session regression test that verifies two 15-token child traces render a 30-token total while collapsed and retain their individual totals when expanded.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests (added the grouped-session token-total regression coverage)
- [ ] Manual tests

Local test execution was blocked because `yarn install --immutable` could not download five `@dnd-kit/*` packages after repeated 503 responses from the public Yarn registry. `git diff --check` passes, and the managed Gitleaks configuration scanned the exact one-commit range with no leaks found.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Grouped trace sessions now display the aggregate token total in their collapsed header.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release