### PR TITLE
Fix register_prompt return type documentation

### DIFF
--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -84,7 +84,7 @@ def register_prompt(
             Example (PromptModelConfig): PromptModelConfig(model_name="gpt-4", temperature=0.7)
 
     Returns:
-        A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
+        A :py:class:`PromptVersion <mlflow.entities.PromptVersion>` object that was created.
 
     Example:
 

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -638,7 +638,7 @@ def register_prompt(
             configuration. Using PromptModelConfig provides validation and type safety.
 
     Returns:
-        A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
+        A :py:class:`PromptVersion <mlflow.entities.PromptVersion>` object that was created.
 
     Example:
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -731,7 +731,7 @@ class MlflowClient:
                 Using PromptModelConfig provides validation and type safety.
 
         Returns:
-            A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
+            A :py:class:`PromptVersion <mlflow.entities.PromptVersion>` object that was created.
         """
         registry_client = self._get_registry_client()
 


### PR DESCRIPTION
### Related Issues/PRs

Closes #25606

### What changes are proposed in this pull request?

This PR updates the `register_prompt` docstrings to correctly document the return type as `PromptVersion` instead of `Prompt`.

The documentation is updated in:

* `mlflow/genai/prompts/__init__.py`
* `mlflow/tracking/_model_registry/fluent.py`
* `mlflow/tracking/client.py`

The function's return type annotation and implementation return `PromptVersion`, so this change brings the documentation in line with the actual API behavior.

### How is this PR tested?

* [x] Existing unit/integration tests
* [ ] New unit/integration tests
* [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

* [x] No.
* [ ] Yes. I've updated:

  * [ ] Examples
  * [ ] API references
  * [ ] Instructions

### Does this PR require updating the [[MLflow Skills](https://github.com/mlflow/skills)](https://github.com/mlflow/skills) repository?

* [x] No.
* [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

* [x] No.
* [ ] Yes. Give a description of this change to be included in the release notes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

* [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
* [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
* [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
* [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
* [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
* [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
* [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
* [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
* [ ] `area/projects`: MLproject format, project running backends
* [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
* [ ] `area/build`: Build and test infrastructure for MLflow
* [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

* [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
* [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
* [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

* [ ] This PR is critical and needs to be in the next patch release
* [x] This PR can wait for the next minor release