### PR TITLE
Fix `evaluate` list input normalization for NumPy targets

### DIFF
--- a/mlflow/data/evaluation_dataset.py
+++ b/mlflow/data/evaluation_dataset.py
@@ -194,11 +194,11 @@ def convert_data_to_mlflow_dataset(data, targets=None, predictions=None, name=No
 
     if isinstance(data, list):
         # If the list is flat, we assume each element is an independent sample.
-        if not isinstance(data[0], (list, np.ndarray)):
+        if data and not isinstance(data[0], (list, np.ndarray)):
             data = [[elm] for elm in data]
 
         return mlflow.data.from_numpy(
-            np.array(data), targets=np.array(targets) if targets else None, name=name
+            np.array(data), targets=np.array(targets) if targets is not None else None, name=name
         )
     elif isinstance(data, np.ndarray):
         return mlflow.data.from_numpy(data, targets=targets, name=name)

--- a/tests/data/test_evaluation_dataset.py
+++ b/tests/data/test_evaluation_dataset.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from mlflow.data.evaluation_dataset import convert_data_to_mlflow_dataset
+from mlflow.exceptions import MlflowException
+
+
+@pytest.mark.parametrize("data", [[[1], [2], [3]], [1, 2, 3]])
+def test_convert_list_data_with_numpy_targets(data):
+    targets = np.array([1, 2, 3])
+
+    dataset = convert_data_to_mlflow_dataset(
+        data=data,
+        targets=targets,
+    )
+
+    assert np.array_equal(dataset.targets, targets)
+
+
+def test_convert_list_data_without_targets():
+    dataset = convert_data_to_mlflow_dataset(data=[[1], [2], [3]], targets=None)
+
+    assert dataset.targets is None
+
+
+def test_convert_list_data_with_empty_targets_uses_standard_validation():
+    dataset = convert_data_to_mlflow_dataset(data=[[1], [2], [3]], targets=[])
+
+    with pytest.raises(MlflowException, match="same length"):
+        dataset.to_evaluation_dataset()
+
+
+def test_convert_empty_list_uses_standard_evaluation_dataset_validation():
+    dataset = convert_data_to_mlflow_dataset(data=[], targets=[1, 2, 3])
+
+    with pytest.raises(MlflowException, match="2-dimensional"):
+        dataset.to_evaluation_dataset()

--- a/tests/data/test_evaluation_dataset.py
+++ b/tests/data/test_evaluation_dataset.py
@@ -15,6 +15,7 @@ def test_convert_list_data_with_numpy_targets(data):
     )
 
     assert np.array_equal(dataset.targets, targets)
+    assert dataset.features.shape == (3, 1)
 
 
 def test_convert_list_data_without_targets():


### PR DESCRIPTION
### Related Issues/PRs

Relates to no existing issue; the bug is reproduced in this PR.

### What changes are proposed in this pull request?

`convert_data_to_mlflow_dataset` accessed the first element of every list without checking whether the list was empty, and used a truth-value check for `targets`.

This caused:
- `IndexError` for empty list evaluation data.
- `ValueError: The truth value of an array with more than one element is ambiguous` when list features were paired with multi-element NumPy targets.

The change guards the first-element access and checks `targets is not None`, so documented list/NumPy inputs are normalized consistently. Explicit empty targets continue through the standard evaluation-dataset length validation instead of being silently treated as absent.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Focused verification:
- `pytest -q tests/data/test_evaluation_dataset.py tests/data/test_numpy_dataset.py tests/data/test_dataset.py` — 23 passed.
- `pytest -q tests/evaluate/test_evaluation.py::test_classifier_evaluate tests/evaluate/test_evaluation.py::test_regressor_evaluate` — 2 passed.
- `mlflow.models.evaluate` with list features, NumPy targets, and the default regressor evaluator completed successfully and returned 9 metrics.
- Ruff lint and format checks passed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow.models.evaluate` now accepts documented list features with multi-element NumPy targets without raising an ambiguous truth-value error, and empty list inputs produce the normal validation error.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [x] `rn/bug-fix`
- [ ] `rn/documentation`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release