### PR TITLE
Allow backend-resolved `UnityCatalog` locations in `mlflow.tracing.set_destination`

### DIFF
--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -474,6 +474,11 @@ def set_destination(destination: TraceLocationBase, *, context_local: bool = Fal
 
             - :py:class:`~mlflow.entities.trace_location.MlflowExperimentLocation`: Logs traces to
                 an MLflow experiment.
+            - :py:class:`~mlflow.entities.trace_location.UnityCatalog`: Logs traces to a Databricks
+                Unity Catalog table-prefix location. Only available in Databricks. The location
+                must carry the table names assigned by the Databricks backend, e.g. the
+                ``trace_location`` of the experiment returned by :py:func:`mlflow.set_experiment`
+                or :py:func:`mlflow.get_experiment`.
 
         context_local: If False (default), the destination is set globally. If True, the destination
             is isolated per async task or thread, providing isolation in concurrent applications.
@@ -496,12 +501,20 @@ def set_destination(destination: TraceLocationBase, *, context_local: bool = Fal
 
         .. code-block:: python
 
-            from mlflow.tracing.destination import MlflowExperimentLocation
+            from mlflow.entities.trace_location import UnityCatalog
 
-            mlflow.tracing.set_destination(
-                MlflowExperimentLocation(experiment_id="123"),
-                context_local=True,
-            )
+            # Link the experiment to a Unity Catalog table-prefix location once, e.g. at
+            # application startup. The returned location carries the backend-assigned
+            # table names.
+            location = mlflow.set_experiment(
+                "my-experiment",
+                trace_location=UnityCatalog(
+                    catalog_name="catalog", schema_name="schema", table_prefix="prefix"
+                ),
+            ).trace_location
+
+            # Route the traces of the current async task or thread to that location.
+            mlflow.tracing.set_destination(location, context_local=True)
 
         The destination set with the ``context_local`` flag will only be effective within the
         current async task or thread. This is particularly useful when you want to send traces
@@ -525,11 +538,13 @@ def set_destination(destination: TraceLocationBase, *, context_local: bool = Fal
             "The destination must be an instance of TraceLocation."
         )
 
-    if isinstance(destination, UnityCatalog):
+    if isinstance(destination, UnityCatalog) and not destination.full_otel_spans_table_name:
         raise MlflowException.invalid_parameter_value(
-            "UnityCatalog table-prefix destinations are not supported by "
-            "`mlflow.tracing.set_destination`. Use `set_experiment` with a "
-            "UnityCatalog location instead."
+            "The `UnityCatalog` destination does not carry the table names assigned by the "
+            "Databricks backend, so traces cannot be exported to it. Pass a location resolved "
+            "by the backend, e.g. `mlflow.set_experiment(..., "
+            "trace_location=UnityCatalog(...)).trace_location` or "
+            "`mlflow.get_experiment(experiment_id).trace_location`."
         )
 
     if isinstance(destination, UCSchemaLocation):

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -1,3 +1,4 @@
+import asyncio
 import random
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -147,12 +148,26 @@ def test_set_destination_databricks_uc():
     assert get_active_spans_table_name() == "catalog.schema.mlflow_experiment_trace_otel_spans"
 
 
-def test_set_destination_databricks_unity_catalog_rejected(monkeypatch):
-    with pytest.raises(
-        MlflowException,
-        match=r"UnityCatalog table-prefix destinations are not supported by "
-        r"`mlflow\.tracing\.set_destination`",
-    ):
+def _resolved_unity_catalog(table_prefix: str) -> UnityCatalog:
+    # Mimics a location returned by the Databricks backend, which assigns the table names.
+    location = UnityCatalog("catalog", "schema", table_prefix=table_prefix)
+    location._otel_spans_table_name = f"catalog.schema.{table_prefix}_otel_spans"
+    return location
+
+
+def test_set_destination_databricks_unity_catalog():
+    mlflow.tracing.set_destination(destination=_resolved_unity_catalog("prefix"))
+
+    tracer = _get_tracer("test")
+    processors = tracer.span_processor._span_processors
+    assert len(processors) == 1
+    assert isinstance(processors[0], DatabricksUCTableSpanProcessor)
+    assert isinstance(processors[0].span_exporter, DatabricksUCTableSpanExporter)
+    assert get_active_spans_table_name() == "catalog.schema.prefix_otel_spans"
+
+
+def test_set_destination_databricks_unity_catalog_without_table_names_rejected():
+    with pytest.raises(MlflowException, match=r"table names assigned by the Databricks backend"):
         mlflow.tracing.set_destination(
             destination=UnityCatalog(
                 catalog_name="catalog",
@@ -160,6 +175,49 @@ def test_set_destination_databricks_unity_catalog_rejected(monkeypatch):
                 table_prefix="prefix",
             )
         )
+
+
+def test_set_destination_databricks_unity_catalog_context_local():
+    from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
+
+    mlflow.tracing.set_destination(destination=_resolved_unity_catalog("global"))
+
+    def resolve() -> tuple[str, str | None]:
+        tracer = _get_tracer("test")
+        assert isinstance(tracer.span_processor._span_processors[0], DatabricksUCTableSpanProcessor)
+        return _MLFLOW_TRACE_USER_DESTINATION.get().table_prefix, get_active_spans_table_name()
+
+    # Threads: both destinations are set before either thread reads its own back.
+    barrier = threading.Barrier(2)
+
+    def route_in_thread(table_prefix: str) -> tuple[str, str | None]:
+        mlflow.tracing.set_destination(_resolved_unity_catalog(table_prefix), context_local=True)
+        barrier.wait()
+        return resolve()
+
+    with ThreadPoolExecutor(max_workers=2, thread_name_prefix="test-uc-destination") as executor:
+        results = list(executor.map(route_in_thread, ["thread_a", "thread_b"]))
+    assert results == [
+        ("thread_a", "catalog.schema.thread_a_otel_spans"),
+        ("thread_b", "catalog.schema.thread_b_otel_spans"),
+    ]
+
+    # Async tasks: yield after setting so the tasks interleave before reading back.
+    async def route_in_task(table_prefix: str) -> tuple[str, str | None]:
+        mlflow.tracing.set_destination(_resolved_unity_catalog(table_prefix), context_local=True)
+        await asyncio.sleep(0)
+        return resolve()
+
+    async def run_tasks():
+        return await asyncio.gather(route_in_task("task_a"), route_in_task("task_b"))
+
+    assert asyncio.run(run_tasks()) == [
+        ("task_a", "catalog.schema.task_a_otel_spans"),
+        ("task_b", "catalog.schema.task_b_otel_spans"),
+    ]
+
+    # The context-local destinations do not leak into the caller's context.
+    assert resolve() == ("global", "catalog.schema.global_otel_spans")
 
 
 def test_set_destination_databricks_uc_with_oltp_env_no_dual_export(monkeypatch):


### PR DESCRIPTION
### Related Issues/PRs

Closes #25646

> **Note on process.** MLflow's contribution policy asks for a triaged issue with the `ready` label before a PR is opened. I filed #25646 with the full motivation and proposed implementation and opened this PR alongside it so the concrete diff is available during triage. I'm happy to hold it until the issue is triaged, and will close it if maintainers prefer a different direction or consider the current guard intentional for reasons I have missed.

Relates to #21424 (added `UnityCatalog` to the destination registry / span processor and introduced the guard during review) and #21385 (added `set_experiment(trace_location=...)`).

### What changes are proposed in this pull request?

`mlflow.tracing.set_destination` rejects every `UnityCatalog` (table-prefix) trace location and points users to `mlflow.set_experiment(trace_location=...)`. That API is process-global (it writes the global registry slot and resets the tracer provider), so a service that handles concurrent requests cannot use it to route *different* requests to *different* UC table prefixes. `set_destination(..., context_local=True)` is the primitive designed for that, and everything downstream of the guard (`UserTraceDestinationRegistry`, `_get_span_processors`, `DatabricksUCTableSpanProcessor`, `get_active_spans_table_name`) already handles `UnityCatalog`.

The guard does protect against one real failure mode: `UnityCatalog.full_otel_spans_table_name` is only populated by the Databricks backend, so a hand-built `UnityCatalog("catalog", "schema", "prefix")` would select the UC exporter and then have every export silently skipped. This PR narrows the guard to exactly that case instead of rejecting the whole type:

- `mlflow/tracing/provider.py`
  - `set_destination` accepts `UnityCatalog` locations that carry backend-assigned table names (e.g. `mlflow.set_experiment(..., trace_location=UnityCatalog(...)).trace_location` or `mlflow.get_experiment(id).trace_location`). Locations without a spans table name are still rejected, with an error that says how to obtain a resolved one.
  - Docstring: lists `UnityCatalog` as a supported location (noting it must be backend-resolved) and the `context_local` example uses a `UnityCatalog` location.
- `tests/tracing/test_provider.py`
  - Removes `test_set_destination_databricks_unity_catalog_rejected`.
  - Adds `test_set_destination_databricks_unity_catalog` (resolved location is accepted, selects `DatabricksUCTableSpanProcessor` / `DatabricksUCTableSpanExporter`, `get_active_spans_table_name()` returns its table).
  - Adds `test_set_destination_databricks_unity_catalog_without_table_names_rejected`.
  - Adds `test_set_destination_databricks_unity_catalog_context_local` (isolation across threads, using a barrier so both destinations are set before either reads back, and across interleaved asyncio tasks; no leak into the caller's context).

`set_experiment`, the `UCSchemaLocation` deprecation warning and `MLFLOW_TRACING_DESTINATION` parsing are unchanged.

Resulting usage:

```python
import mlflow
from mlflow.entities.trace_location import UnityCatalog

# Once at startup: link the experiment to its UC table prefix. The returned location
# carries the backend-assigned table names.
location = mlflow.set_experiment(
    "my-experiment",
    trace_location=UnityCatalog(catalog_name="catalog", schema_name="schema", table_prefix="prefix"),
).trace_location

# Per request, in the request's thread / asyncio task:
mlflow.tracing.set_destination(location, context_local=True)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
uv run pytest tests/tracing/test_provider.py tests/tracing/processor/test_uc_table_processor.py tests/tracing/export/test_uc_table_exporter.py tests/tracing/test_enablement.py
# 94 passed
SKIP=prettier uv run --only-group lint pre-commit run --files mlflow/tracing/provider.py tests/tracing/test_provider.py
# ruff, format, clint, typos, ... all passed (prettier skipped due to a local npm restriction; no non-Python files changed)
```

Manual: the context-local registry path was exercised end-to-end against a real Databricks workspace on MLflow 3.16.0. Concurrent threads and interleaved asyncio tasks were routed to two different UC table prefixes, and spans landed only in the table of the prefix set in their own context.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] API references (the `mlflow.tracing.set_destination` docstring: supported locations and the `context_local` example)

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No. I could not find any reference to `mlflow.tracing.set_destination` or UC trace locations in that repository. Happy to follow up there if maintainers point me at the relevant skill.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.tracing.set_destination` now accepts backend-resolved `UnityCatalog` trace locations (e.g. `mlflow.set_experiment(..., trace_location=...).trace_location`), so traces can be routed to different Unity Catalog table prefixes per thread or asyncio task with `context_local=True`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
