### PR TITLE
Use agent terminology in first-trace onboarding

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.test.tsx
@@ -101,6 +101,7 @@ describe('AgentActionCard', () => {
       </DesignSystemProvider>,
     );
     expect(screen.getByRole('tab', { name: /One-line setup/ })).toBeInTheDocument();
+    expect(screen.getByText(/with instructions to instrument your agent\./)).toBeInTheDocument();
   });
 
   it('clicking "Open assistant" opens the panel and prefills the chat input with the prompt', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/onboarding/AgentActionCard.tsx
@@ -147,7 +147,7 @@ export const AgentActionCard = ({
           <Tabs.Content value="agent-setup" css={{ paddingTop: 0 }}>
             <Typography.Text color="secondary" css={{ fontSize: 13, display: 'block', marginBottom: theme.spacing.sm }}>
               <FormattedMessage
-                defaultMessage="Run this in your terminal to install MLflow skills into your project and launch your coding agent (Claude Code, Codex, or OpenCode) with instructions to instrument your app."
+                defaultMessage="Run this in your terminal to install MLflow skills into your project and launch your coding agent (Claude Code, Codex, or OpenCode) with instructions to instrument your agent."
                 description="Description above the mlflow agent setup terminal command in the agent action card"
               />
             </Typography.Text>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changes the one-line first-trace setup guidance from “instrument your app” to “instrument your agent,” matching the card’s coding-agent workflow.

Closes #25609.

## How is this PR tested?

Adds focused React Testing Library coverage that asserts the visible one-line setup guidance uses “instrument your agent.”

The local test command could not run because Yarn is not installed in this environment (`yarn: command not found`).

## Checklist

- [x] I have signed all commits with DCO.