### PR TITLE
Record LLM cost in the Codex CLI tracing integration

### DIFF
--- a/libs/typescript/integrations/codex/package.json
+++ b/libs/typescript/integrations/codex/package.json
@@ -41,6 +41,7 @@
     "build:bundle": "node esbuild.config.mjs",
     "prepublishOnly": "npm run build",
     "test": "jest --config jest.config.cjs",
+    "sync:pricing": "node scripts/sync-openai-pricing.mjs && prettier --write src/openaiPricing.ts",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "format": "prettier --write .",

--- a/libs/typescript/integrations/codex/scripts/sync-openai-pricing.mjs
+++ b/libs/typescript/integrations/codex/scripts/sync-openai-pricing.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Regenerate src/openaiPricing.ts from MLflow's bundled model catalog
+ * (mlflow/utils/model_catalog/openai.json), so the plugin prices OpenAI
+ * models from the same data as MLflow's Python cost pipeline.
+ *
+ * Usage: npm run sync:pricing
+ *
+ * tests/openaiPricing.test.ts fails when the generated file drifts from
+ * the catalog.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = join(packageDir, '../../../..');
+const catalogPath = join(repoRoot, 'mlflow/utils/model_catalog/openai.json');
+const outputPath = join(packageDir, 'src/openaiPricing.ts');
+
+const catalog = JSON.parse(readFileSync(catalogPath, 'utf8'));
+
+const entries = Object.entries(catalog.models)
+  .filter(
+    ([, entry]) =>
+      entry.pricing?.input_per_million_tokens != null &&
+      entry.pricing?.output_per_million_tokens != null,
+  )
+  .sort(([a], [b]) => (a < b ? -1 : 1));
+
+const lines = entries.map(([name, entry]) => {
+  const pricing = entry.pricing;
+  const fields = [
+    `input: ${pricing.input_per_million_tokens}`,
+    `output: ${pricing.output_per_million_tokens}`,
+  ];
+  if (pricing.cache_read_per_million_tokens != null) {
+    fields.push(`cacheRead: ${pricing.cache_read_per_million_tokens}`);
+  }
+  if (pricing.cache_write_per_million_tokens != null) {
+    fields.push(`cacheWrite: ${pricing.cache_write_per_million_tokens}`);
+  }
+  return `  '${name}': { ${fields.join(', ')} },`;
+});
+
+const content = `/**
+ * GENERATED FILE - DO NOT EDIT BY HAND.
+ *
+ * Snapshot of OpenAI per-model pricing from MLflow's bundled model catalog
+ * (mlflow/utils/model_catalog/openai.json). Regenerate with:
+ *
+ *   npm run sync:pricing
+ *
+ * tests/openaiPricing.test.ts fails when this file drifts from the catalog.
+ */
+
+/** Per-million-token USD rates for one OpenAI model. */
+export interface OpenAIModelRate {
+  /** USD per million regular (non-cached) input tokens. */
+  input: number;
+  /** USD per million output tokens. */
+  output: number;
+  /** USD per million cache-read (cached) input tokens. */
+  cacheRead?: number;
+  /** USD per million cache-write input tokens (unused by OpenAI today). */
+  cacheWrite?: number;
+}
+
+export const OPENAI_MODEL_RATES: Readonly<Record<string, OpenAIModelRate>> = {
+${lines.join('\n')}
+};
+`;
+
+writeFileSync(outputPath, content);
+console.log(`Wrote ${entries.length} models to ${outputPath}`);

--- a/libs/typescript/integrations/codex/src/modelCatalog.ts
+++ b/libs/typescript/integrations/codex/src/modelCatalog.ts
@@ -1,0 +1,184 @@
+/**
+ * Remote model-catalog lookup, mirroring Python's `mlflow/utils/providers.py`.
+ *
+ * Rates are fetched from the published catalog (a GitHub Release asset updated
+ * weekly by CI) so pricing stays current between npm releases. Python caches
+ * fetches in memory with a TTL; the notify hook is a short-lived process that
+ * runs after every assistant turn, so the cache lives on the filesystem
+ * instead. Like Python, a failed fetch is also cached for the TTL (as a
+ * `rates: null` marker) so offline machines stall at most once per TTL window,
+ * and callers fall back to the bundled snapshot (`openaiPricing.ts`) when this
+ * returns null.
+ *
+ * Same semantics as Python: `MLFLOW_MODEL_CATALOG_URI` overrides the base URI
+ * (`file://` mirrors supported for air-gapped environments; empty string
+ * disables remote lookup), and `MLFLOW_MODEL_CATALOG_CACHE_TTL` sets the cache
+ * TTL in seconds (0 disables caching).
+ */
+import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { OpenAIModelRate } from './openaiPricing.js';
+
+export const MODEL_CATALOG_URI_ENV = 'MLFLOW_MODEL_CATALOG_URI';
+export const MODEL_CATALOG_CACHE_TTL_ENV = 'MLFLOW_MODEL_CATALOG_CACHE_TTL';
+
+const DEFAULT_CATALOG_URI =
+  'https://github.com/mlflow/mlflow/releases/download/model-catalog%2Flatest';
+const DEFAULT_CACHE_TTL_SECONDS = 86400;
+const FETCH_TIMEOUT_MS = 5000;
+const CACHE_SCHEMA_VERSION = 1;
+
+interface CatalogPricing {
+  input_per_million_tokens?: number;
+  output_per_million_tokens?: number;
+  cache_read_per_million_tokens?: number;
+  cache_write_per_million_tokens?: number;
+}
+
+interface CatalogFile {
+  models?: Record<string, { pricing?: CatalogPricing }>;
+}
+
+interface CacheFile {
+  schemaVersion: number;
+  fetchedAt: string;
+  /** null records a failed fetch so it is not retried within the TTL. */
+  rates: Record<string, OpenAIModelRate> | null;
+}
+
+export interface LoadCatalogOptions {
+  /** Base URI override (default: MLFLOW_MODEL_CATALOG_URI or the GitHub Release). */
+  baseUri?: string;
+  /** Cache directory override (default: ~/.mlflow/model_catalog_cache). */
+  cacheDir?: string;
+  /** Cache TTL override in seconds (default: MLFLOW_MODEL_CATALOG_CACHE_TTL or 86400). */
+  ttlSeconds?: number;
+  /** fetch override for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+/** Convert a catalog file to the per-model rate map used by calculateCost. */
+export function catalogToRates(catalog: CatalogFile): Record<string, OpenAIModelRate> {
+  const rates: Record<string, OpenAIModelRate> = {};
+  for (const [name, entry] of Object.entries(catalog.models ?? {})) {
+    const pricing = entry.pricing;
+    if (pricing?.input_per_million_tokens == null || pricing?.output_per_million_tokens == null) {
+      continue;
+    }
+    rates[name] = {
+      input: pricing.input_per_million_tokens,
+      output: pricing.output_per_million_tokens,
+      ...(pricing.cache_read_per_million_tokens != null && {
+        cacheRead: pricing.cache_read_per_million_tokens,
+      }),
+      ...(pricing.cache_write_per_million_tokens != null && {
+        cacheWrite: pricing.cache_write_per_million_tokens,
+      }),
+    };
+  }
+  return rates;
+}
+
+function envTtlSeconds(): number {
+  const raw = process.env[MODEL_CATALOG_CACHE_TTL_ENV];
+  const parsed = raw == null || raw.trim() === '' ? NaN : Number(raw);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_CACHE_TTL_SECONDS;
+}
+
+/** Read the cache file; undefined = miss (absent, stale, or unreadable). */
+function readCache(
+  cachePath: string,
+  ttlSeconds: number,
+): Record<string, OpenAIModelRate> | null | undefined {
+  try {
+    if (Date.now() - statSync(cachePath).mtimeMs > ttlSeconds * 1000) {
+      return undefined;
+    }
+    const cached = JSON.parse(readFileSync(cachePath, 'utf8')) as CacheFile;
+    if (cached.schemaVersion !== CACHE_SCHEMA_VERSION) {
+      return undefined;
+    }
+    if (cached.rates == null) {
+      return null;
+    }
+    // An empty rate map would price every model as unknown; treat it as a miss
+    // so the next call refetches, matching how fetchRates rejects empty rates.
+    return typeof cached.rates === 'object' && Object.keys(cached.rates).length > 0
+      ? cached.rates
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeCache(cachePath: string, rates: Record<string, OpenAIModelRate> | null): void {
+  // Best-effort: an unwritable cache dir just means refetching next time.
+  try {
+    mkdirSync(join(cachePath, '..'), { recursive: true });
+    const cache: CacheFile = {
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      fetchedAt: new Date().toISOString(),
+      rates,
+    };
+    writeFileSync(cachePath, JSON.stringify(cache));
+  } catch {
+    // ignore
+  }
+}
+
+async function fetchRates(
+  baseUri: string,
+  fetchImpl: typeof fetch,
+): Promise<Record<string, OpenAIModelRate> | null> {
+  try {
+    const url = `${baseUri.replace(/\/+$/, '')}/openai.json`;
+    let raw: string;
+    if (url.startsWith('file:')) {
+      raw = readFileSync(fileURLToPath(new URL(url)), 'utf8');
+    } else {
+      const res = await fetchImpl(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+      if (!res.ok) {
+        return null;
+      }
+      raw = await res.text();
+    }
+    const rates = catalogToRates(JSON.parse(raw) as CatalogFile);
+    return Object.keys(rates).length ? rates : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load model rates from the remote catalog, using the filesystem cache when
+ * fresh. Returns null when remote lookup is disabled, fails, or yields no
+ * usable rates — callers fall back to the bundled snapshot.
+ */
+export async function loadCatalogRates(
+  options: LoadCatalogOptions = {},
+): Promise<Record<string, OpenAIModelRate> | null> {
+  const baseUri = options.baseUri ?? process.env[MODEL_CATALOG_URI_ENV] ?? DEFAULT_CATALOG_URI;
+  if (!baseUri.trim()) {
+    return null;
+  }
+
+  const ttlSeconds = options.ttlSeconds ?? envTtlSeconds();
+  const cachePath = join(
+    options.cacheDir ?? join(homedir(), '.mlflow', 'model_catalog_cache'),
+    'openai.json',
+  );
+
+  if (ttlSeconds > 0) {
+    const cached = readCache(cachePath, ttlSeconds);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
+
+  const rates = await fetchRates(baseUri, options.fetchImpl ?? fetch);
+  writeCache(cachePath, rates);
+  return rates;
+}

--- a/libs/typescript/integrations/codex/src/openaiPricing.ts
+++ b/libs/typescript/integrations/codex/src/openaiPricing.ts
@@ -1,0 +1,129 @@
+/**
+ * GENERATED FILE - DO NOT EDIT BY HAND.
+ *
+ * Snapshot of OpenAI per-model pricing from MLflow's bundled model catalog
+ * (mlflow/utils/model_catalog/openai.json). Regenerate with:
+ *
+ *   npm run sync:pricing
+ *
+ * tests/openaiPricing.test.ts fails when this file drifts from the catalog.
+ */
+
+/** Per-million-token USD rates for one OpenAI model. */
+export interface OpenAIModelRate {
+  /** USD per million regular (non-cached) input tokens. */
+  input: number;
+  /** USD per million output tokens. */
+  output: number;
+  /** USD per million cache-read (cached) input tokens. */
+  cacheRead?: number;
+  /** USD per million cache-write input tokens (unused by OpenAI today). */
+  cacheWrite?: number;
+}
+
+export const OPENAI_MODEL_RATES: Readonly<Record<string, OpenAIModelRate>> = {
+  'chat-latest': { input: 5, output: 30, cacheRead: 0.5 },
+  'chatgpt-4o-latest': { input: 5, output: 15 },
+  'daybreak-blue-latest': { input: 4, output: 20, cacheRead: 0.4, cacheWrite: 5 },
+  'daybreak-red-latest': { input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 15.625 },
+  'gpt-3.5-turbo': { input: 0.5, output: 1.5 },
+  'gpt-3.5-turbo-0125': { input: 0.5, output: 1.5 },
+  'gpt-3.5-turbo-1106': { input: 1, output: 2 },
+  'gpt-3.5-turbo-16k': { input: 3, output: 4 },
+  'gpt-4': { input: 30, output: 60 },
+  'gpt-4-0125-preview': { input: 10, output: 30 },
+  'gpt-4-0314': { input: 30, output: 60 },
+  'gpt-4-0613': { input: 30, output: 60 },
+  'gpt-4-1106-preview': { input: 10, output: 30 },
+  'gpt-4-turbo': { input: 10, output: 30 },
+  'gpt-4-turbo-2024-04-09': { input: 10, output: 30 },
+  'gpt-4-turbo-preview': { input: 10, output: 30 },
+  'gpt-4.1': { input: 2, output: 8, cacheRead: 0.5 },
+  'gpt-4.1-2025-04-14': { input: 2, output: 8, cacheRead: 0.5 },
+  'gpt-4.1-mini': { input: 0.4, output: 1.6, cacheRead: 0.1 },
+  'gpt-4.1-mini-2025-04-14': { input: 0.4, output: 1.6, cacheRead: 0.1 },
+  'gpt-4.1-nano': { input: 0.1, output: 0.4, cacheRead: 0.025 },
+  'gpt-4.1-nano-2025-04-14': { input: 0.1, output: 0.4, cacheRead: 0.025 },
+  'gpt-4o': { input: 2.5, output: 10, cacheRead: 1.25 },
+  'gpt-4o-2024-05-13': { input: 5, output: 15 },
+  'gpt-4o-2024-08-06': { input: 2.5, output: 10, cacheRead: 1.25 },
+  'gpt-4o-2024-11-20': { input: 2.5, output: 10, cacheRead: 1.25 },
+  'gpt-4o-audio-preview': { input: 2.5, output: 10 },
+  'gpt-4o-audio-preview-2024-12-17': { input: 2.5, output: 10 },
+  'gpt-4o-audio-preview-2025-06-03': { input: 2.5, output: 10 },
+  'gpt-4o-mini': { input: 0.15, output: 0.6, cacheRead: 0.075 },
+  'gpt-4o-mini-2024-07-18': { input: 0.15, output: 0.6, cacheRead: 0.075 },
+  'gpt-4o-mini-audio-preview': { input: 0.15, output: 0.6 },
+  'gpt-4o-mini-audio-preview-2024-12-17': { input: 0.15, output: 0.6 },
+  'gpt-4o-mini-realtime-preview': { input: 0.6, output: 2.4, cacheRead: 0.3 },
+  'gpt-4o-mini-realtime-preview-2024-12-17': { input: 0.6, output: 2.4, cacheRead: 0.3 },
+  'gpt-4o-mini-search-preview': { input: 0.15, output: 0.6, cacheRead: 0.075 },
+  'gpt-4o-mini-search-preview-2025-03-11': { input: 0.15, output: 0.6, cacheRead: 0.075 },
+  'gpt-4o-realtime-preview': { input: 5, output: 20, cacheRead: 2.5 },
+  'gpt-4o-realtime-preview-2024-12-17': { input: 5, output: 20, cacheRead: 2.5 },
+  'gpt-4o-realtime-preview-2025-06-03': { input: 5, output: 20, cacheRead: 2.5 },
+  'gpt-4o-search-preview': { input: 2.5, output: 10, cacheRead: 1.25 },
+  'gpt-4o-search-preview-2025-03-11': { input: 2.5, output: 10, cacheRead: 1.25 },
+  'gpt-5': { input: 1.25, output: 10, cacheRead: 0.125 },
+  'gpt-5-2025-08-07': { input: 1.25, output: 10, cacheRead: 0.125 },
+  'gpt-5-chat': { input: 1.25, output: 10, cacheRead: 0.125 },
+  'gpt-5-chat-latest': { input: 1.25, output: 10, cacheRead: 0.125 },
+  'gpt-5-mini': { input: 0.25, output: 2, cacheRead: 0.025 },
+  'gpt-5-mini-2025-08-07': { input: 0.25, output: 2, cacheRead: 0.025 },
+  'gpt-5-nano': { input: 0.05, output: 0.4, cacheRead: 0.005 },
+  'gpt-5-nano-2025-08-07': { input: 0.05, output: 0.4, cacheRead: 0.005 },
+  'gpt-5-search-api': { input: 1.25, output: 10, cacheRead: 0.125 },
+  'gpt-5-search-api-2025-10-14': { input: 1.25, output: 10, cacheRead: 0.125 },
+  'gpt-5.1': { input: 1.25, output: 10, cacheRead: 0.125 },
+  'gpt-5.1-2025-11-13': { input: 1.25, output: 10, cacheRead: 0.125 },
+  'gpt-5.1-chat-latest': { input: 1.25, output: 10, cacheRead: 0.125 },
+  'gpt-5.2': { input: 1.75, output: 14, cacheRead: 0.175 },
+  'gpt-5.2-2025-12-11': { input: 1.75, output: 14, cacheRead: 0.175 },
+  'gpt-5.2-chat-latest': { input: 1.75, output: 14, cacheRead: 0.175 },
+  'gpt-5.3-chat-latest': { input: 1.75, output: 14, cacheRead: 0.175 },
+  'gpt-5.4': { input: 2.5, output: 15, cacheRead: 0.25 },
+  'gpt-5.4-2026-03-05': { input: 2.5, output: 15, cacheRead: 0.25 },
+  'gpt-5.4-mini': { input: 0.75, output: 4.5, cacheRead: 0.075 },
+  'gpt-5.4-mini-2026-03-17': { input: 0.75, output: 4.5, cacheRead: 0.075 },
+  'gpt-5.4-nano': { input: 0.2, output: 1.25, cacheRead: 0.02 },
+  'gpt-5.4-nano-2026-03-17': { input: 0.2, output: 1.25, cacheRead: 0.02 },
+  'gpt-5.5': { input: 5, output: 30, cacheRead: 0.5 },
+  'gpt-5.5-2026-04-23': { input: 5, output: 30, cacheRead: 0.5 },
+  'gpt-5.6': { input: 4, output: 20, cacheRead: 0.4, cacheWrite: 5 },
+  'gpt-5.6-cyber': { input: 12.5, output: 75, cacheRead: 1.25, cacheWrite: 15.625 },
+  'gpt-5.6-luna': { input: 0.2, output: 1.2, cacheRead: 0.02, cacheWrite: 0.25 },
+  'gpt-5.6-sol': { input: 4, output: 20, cacheRead: 0.4, cacheWrite: 5 },
+  'gpt-5.6-terra': { input: 2, output: 12, cacheRead: 0.2, cacheWrite: 2.5 },
+  'gpt-6-astra': { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  'gpt-audio': { input: 2.5, output: 10 },
+  'gpt-audio-1.5': { input: 2.5, output: 10 },
+  'gpt-audio-2025-08-28': { input: 2.5, output: 10 },
+  'gpt-audio-mini': { input: 0.6, output: 2.4 },
+  'gpt-audio-mini-2025-10-06': { input: 0.6, output: 2.4 },
+  'gpt-audio-mini-2025-12-15': { input: 0.6, output: 2.4 },
+  'gpt-image-1.5': { input: 5, output: 10, cacheRead: 1.25 },
+  'gpt-image-1.5-2025-12-16': { input: 5, output: 10, cacheRead: 1.25 },
+  'gpt-image-2': { input: 5, output: 10, cacheRead: 1.25 },
+  'gpt-image-2-2026-04-21': { input: 5, output: 10, cacheRead: 1.25 },
+  'gpt-realtime': { input: 4, output: 16, cacheRead: 0.4 },
+  'gpt-realtime-1.5': { input: 4, output: 16, cacheRead: 0.4 },
+  'gpt-realtime-2': { input: 4, output: 16, cacheRead: 0.4 },
+  'gpt-realtime-2.1': { input: 4, output: 24, cacheRead: 0.4 },
+  'gpt-realtime-2.1-mini': { input: 0.6, output: 2.4, cacheRead: 0.06 },
+  'gpt-realtime-2025-08-28': { input: 4, output: 16, cacheRead: 0.4 },
+  'gpt-realtime-mini': { input: 0.6, output: 2.4 },
+  'gpt-realtime-mini-2025-10-06': { input: 0.6, output: 2.4, cacheRead: 0.06 },
+  'gpt-realtime-mini-2025-12-15': { input: 0.6, output: 2.4, cacheRead: 0.06 },
+  o1: { input: 15, output: 60, cacheRead: 7.5 },
+  'o1-2024-12-17': { input: 15, output: 60, cacheRead: 7.5 },
+  o3: { input: 2, output: 8, cacheRead: 0.5 },
+  'o3-2025-04-16': { input: 2, output: 8, cacheRead: 0.5 },
+  'o3-mini': { input: 1.1, output: 4.4, cacheRead: 0.55 },
+  'o3-mini-2025-01-31': { input: 1.1, output: 4.4, cacheRead: 0.55 },
+  'o4-mini': { input: 1.1, output: 4.4, cacheRead: 0.275 },
+  'o4-mini-2025-04-16': { input: 1.1, output: 4.4, cacheRead: 0.275 },
+  'text-embedding-3-large': { input: 0.13, output: 0 },
+  'text-embedding-3-small': { input: 0.02, output: 0 },
+  'text-embedding-ada-002': { input: 0.1, output: 0 },
+  'text-embedding-ada-002-v2': { input: 0.1, output: 0 },
+};

--- a/libs/typescript/integrations/codex/src/pricing.ts
+++ b/libs/typescript/integrations/codex/src/pricing.ts
@@ -1,0 +1,113 @@
+/**
+ * Cost estimation for OpenAI models, used to populate `mlflow.llm.cost`.
+ *
+ * The Codex transcript carries the model and token usage but no cost, and
+ * neither the MLflow TypeScript SDK nor the Databricks tracing backend computes
+ * cost from usage (unlike the OSS Python path, which does it server-side or via
+ * the client on Databricks). So the plugin computes it here and writes it onto
+ * the spans/trace in the same shape MLflow's Python cost pipeline produces.
+ *
+ * Rates come from MLflow's model catalog, the same data the Python cost
+ * pipeline reads: the published catalog fetched at runtime when available
+ * (see `modelCatalog.ts`), falling back to the snapshot bundled in
+ * `openaiPricing.ts` at development time (`npm run sync:pricing`).
+ *
+ * OpenAI reports `input_tokens` as the total prompt size and
+ * `cached_input_tokens` as the cached subset of it, so cached tokens are priced
+ * at the cache-read rate and the remainder at the base input rate. This differs
+ * from Anthropic, which reports cache reads separately from `input_tokens`.
+ */
+import type { TokenUsage } from './types.js';
+import { OPENAI_MODEL_RATES, type OpenAIModelRate } from './openaiPricing.js';
+
+export type ModelRates = Readonly<Record<string, OpenAIModelRate>>;
+
+/** Span attribute holding a single call's cost, matching Python's SpanAttributeKey.LLM_COST. */
+export const LLM_COST_ATTRIBUTE = 'mlflow.llm.cost';
+
+/** Trace metadata holding the aggregated cost, matching Python's TraceMetadataKey.COST. */
+export const TRACE_COST_METADATA = 'mlflow.trace.cost';
+
+export interface LlmCost {
+  input_cost: number;
+  output_cost: number;
+  total_cost: number;
+}
+
+const PER_MTOK = 1e-6;
+
+let activeRates: ModelRates = OPENAI_MODEL_RATES;
+
+/**
+ * Replace the rate table used by calculateCost — processNotify calls this with
+ * rates resolved from the remote model catalog. Passing null restores the
+ * bundled snapshot.
+ */
+export function setModelRates(rates: ModelRates | null): void {
+  activeRates = rates ?? OPENAI_MODEL_RATES;
+}
+
+function lookupRate(model: string): OpenAIModelRate | undefined {
+  const exact = activeRates[model];
+  if (exact) {
+    return exact;
+  }
+  // A dated snapshot newer than the catalog (e.g. gpt-5-2026-01-01) falls back
+  // to its undated family alias.
+  const undated = model.replace(/-\d{4}-\d{2}-\d{2}$/, '');
+  return undated === model ? undefined : activeRates[undated];
+}
+
+/**
+ * Estimate the cost of a single LLM call from its model and token usage.
+ * Returns null when the model is unknown or there is no billable base usage.
+ */
+export function calculateCost(
+  model: string | undefined,
+  usage: TokenUsage | undefined,
+): LlmCost | null {
+  if (!model || !usage) {
+    return null;
+  }
+  const rate = lookupRate(model);
+  if (!rate) {
+    return null;
+  }
+
+  const inputTokens = usage.input_tokens || 0;
+  const outputTokens = usage.output_tokens || 0;
+  // Matches the Python pipeline: no billable base usage -> no cost.
+  if (inputTokens === 0 && outputTokens === 0) {
+    return null;
+  }
+
+  // OpenAI's cached_input_tokens is a subset of input_tokens: price the cached
+  // portion at the cache-read rate and the remainder at the base input rate.
+  const cached = Math.min(usage.cached_input_tokens || 0, inputTokens);
+  const uncachedInput = inputTokens - cached;
+
+  const inputCost =
+    uncachedInput * rate.input * PER_MTOK + cached * (rate.cacheRead ?? rate.input) * PER_MTOK;
+  const outputCost = outputTokens * rate.output * PER_MTOK;
+
+  return {
+    input_cost: inputCost,
+    output_cost: outputCost,
+    total_cost: inputCost + outputCost,
+  };
+}
+
+/** Sum per-call costs into a single trace-level total; null when there are none. */
+export function sumCosts(costs: readonly LlmCost[]): LlmCost | null {
+  if (!costs.length) {
+    return null;
+  }
+  return costs.reduce(
+    (acc, c) => ({
+      input_cost: acc.input_cost + c.input_cost,
+      output_cost: acc.output_cost + c.output_cost,
+      total_cost: acc.total_cost + c.total_cost,
+    }),
+    { input_cost: 0, output_cost: 0, total_cost: 0 },
+  );
+}

--- a/libs/typescript/integrations/codex/src/tracing.ts
+++ b/libs/typescript/integrations/codex/src/tracing.ts
@@ -34,6 +34,7 @@ import type {
   NotifyPayload,
   RolloutLine,
   ResponseItemPayload,
+  TokenUsage,
 } from './types.js';
 import {
   parseTimestampToNs,
@@ -45,6 +46,14 @@ import {
   getLastTurnRecords,
   readTranscript,
 } from './transcript.js';
+import {
+  LLM_COST_ATTRIBUTE,
+  TRACE_COST_METADATA,
+  calculateCost,
+  setModelRates,
+  type LlmCost,
+} from './pricing.js';
+import { loadCatalogRates } from './modelCatalog.js';
 
 /**
  * Process a Codex notify hook payload and create an MLflow trace.
@@ -77,6 +86,10 @@ export async function processNotify(payload: NotifyPayload): Promise<void> {
     }
   }
 
+  // Prefer fresh rates from the published model catalog (filesystem TTL cache);
+  // calculateCost falls back to the bundled snapshot when unavailable.
+  setModelRates(await loadCatalogRates());
+
   // Root span bracket: use task_started / task_complete from the transcript
   // so the root span covers the full turn. Without this, the root span would
   // only cover the hook's own wall-clock execution time (a few ms), which is
@@ -98,21 +111,20 @@ export async function processNotify(payload: NotifyPayload): Promise<void> {
     ...(rootStartNs != null ? { startTimeNs: rootStartNs } : {}),
   });
 
+  // Cost is computed once per turn from the cumulative token usage and attached
+  // to the final LLM span (token usage goes there too), then summed onto the
+  // trace below, matching the claude-code integration and the Python pipeline.
+  let turnCost: LlmCost | null = null;
+
   // If we have transcript data, create detailed child spans
   if (turnRecords && turnRecords.length > 0) {
-    createChildSpans(rootSpan, turnRecords, model);
-
     const tokenUsage = getTokenUsage(turnRecords);
-    if (tokenUsage) {
-      rootSpan.setAttribute(SpanAttributeKey.TOKEN_USAGE, {
-        [TokenUsageKey.INPUT_TOKENS]: tokenUsage.input_tokens,
-        [TokenUsageKey.OUTPUT_TOKENS]: tokenUsage.output_tokens,
-        [TokenUsageKey.TOTAL_TOKENS]: tokenUsage.total_tokens,
-      });
-    }
+    turnCost = calculateCost(model, tokenUsage ?? undefined);
+    createChildSpans(rootSpan, turnRecords, model, tokenUsage, turnCost);
   } else {
     // Fallback: create a simple LLM span from the notify data using the same
-    // OpenAI chat format the transcript path produces.
+    // OpenAI chat format the transcript path produces. The notify payload has
+    // no token usage, so this path reports the model but no cost.
     const llmSpan = startSpan({
       name: 'llm_call',
       parent: rootSpan,
@@ -121,7 +133,7 @@ export async function processNotify(payload: NotifyPayload): Promise<void> {
         model,
         messages: [{ role: 'user', content: userPrompt }],
       },
-      attributes: { model },
+      attributes: { model, 'mlflow.llm.model': model },
     });
     llmSpan.end({
       outputs: {
@@ -143,6 +155,7 @@ export async function processNotify(payload: NotifyPayload): Promise<void> {
         ...trace.info.traceMetadata,
         [TraceMetadataKey.TRACE_SESSION]: sessionId,
         [TraceMetadataKey.TRACE_USER]: process.env.USER ?? '',
+        ...(turnCost ? { [TRACE_COST_METADATA]: JSON.stringify(turnCost) } : {}),
       };
     }
   }
@@ -229,6 +242,8 @@ export function createChildSpans(
   parentSpan: LiveSpan,
   turnRecords: RolloutLine[],
   model: string,
+  tokenUsage: TokenUsage | null = null,
+  cost: LlmCost | null = null,
 ): void {
   const toolResults = buildToolResultMap(turnRecords);
   const toolEndTimes = buildToolEndTimes(turnRecords);
@@ -239,6 +254,22 @@ export function createChildSpans(
   let prevBoundaryNs: number | null = findTaskStartedNs(turnRecords);
 
   const responseItems = turnRecords.filter((record) => record.type === 'response_item');
+
+  // Codex reports usage cumulatively once per turn, so token usage and cost go
+  // on the final assistant LLM span. MLflow aggregates LLM-span usage/cost for
+  // the trace list's Tokens and Cost columns.
+  let lastAssistantIndex = -1;
+  for (let i = responseItems.length - 1; i >= 0; i--) {
+    const payload = responseItems[i].payload as ResponseItemPayload;
+    if (
+      payload.type === 'message' &&
+      payload.role === 'assistant' &&
+      extractTextFromContent(payload.content).trim()
+    ) {
+      lastAssistantIndex = i;
+      break;
+    }
+  }
 
   for (let i = 0; i < responseItems.length; i++) {
     const record = responseItems[i];
@@ -258,8 +289,20 @@ export function createChildSpans(
           spanType: SpanType.LLM,
           startTimeNs: prevBoundaryNs ?? timestampNs,
           inputs: { model, messages },
-          attributes: { model },
+          attributes: { model, 'mlflow.llm.model': model },
         });
+        if (i === lastAssistantIndex) {
+          if (tokenUsage) {
+            llmSpan.setAttribute(SpanAttributeKey.TOKEN_USAGE, {
+              [TokenUsageKey.INPUT_TOKENS]: tokenUsage.input_tokens,
+              [TokenUsageKey.OUTPUT_TOKENS]: tokenUsage.output_tokens,
+              [TokenUsageKey.TOTAL_TOKENS]: tokenUsage.total_tokens,
+            });
+          }
+          if (cost) {
+            llmSpan.setAttribute(LLM_COST_ATTRIBUTE, cost);
+          }
+        }
         llmSpan.end({
           outputs: {
             choices: [{ message: { role: 'assistant', content: text } }],

--- a/libs/typescript/integrations/codex/src/transcript.ts
+++ b/libs/typescript/integrations/codex/src/transcript.ts
@@ -129,10 +129,17 @@ export function getLastTurnRecords(records: RolloutLine[]): RolloutLine[] {
 }
 
 /**
- * Extract cumulative token usage from the last token_count event in a set of records.
+ * Sum the per-request token usage across a set of records.
+ *
+ * Codex emits a `token_count` event after each model request, where
+ * `info.last_token_usage` is that one request's usage (a separate
+ * `total_token_usage` tracks the cumulative session total). A tool-using turn
+ * makes several billed requests, so the turn's usage is the sum of each
+ * request's `last_token_usage`. Callers pass turn-scoped records, so this sums
+ * one turn. Returns null when no request reported usage.
  */
 export function getTokenUsage(records: RolloutLine[]): TokenUsage | null {
-  let usage: TokenUsage | null = null;
+  let total: TokenUsage | null = null;
   for (const record of records) {
     if (record.type !== 'event_msg') {
       continue;
@@ -141,11 +148,25 @@ export function getTokenUsage(records: RolloutLine[]): TokenUsage | null {
     if (payload.type !== 'token_count') {
       continue;
     }
-    if (payload.info?.last_token_usage) {
-      usage = payload.info.last_token_usage;
+    const usage = payload.info?.last_token_usage;
+    if (!usage) {
+      continue;
+    }
+    if (total == null) {
+      total = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+    }
+    total.input_tokens += usage.input_tokens || 0;
+    total.output_tokens += usage.output_tokens || 0;
+    total.total_tokens += usage.total_tokens || 0;
+    if (usage.cached_input_tokens != null) {
+      total.cached_input_tokens = (total.cached_input_tokens ?? 0) + usage.cached_input_tokens;
+    }
+    if (usage.reasoning_output_tokens != null) {
+      total.reasoning_output_tokens =
+        (total.reasoning_output_tokens ?? 0) + usage.reasoning_output_tokens;
     }
   }
-  return usage;
+  return total;
 }
 
 /**

--- a/libs/typescript/integrations/codex/tests/fixtures/priced-turn.jsonl
+++ b/libs/typescript/integrations/codex/tests/fixtures/priced-turn.jsonl
@@ -1,0 +1,6 @@
+{"timestamp":"2026-04-05T10:00:00Z","type":"session_meta","payload":{"id":"priced-session","model":"gpt-4o","cwd":"/tmp/test","originator":"codex-tui","cli_version":"0.118.0","source":"cli"}}
+{"timestamp":"2026-04-05T10:00:00Z","type":"event_msg","payload":{"type":"task_started"}}
+{"timestamp":"2026-04-05T10:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}
+{"timestamp":"2026-04-05T10:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi there"}]}}
+{"timestamp":"2026-04-05T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1000000,"output_tokens":1000000,"total_tokens":2000000}}}}
+{"timestamp":"2026-04-05T10:00:02Z","type":"event_msg","payload":{"type":"task_complete"}}

--- a/libs/typescript/integrations/codex/tests/modelCatalog.test.ts
+++ b/libs/typescript/integrations/codex/tests/modelCatalog.test.ts
@@ -1,0 +1,166 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { catalogToRates, loadCatalogRates } from '../src/modelCatalog';
+
+const CATALOG = {
+  schema_version: '1.0',
+  models: {
+    'gpt-4o': {
+      pricing: {
+        input_per_million_tokens: 2.5,
+        output_per_million_tokens: 10,
+        cache_read_per_million_tokens: 1.25,
+      },
+    },
+    'no-pricing-model': {},
+  },
+};
+
+const EXPECTED_RATES = {
+  'gpt-4o': { input: 2.5, output: 10, cacheRead: 1.25 },
+};
+
+function okFetch(body: unknown = CATALOG): jest.Mock {
+  return jest
+    .fn()
+    .mockResolvedValue({ ok: true, text: () => Promise.resolve(JSON.stringify(body)) });
+}
+
+function failFetch(): jest.Mock {
+  return jest.fn().mockRejectedValue(new Error('network down'));
+}
+
+function tempCacheDir(): string {
+  return mkdtempSync(join(tmpdir(), 'mlflow-catalog-test-'));
+}
+
+describe('catalogToRates', () => {
+  it('converts pricing entries and skips models without base pricing', () => {
+    expect(catalogToRates(CATALOG)).toEqual(EXPECTED_RATES);
+  });
+
+  it('omits cache rates when absent', () => {
+    const rates = catalogToRates({
+      models: {
+        m: { pricing: { input_per_million_tokens: 1, output_per_million_tokens: 2 } },
+      },
+    });
+    expect(rates).toEqual({ m: { input: 1, output: 2 } });
+  });
+});
+
+describe('loadCatalogRates', () => {
+  it('fetches openai.json, returns rates, and writes the cache file', async () => {
+    const fetchImpl = okFetch();
+    const cacheDir = tempCacheDir();
+
+    const rates = await loadCatalogRates({
+      baseUri: 'https://example.com/base/',
+      cacheDir,
+      fetchImpl,
+    });
+
+    expect(rates).toEqual(EXPECTED_RATES);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://example.com/base/openai.json',
+      expect.anything(),
+    );
+    const cached = JSON.parse(readFileSync(join(cacheDir, 'openai.json'), 'utf8'));
+    expect(cached.rates).toEqual(EXPECTED_RATES);
+  });
+
+  it('serves from the cache within the TTL without fetching', async () => {
+    const cacheDir = tempCacheDir();
+    await loadCatalogRates({ baseUri: 'https://example.com', cacheDir, fetchImpl: okFetch() });
+
+    const fetchImpl = failFetch();
+    const rates = await loadCatalogRates({ baseUri: 'https://example.com', cacheDir, fetchImpl });
+
+    expect(rates).toEqual(EXPECTED_RATES);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('caches a failed fetch so it is not retried within the TTL', async () => {
+    const cacheDir = tempCacheDir();
+    const first = await loadCatalogRates({
+      baseUri: 'https://example.com',
+      cacheDir,
+      fetchImpl: failFetch(),
+    });
+    expect(first).toBeNull();
+
+    const fetchImpl = okFetch();
+    const second = await loadCatalogRates({ baseUri: 'https://example.com', cacheDir, fetchImpl });
+    expect(second).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('bypasses the cache when ttlSeconds is 0', async () => {
+    const cacheDir = tempCacheDir();
+    await loadCatalogRates({ baseUri: 'https://example.com', cacheDir, fetchImpl: okFetch() });
+
+    const fetchImpl = okFetch();
+    await loadCatalogRates({ baseUri: 'https://example.com', cacheDir, fetchImpl, ttlSeconds: 0 });
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+
+  it('returns null without fetching when the base URI is empty', async () => {
+    const fetchImpl = okFetch();
+    const rates = await loadCatalogRates({ baseUri: '', cacheDir: tempCacheDir(), fetchImpl });
+    expect(rates).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a non-OK response', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue({ ok: false, text: () => Promise.resolve('not found') });
+    const rates = await loadCatalogRates({
+      baseUri: 'https://example.com',
+      cacheDir: tempCacheDir(),
+      fetchImpl,
+    });
+    expect(rates).toBeNull();
+  });
+
+  it('returns null for a catalog with no usable rates', async () => {
+    const rates = await loadCatalogRates({
+      baseUri: 'https://example.com',
+      cacheDir: tempCacheDir(),
+      fetchImpl: okFetch({ models: { m: {} } }),
+    });
+    expect(rates).toBeNull();
+  });
+
+  it('refetches when the cache holds an empty rate map', async () => {
+    const cacheDir = tempCacheDir();
+    writeFileSync(
+      join(cacheDir, 'openai.json'),
+      JSON.stringify({ schemaVersion: 1, fetchedAt: new Date().toISOString(), rates: {} }),
+    );
+
+    const fetchImpl = okFetch();
+    const rates = await loadCatalogRates({ baseUri: 'https://example.com', cacheDir, fetchImpl });
+
+    expect(rates).toEqual(EXPECTED_RATES);
+    expect(fetchImpl).toHaveBeenCalled();
+  });
+
+  it('reads from a file:// mirror', async () => {
+    const mirrorDir = tempCacheDir();
+    writeFileSync(join(mirrorDir, 'openai.json'), JSON.stringify(CATALOG));
+
+    const fetchImpl = okFetch();
+    const rates = await loadCatalogRates({
+      baseUri: pathToFileURL(mirrorDir).href,
+      cacheDir: tempCacheDir(),
+      fetchImpl,
+    });
+
+    expect(rates).toEqual(EXPECTED_RATES);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/libs/typescript/integrations/codex/tests/openaiPricing.test.ts
+++ b/libs/typescript/integrations/codex/tests/openaiPricing.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { OPENAI_MODEL_RATES } from '../src/openaiPricing';
+import { catalogToRates } from '../src/modelCatalog';
+
+const CATALOG_PATH = join(__dirname, '../../../../../mlflow/utils/model_catalog/openai.json');
+
+describe('openaiPricing.ts (generated)', () => {
+  it('matches mlflow/utils/model_catalog/openai.json (run `npm run sync:pricing` to fix)', () => {
+    const catalog = JSON.parse(readFileSync(CATALOG_PATH, 'utf8'));
+    expect(OPENAI_MODEL_RATES).toEqual(catalogToRates(catalog));
+  });
+});

--- a/libs/typescript/integrations/codex/tests/pricing.test.ts
+++ b/libs/typescript/integrations/codex/tests/pricing.test.ts
@@ -1,0 +1,140 @@
+import { calculateCost, setModelRates, sumCosts } from '../src/pricing';
+
+describe('calculateCost', () => {
+  it('prices input and output tokens at the model rate', () => {
+    // gpt-4o: input 2.5/MTok, output 10/MTok
+    const cost = calculateCost('gpt-4o', {
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      total_tokens: 2_000_000,
+    });
+    expect(cost).not.toBeNull();
+    expect(cost!.input_cost).toBeCloseTo(2.5, 6);
+    expect(cost!.output_cost).toBeCloseTo(10, 6);
+    expect(cost!.total_cost).toBeCloseTo(12.5, 6);
+  });
+
+  it('prices the cached subset of input at the cache-read rate', () => {
+    // gpt-4o: input 2.5/MTok, cacheRead 1.25/MTok. OpenAI reports
+    // cached_input_tokens as a subset of input_tokens.
+    const cost = calculateCost('gpt-4o', {
+      input_tokens: 1000,
+      output_tokens: 1000,
+      total_tokens: 2000,
+      cached_input_tokens: 400,
+    });
+    // 600 uncached * 2.5 + 400 cached * 1.25 (per MTok)
+    expect(cost!.input_cost).toBeCloseTo(0.002, 9);
+    expect(cost!.output_cost).toBeCloseTo(0.01, 9);
+    expect(cost!.total_cost).toBeCloseTo(0.012, 9);
+  });
+
+  it('caps cached tokens at the reported input tokens', () => {
+    // A cached count larger than input_tokens must not produce negative
+    // uncached input; the whole input is priced at the cache-read rate.
+    const cost = calculateCost('gpt-4o', {
+      input_tokens: 1000,
+      output_tokens: 0,
+      total_tokens: 1000,
+      cached_input_tokens: 5000,
+    });
+    expect(cost!.input_cost).toBeCloseTo(1000 * 1.25e-6, 12);
+  });
+
+  it('prices each model individually, not by family prefix', () => {
+    // gpt-5 (1.25/10) is far cheaper than gpt-4 (30/60); a prefix match would
+    // mis-price them.
+    const gpt5 = calculateCost('gpt-5', {
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      total_tokens: 2_000_000,
+    });
+    expect(gpt5!.input_cost).toBeCloseTo(1.25, 6);
+    expect(gpt5!.output_cost).toBeCloseTo(10, 6);
+
+    const gpt4 = calculateCost('gpt-4', {
+      input_tokens: 1_000_000,
+      output_tokens: 0,
+      total_tokens: 1_000_000,
+    });
+    expect(gpt4!.input_cost).toBeCloseTo(30, 6);
+  });
+
+  it('falls back to the undated family alias for unknown dated snapshots', () => {
+    // gpt-5-2099-12-31 is not in the catalog; it should price as gpt-5.
+    const cost = calculateCost('gpt-5-2099-12-31', {
+      input_tokens: 1_000_000,
+      output_tokens: 0,
+      total_tokens: 1_000_000,
+    });
+    expect(cost!.input_cost).toBeCloseTo(1.25, 6);
+  });
+
+  it('returns null for unknown models', () => {
+    // Codex-family model names are not yet in the published catalog, so they
+    // get no cost, matching the Python pipeline reading the same catalog.
+    expect(
+      calculateCost('gpt-5-codex', { input_tokens: 100, output_tokens: 100, total_tokens: 200 }),
+    ).toBeNull();
+    // A different provider's model is also absent from openai.json.
+    expect(
+      calculateCost('claude-opus-4-8', {
+        input_tokens: 100,
+        output_tokens: 100,
+        total_tokens: 200,
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when there is no billable base usage', () => {
+    expect(
+      calculateCost('gpt-4o', { input_tokens: 0, output_tokens: 0, total_tokens: 0 }),
+    ).toBeNull();
+  });
+
+  it('returns null for missing model or usage', () => {
+    expect(
+      calculateCost(undefined, { input_tokens: 10, output_tokens: 10, total_tokens: 20 }),
+    ).toBeNull();
+    expect(calculateCost('gpt-4o', undefined)).toBeNull();
+  });
+});
+
+describe('setModelRates', () => {
+  afterEach(() => setModelRates(null));
+
+  it('overrides the bundled rates until reset', () => {
+    setModelRates({ 'custom-model': { input: 100, output: 200 } });
+
+    const cost = calculateCost('custom-model', {
+      input_tokens: 1_000_000,
+      output_tokens: 0,
+      total_tokens: 1_000_000,
+    });
+    expect(cost!.input_cost).toBeCloseTo(100, 6);
+    // Bundled models are replaced wholesale, matching Python's remote-first load.
+    expect(
+      calculateCost('gpt-4o', { input_tokens: 100, output_tokens: 0, total_tokens: 100 }),
+    ).toBeNull();
+
+    setModelRates(null);
+    expect(
+      calculateCost('gpt-4o', { input_tokens: 100, output_tokens: 0, total_tokens: 100 }),
+    ).not.toBeNull();
+  });
+});
+
+describe('sumCosts', () => {
+  it('sums component costs', () => {
+    expect(
+      sumCosts([
+        { input_cost: 1, output_cost: 2, total_cost: 3 },
+        { input_cost: 0.5, output_cost: 0.5, total_cost: 1 },
+      ]),
+    ).toEqual({ input_cost: 1.5, output_cost: 2.5, total_cost: 4 });
+  });
+
+  it('returns null for an empty list', () => {
+    expect(sumCosts([])).toBeNull();
+  });
+});

--- a/libs/typescript/integrations/codex/tests/tracing.test.ts
+++ b/libs/typescript/integrations/codex/tests/tracing.test.ts
@@ -83,7 +83,7 @@ jest.mock('@mlflow/core', () => {
 // Wrap the transcript module so individual tests can point
 // findTranscriptForThread at a fixture; every other export stays real.
 jest.mock('../src/transcript', () => {
-  const actual = jest.requireActual('../src/transcript');
+  const actual = jest.requireActual<typeof import('../src/transcript')>('../src/transcript');
   return {
     __esModule: true,
     ...actual,

--- a/libs/typescript/integrations/codex/tests/tracing.test.ts
+++ b/libs/typescript/integrations/codex/tests/tracing.test.ts
@@ -80,6 +80,17 @@ jest.mock('@mlflow/core', () => {
   };
 });
 
+// Wrap the transcript module so individual tests can point
+// findTranscriptForThread at a fixture; every other export stays real.
+jest.mock('../src/transcript', () => {
+  const actual = jest.requireActual('../src/transcript');
+  return {
+    __esModule: true,
+    ...actual,
+    findTranscriptForThread: jest.fn(actual.findTranscriptForThread),
+  };
+});
+
 import { resolve } from 'path';
 
 import {
@@ -90,7 +101,7 @@ import {
   processNotify,
   reconstructMessages,
 } from '../src/tracing';
-import { readTranscript, getLastTurnRecords } from '../src/transcript';
+import { readTranscript, getLastTurnRecords, findTranscriptForThread } from '../src/transcript';
 import { calculateCost } from '../src/pricing';
 import { flushTraces } from '@mlflow/core';
 import type { NotifyPayload, RolloutLine } from '../src/types';
@@ -643,5 +654,33 @@ describe('token usage and cost on LLM spans', () => {
       total_tokens: 1500,
     });
     expect(llmSpans[1].attributes['mlflow.llm.cost']).toEqual(cost);
+  });
+});
+
+describe('processNotify cost aggregation (end to end)', () => {
+  beforeEach(() => {
+    spanCounter = 0;
+    Object.keys(mockSpans).forEach((key) => delete mockSpans[key]);
+    mockTraceInfo.traceMetadata = {};
+    jest.clearAllMocks();
+  });
+
+  it('records mlflow.trace.cost and the LLM span cost from a priced transcript', async () => {
+    (findTranscriptForThread as jest.Mock).mockReturnValueOnce(
+      resolve(FIXTURES_DIR, 'priced-turn.jsonl'),
+    );
+
+    await processNotify(makeNotifyPayload({ 'thread-id': 'priced-session' }));
+
+    // gpt-4o priced at 2.5/MTok input + 10/MTok output; the fixture reports
+    // 1M input + 1M output, so total cost is 12.5.
+    expect(mockTraceInfo.traceMetadata['mlflow.trace.cost']).toBeDefined();
+    const traceCost = JSON.parse(mockTraceInfo.traceMetadata['mlflow.trace.cost']);
+    expect(traceCost.total_cost).toBeCloseTo(12.5, 6);
+
+    const llmSpans = getSpansByType('LLM');
+    const finalLlm = llmSpans[llmSpans.length - 1];
+    expect(finalLlm.attributes['mlflow.llm.model']).toBe('gpt-4o');
+    expect(finalLlm.attributes['mlflow.llm.cost'].total_cost).toBeCloseTo(12.5, 6);
   });
 });

--- a/libs/typescript/integrations/codex/tests/tracing.test.ts
+++ b/libs/typescript/integrations/codex/tests/tracing.test.ts
@@ -91,10 +91,25 @@ import {
   reconstructMessages,
 } from '../src/tracing';
 import { readTranscript, getLastTurnRecords } from '../src/transcript';
+import { calculateCost } from '../src/pricing';
 import { flushTraces } from '@mlflow/core';
 import type { NotifyPayload, RolloutLine } from '../src/types';
 
 const FIXTURES_DIR = resolve(__dirname, 'fixtures');
+
+// Disable remote catalog lookup so tests use the bundled snapshot only (no
+// network in the notify hook path).
+const ORIGINAL_CATALOG_URI = process.env.MLFLOW_MODEL_CATALOG_URI;
+beforeAll(() => {
+  process.env.MLFLOW_MODEL_CATALOG_URI = '';
+});
+afterAll(() => {
+  if (ORIGINAL_CATALOG_URI === undefined) {
+    delete process.env.MLFLOW_MODEL_CATALOG_URI;
+  } else {
+    process.env.MLFLOW_MODEL_CATALOG_URI = ORIGINAL_CATALOG_URI;
+  }
+});
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getSpans(): any[] {
@@ -578,5 +593,55 @@ describe('tool span failure status', () => {
     // OK tool: setStatus should NOT have been called
     expect(ok.statusCode).toBeNull();
     expect(ok.setStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('token usage and cost on LLM spans', () => {
+  beforeEach(() => {
+    spanCounter = 0;
+    Object.keys(mockSpans).forEach((key) => delete mockSpans[key]);
+    jest.clearAllMocks();
+  });
+
+  it('sets mlflow.llm.model on every LLM span', () => {
+    const records = readTranscript(resolve(FIXTURES_DIR, 'with-tool-call.jsonl'));
+    const turn = getLastTurnRecords(records);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parent = { spanId: 'root' } as any;
+
+    createChildSpans(parent, turn, 'gpt-4o');
+
+    const llmSpans = getSpansByType('LLM');
+    expect(llmSpans.length).toBe(2);
+    for (const span of llmSpans) {
+      expect(span.attributes['mlflow.llm.model']).toBe('gpt-4o');
+    }
+  });
+
+  it('attaches cumulative token usage and cost to the final LLM span only', () => {
+    const records = readTranscript(resolve(FIXTURES_DIR, 'with-tool-call.jsonl'));
+    const turn = getLastTurnRecords(records);
+    const usage = { input_tokens: 1000, output_tokens: 500, total_tokens: 1500 };
+    const cost = calculateCost('gpt-4o', usage);
+    expect(cost).not.toBeNull();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parent = { spanId: 'root' } as any;
+    createChildSpans(parent, turn, 'gpt-4o', usage, cost);
+
+    const llmSpans = getSpansByType('LLM');
+    expect(llmSpans.length).toBe(2);
+
+    // First (non-final) LLM span carries neither usage nor cost.
+    expect(llmSpans[0].attributes['mlflow.chat.tokenUsage']).toBeUndefined();
+    expect(llmSpans[0].attributes['mlflow.llm.cost']).toBeUndefined();
+
+    // Final LLM span carries the turn's cumulative usage and computed cost.
+    expect(llmSpans[1].attributes['mlflow.chat.tokenUsage']).toEqual({
+      input_tokens: 1000,
+      output_tokens: 500,
+      total_tokens: 1500,
+    });
+    expect(llmSpans[1].attributes['mlflow.llm.cost']).toEqual(cost);
   });
 });

--- a/libs/typescript/integrations/codex/tests/transcript.test.ts
+++ b/libs/typescript/integrations/codex/tests/transcript.test.ts
@@ -11,6 +11,7 @@ import {
   getSessionId,
   buildToolResultMap,
 } from '../src/transcript';
+import type { RolloutLine } from '../src/types';
 
 const FIXTURES_DIR = resolve(__dirname, 'fixtures');
 
@@ -77,6 +78,50 @@ describe('readTranscript + parsing', () => {
     expect(usage!.input_tokens).toBe(100);
     expect(usage!.output_tokens).toBe(10);
     expect(usage!.total_tokens).toBe(110);
+  });
+
+  it('sums per-request usage across a multi-request turn', () => {
+    // A tool-using turn emits one token_count per model request; the turn's
+    // billed usage is the sum, not just the final request.
+    const records = [
+      {
+        timestamp: '2026-04-05T10:00:01Z',
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            last_token_usage: {
+              input_tokens: 100,
+              output_tokens: 10,
+              total_tokens: 110,
+              cached_input_tokens: 40,
+            },
+          },
+        },
+      },
+      {
+        timestamp: '2026-04-05T10:00:03Z',
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            last_token_usage: {
+              input_tokens: 250,
+              output_tokens: 30,
+              total_tokens: 280,
+              cached_input_tokens: 100,
+            },
+          },
+        },
+      },
+    ] as unknown as RolloutLine[];
+
+    expect(getTokenUsage(records)).toEqual({
+      input_tokens: 350,
+      output_tokens: 40,
+      total_tokens: 390,
+      cached_input_tokens: 140,
+    });
   });
 
   it('gets model from session meta', () => {


### PR DESCRIPTION
### Related Issues/PRs

Closes #25612

### What changes are proposed in this pull request?

The Codex CLI integration (`libs/typescript/integrations/codex`) recorded token usage on its LLM spans but never computed cost, so Codex traces contributed no cost to an experiment's usage/cost breakdown and were not attributed by model there. LLM spans also set only a bare `model` attribute instead of the canonical `mlflow.llm.model`.

This PR mirrors the `@mlflow/claude-code` integration:

- Adds `pricing.ts` (`calculateCost` / `sumCosts`) and `modelCatalog.ts`, which resolve per-model rates from MLflow's published model catalog (`openai.json`, the same data the Python cost pipeline reads) with a bundled `openaiPricing.ts` snapshot fallback and a `sync:pricing` script that regenerates it from the checked-in catalog.
- In `tracing.ts`, sets `mlflow.llm.model`, `mlflow.chat.tokenUsage`, and a computed `mlflow.llm.cost` on the final LLM span of a turn, and aggregates `mlflow.trace.cost` onto the trace.
- Prices OpenAI usage correctly: OpenAI reports `cached_input_tokens` as a subset of `input_tokens`, so the cached portion is charged at the cache-read rate and the remainder at the base input rate (unlike Anthropic, which reports cache reads separately from `input_tokens`).

Note: OpenAI's Codex-family model names (e.g. `gpt-5-codex`) are not yet in the published catalog, so cost is computed for catalog-priced models (`gpt-4o`, `gpt-5`, `o4-mini`, ...) and omitted for models absent from the catalog, matching the Python pipeline. Extending catalog coverage is a separate follow-up.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests cover cost calculation (including the OpenAI cached-subset semantics and unknown/dated model handling), model-catalog fetching and caching, snapshot drift against the checked-in catalog, and the span/trace attribute wiring. The codex package test suite passes (7 suites, 82 tests).

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Codex CLI traces now record LLM cost (`mlflow.llm.cost` and aggregated `mlflow.trace.cost`) and the canonical model, so cost appears in the experiment usage breakdown for catalog-priced models.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
