### PR TITLE
Fix order-dependent flake in test_search_traces_with_assessments

### DIFF
--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -795,11 +795,16 @@ def test_search_traces_with_assessments():
         return_type="list",
         order_by=["timestamp_ms"],
     )
-    # Verify the results
+    # Verify the results. trace_1 and trace_2 can be created within the same
+    # millisecond, and search tie-breaks equal timestamp_ms on the (random)
+    # request_id, so result position is not creation order. Key by trace id
+    # instead of asserting on a fixed position.
     assert len(traces) == 2
-    assert len(traces[0].info.assessments) == 3
+    traces_by_id = {trace.info.trace_id: trace for trace in traces}
 
-    assessments = {a.name: a for a in traces[0].info.assessments}
+    trace_1 = traces_by_id[span_1.trace_id]
+    assert len(trace_1.info.assessments) == 3
+    assessments = {a.name: a for a in trace_1.info.assessments}
     assert assessments["feedback_1"].trace_id == span_1.trace_id
     assert assessments["feedback_1"].name == "feedback_1"
     assert assessments["feedback_1"].value == 1.0
@@ -810,8 +815,9 @@ def test_search_traces_with_assessments():
     assert assessments["feedback_2"].name == "feedback_2"
     assert assessments["feedback_2"].value == 1.0
 
-    assert len(traces[1].info.assessments) == 1
-    assessment = traces[1].info.assessments[0]
+    trace_2 = traces_by_id[span_2.trace_id]
+    assert len(trace_2.info.assessments) == 1
+    assessment = trace_2.info.assessments[0]
     assert assessment.trace_id == span_2.trace_id
     assert assessment.name == "feedback_3"
     assert assessment.value == 1.0


### PR DESCRIPTION
### Related Issues/PRs

Closes #25643

### What changes are proposed in this pull request?

`test_search_traces_with_assessments` asserted on fixed result positions (`traces[0]` = the first-created trace with 3 assessments, `traces[1]` = the second with 1). But the search orders by `timestamp_ms` ascending and the store breaks ties on the random `request_id`, so when the two traces land in the same millisecond the position is decided by trace id, not creation order. About half the time `traces[0]` is the second trace, giving `assert 1 == 3`.

This keys the results by trace id instead of by position, so the assertions are independent of the tie-break order. No production behavior changes; this is a test-only fix.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Ran `test_search_traces_with_assessments` repeatedly against the sqlalchemy backend; it passes deterministically. The change removes the positional assumption, so the outcome no longer depends on how equal-`timestamp_ms` traces are tie-broken.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [x] This PR can wait for the next minor release
