### PR TITLE
Preserve the original exception when cleanup fails in `remove_on_error`

### DIFF
--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -809,13 +809,18 @@ def remove_on_error(path: os.PathLike, onerror=None):
         if onerror:
             onerror(e)
         if os.path.exists(path):
-            if os.path.isfile(path):
-                os.remove(path)
-            elif os.path.isdir(path):
-                shutil.rmtree(path)
-        _logger.warning(
-            f"Failed to remove {path}" if os.path.exists(path) else f"Successfully removed {path}"
-        )
+            try:
+                if os.path.isfile(path):
+                    os.remove(path)
+                elif os.path.isdir(path):
+                    shutil.rmtree(path)
+                else:
+                    _logger.warning(f"Not removing {path}: neither a regular file nor a directory")
+                    raise e
+                _logger.warning(f"Successfully removed {path}")
+            except Exception as remove_error:
+                if remove_error is not e:
+                    _logger.warning(f"Failed to remove {path}: {remove_error}")
         raise
 
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -809,17 +809,18 @@ def remove_on_error(path: os.PathLike, onerror=None):
         if onerror:
             onerror(e)
         if os.path.exists(path):
-            try:
-                if os.path.isfile(path):
-                    os.remove(path)
-                elif os.path.isdir(path):
-                    shutil.rmtree(path)
-                else:
-                    _logger.warning(f"Not removing {path}: neither a regular file nor a directory")
-                    raise e
-                _logger.warning(f"Successfully removed {path}")
-            except Exception as remove_error:
-                if remove_error is not e:
+            remover = None
+            if os.path.isfile(path):
+                remover = os.remove
+            elif os.path.isdir(path):
+                remover = shutil.rmtree
+            else:
+                _logger.warning(f"Not removing {path}: neither a regular file nor a directory")
+            if remover is not None:
+                try:
+                    remover(path)
+                    _logger.warning(f"Successfully removed {path}")
+                except Exception as remove_error:
                     _logger.warning(f"Failed to remove {path}: {remove_error}")
         raise
 

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -1,6 +1,7 @@
 import filecmp
 import hashlib
 import io
+import logging
 import os
 import shutil
 import stat
@@ -22,6 +23,7 @@ from mlflow.utils.file_utils import (
     get_parent_dir,
     get_total_file_size,
     local_file_uri_to_path,
+    remove_on_error,
 )
 from mlflow.utils.os import is_windows
 
@@ -390,3 +392,44 @@ def test_safe_extractall_blocks_symlink_escape(tmp_path):
         with pytest.raises(MlflowException, match="would be extracted outside"):
             _safe_extractall(tar, dest)
     assert not (tmp_path.parent / "pwned.txt").exists()
+
+
+def test_remove_on_error_reraises_original_exception_when_cleanup_fails(tmp_path, monkeypatch):
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content")
+
+    def fail_remove(path):
+        raise PermissionError("cleanup failed")
+
+    monkeypatch.setattr(os, "remove", fail_remove)
+
+    with pytest.raises(ValueError, match="root cause"):
+        with remove_on_error(file_path):
+            raise ValueError("root cause")
+
+
+def test_remove_on_error_removes_file_and_reraises(tmp_path, caplog, monkeypatch):
+    monkeypatch.setattr(logging.getLogger("mlflow"), "propagate", True)
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("content")
+
+    with caplog.at_level(logging.WARNING, logger="mlflow.utils.file_utils"):
+        with pytest.raises(ValueError, match="root cause"):
+            with remove_on_error(file_path):
+                raise ValueError("root cause")
+
+    assert not file_path.exists()
+    assert f"Successfully removed {file_path}" in caplog.text
+
+
+def test_remove_on_error_does_not_log_removal_for_nonexistent_path(tmp_path, caplog, monkeypatch):
+    # The "mlflow" logger disables propagation, so enable it for caplog to capture records
+    monkeypatch.setattr(logging.getLogger("mlflow"), "propagate", True)
+    path = tmp_path / "never_created"
+
+    with caplog.at_level(logging.WARNING, logger="mlflow.utils.file_utils"):
+        with pytest.raises(ValueError, match="root cause"):
+            with remove_on_error(path):
+                raise ValueError("root cause")
+
+    assert f"Successfully removed {path}" not in caplog.text

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -403,24 +403,34 @@ def file_utils_caplog(caplog, monkeypatch):
         yield caplog
 
 
+@pytest.mark.parametrize("is_dir", [False, True], ids=["file", "directory"])
 def test_remove_on_error_reraises_original_exception_when_cleanup_fails(
-    tmp_path, file_utils_caplog, monkeypatch
+    tmp_path, file_utils_caplog, is_dir
 ):
-    file_path = tmp_path / "file.txt"
-    file_path.write_text("content")
-
     def fail_remove(path):
         raise PermissionError("cleanup failed")
 
-    monkeypatch.setattr(os, "remove", fail_remove)
+    if is_dir:
+        path = tmp_path / "dir"
+        path.mkdir()
+        (path / "nested.txt").write_text("content")
+        # Scope the patch to the remove_on_error call so the failing rmtree does not
+        # leak into other fixtures' teardown (e.g. db_uri's rmtree)
+        fail_cleanup = mock.patch.object(shutil, "rmtree", side_effect=fail_remove)
+    else:
+        path = tmp_path / "file.txt"
+        path.write_text("content")
+        fail_cleanup = mock.patch.object(os, "remove", side_effect=fail_remove)
 
-    with pytest.raises(ValueError, match="root cause"):
-        with remove_on_error(file_path):
+    with fail_cleanup, pytest.raises(ValueError, match="root cause") as exc_info:
+        with remove_on_error(path):
             raise ValueError("root cause")
 
-    assert file_path.exists()
+    # The cleanup failure must not pollute the propagated exception's chain
+    assert exc_info.value.__context__ is None
+    assert path.exists()
     assert [r.getMessage() for r in file_utils_caplog.records] == [
-        f"Failed to remove {file_path}: cleanup failed"
+        f"Failed to remove {path}: cleanup failed"
     ]
 
 

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -7,6 +7,7 @@ import shutil
 import stat
 import tarfile
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from pyspark.sql import SparkSession
@@ -394,7 +395,17 @@ def test_safe_extractall_blocks_symlink_escape(tmp_path):
     assert not (tmp_path.parent / "pwned.txt").exists()
 
 
-def test_remove_on_error_reraises_original_exception_when_cleanup_fails(tmp_path, monkeypatch):
+@pytest.fixture
+def file_utils_caplog(caplog, monkeypatch):
+    # The "mlflow" logger disables propagation, so enable it for caplog to capture records
+    monkeypatch.setattr(logging.getLogger("mlflow"), "propagate", True)
+    with caplog.at_level(logging.WARNING, logger="mlflow.utils.file_utils"):
+        yield caplog
+
+
+def test_remove_on_error_reraises_original_exception_when_cleanup_fails(
+    tmp_path, file_utils_caplog, monkeypatch
+):
     file_path = tmp_path / "file.txt"
     file_path.write_text("content")
 
@@ -407,29 +418,53 @@ def test_remove_on_error_reraises_original_exception_when_cleanup_fails(tmp_path
         with remove_on_error(file_path):
             raise ValueError("root cause")
 
-
-def test_remove_on_error_removes_file_and_reraises(tmp_path, caplog, monkeypatch):
-    monkeypatch.setattr(logging.getLogger("mlflow"), "propagate", True)
-    file_path = tmp_path / "file.txt"
-    file_path.write_text("content")
-
-    with caplog.at_level(logging.WARNING, logger="mlflow.utils.file_utils"):
-        with pytest.raises(ValueError, match="root cause"):
-            with remove_on_error(file_path):
-                raise ValueError("root cause")
-
-    assert not file_path.exists()
-    assert f"Successfully removed {file_path}" in caplog.text
+    assert file_path.exists()
+    assert [r.getMessage() for r in file_utils_caplog.records] == [
+        f"Failed to remove {file_path}: cleanup failed"
+    ]
 
 
-def test_remove_on_error_does_not_log_removal_for_nonexistent_path(tmp_path, caplog, monkeypatch):
-    # The "mlflow" logger disables propagation, so enable it for caplog to capture records
-    monkeypatch.setattr(logging.getLogger("mlflow"), "propagate", True)
+@pytest.mark.parametrize("is_dir", [False, True], ids=["file", "directory"])
+def test_remove_on_error_removes_path_and_reraises(tmp_path, file_utils_caplog, is_dir):
+    path = tmp_path / ("dir" if is_dir else "file.txt")
+    if is_dir:
+        path.mkdir()
+        (path / "nested.txt").write_text("content")
+    else:
+        path.write_text("content")
+    onerror = mock.Mock()
+
+    with pytest.raises(ValueError, match="root cause") as exc_info:
+        with remove_on_error(path, onerror=onerror):
+            raise ValueError("root cause")
+
+    onerror.assert_called_once_with(exc_info.value)
+    assert not path.exists()
+    assert [r.getMessage() for r in file_utils_caplog.records] == [f"Successfully removed {path}"]
+
+
+def test_remove_on_error_leaves_non_regular_path_alone(tmp_path, file_utils_caplog, monkeypatch):
+    path = tmp_path / "special"
+    path.write_text("content")
+    # Simulate a path that exists but is neither a regular file nor a directory (e.g. a FIFO)
+    monkeypatch.setattr(os.path, "isfile", lambda p: False)
+    monkeypatch.setattr(os.path, "isdir", lambda p: False)
+
+    with pytest.raises(ValueError, match="root cause"):
+        with remove_on_error(path):
+            raise ValueError("root cause")
+
+    assert path.exists()
+    assert [r.getMessage() for r in file_utils_caplog.records] == [
+        f"Not removing {path}: neither a regular file nor a directory"
+    ]
+
+
+def test_remove_on_error_logs_nothing_for_nonexistent_path(tmp_path, file_utils_caplog):
     path = tmp_path / "never_created"
 
-    with caplog.at_level(logging.WARNING, logger="mlflow.utils.file_utils"):
-        with pytest.raises(ValueError, match="root cause"):
-            with remove_on_error(path):
-                raise ValueError("root cause")
+    with pytest.raises(ValueError, match="root cause"):
+        with remove_on_error(path):
+            raise ValueError("root cause")
 
-    assert f"Successfully removed {path}" not in caplog.text
+    assert file_utils_caplog.records == []


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25627

### What changes are proposed in this pull request?

`remove_on_error` in `mlflow/utils/file_utils.py` has two problems in its `except` block.

First, `os.remove` / `shutil.rmtree` run unguarded. If the cleanup itself fails (for example a `PermissionError` on a read-only directory, or a file still locked on Windows), the cleanup exception replaces the original error and the trailing `raise` never executes. Callers such as artifact downloads then surface a confusing cleanup error instead of the real root cause.

Second, the log message is chosen by re-checking `os.path.exists(path)`, so it prints `Successfully removed <path>` whenever the path is absent, including when it never existed in the first place.

This PR wraps the cleanup in its own `try`/`except`, logs cleanup failures separately, always re-raises the original exception (same object, traceback intact), and only claims a removal when a regular file or directory was actually removed. `remove_on_error` has four callers (`HttpArtifactRepository._multipart_download`, `CloudArtifactRepository._parallelized_download_from_cloud`, `DatabricksModelsArtifactRepository`, `_create_virtualenv`); the change is inert when cleanup succeeds, so their happy paths are unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Five test cases in `tests/utils/test_file_utils.py` (four functions, the happy path parametrized over file and directory). Three fail on master: cleanup failure surfaces as `PermissionError` instead of the original `ValueError`, a path that exists but is neither a file nor a directory gets a bogus `Failed to remove` warning, and a path that never existed gets the bogus `Successfully removed` warning. The file and directory happy paths pass on both and also check that `onerror` is called with the original exception. Every test asserts the exact list of warnings emitted.

Manual end-to-end test: real `mlflow server` (uvicorn) with `--artifacts-destination s3://...` (moto S3 endpoint) and a real client process calling `mlflow.artifacts.download_artifacts(run_id=..., dst_path=...)`, once per build (unmodified `eae5d26` vs this branch, each in its own venv, module path and fix marker checked before every run), 3 runs per scenario per build.

Scenario 1, destination directory read-only with a stale partial file, artifact deleted from the bucket while the download is in flight:

```
# unmodified
##### File model/weights.bin #####
[Errno 13] Permission denied: '.../dst/model/weights.bin'
# (the real error "Failed to download 64 chunk(s) ... after all retries exhausted" is lost)

# this branch
WARNING mlflow.utils.file_utils: Failed to remove .../dst/model/weights.bin: [Errno 13] Permission denied: '...'
##### File model/weights.bin #####
Failed to download 64 chunk(s) for model/weights.bin after all retries exhausted.
```

Scenario 2, empty read-only destination directory (the file is never created):

```
# unmodified
WARNING mlflow.utils.file_utils: Successfully removed .../dst/model/weights.bin
# this branch: no such line
```

A control run with a writable destination behaves identically on both builds (partial file removed, real error surfaced, `Successfully removed` logged), so the change only kicks in when cleanup fails. The same bogus `Successfully removed` line also shows up on master from `_create_virtualenv` when the requested Python is unavailable.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Artifact download failures now report the original error instead of a secondary cleanup error when removing the partial download fails.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

