### PR TITLE
Add The Grid as an OpenAI-compatible gateway provider

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -62,6 +62,7 @@ class Provider(str, Enum):
     DEEPSEEK = "deepseek"
     XAI = "xai"
     OPENROUTER = "openrouter"
+    THEGRID = "thegrid"
     OLLAMA = "ollama"
     VERTEX_AI = "vertex_ai"
     PORTKEY = "portkey"

--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -55,6 +55,7 @@ def _register_default_providers(registry: ProviderRegistry):
     from mlflow.gateway.providers.ollama import OllamaProvider
     from mlflow.gateway.providers.openai import OpenAIProvider
     from mlflow.gateway.providers.openrouter import OpenRouterProvider
+    from mlflow.gateway.providers.thegrid import TheGridProvider
     from mlflow.gateway.providers.palm import PaLMProvider
     from mlflow.gateway.providers.portkey import PortkeyProvider
     from mlflow.gateway.providers.sap_ai_core import SapAiCoreProvider
@@ -83,6 +84,7 @@ def _register_default_providers(registry: ProviderRegistry):
     registry.register(Provider.OLLAMA, OllamaProvider)
     registry.register(Provider.OPENAI, OpenAIProvider)
     registry.register(Provider.OPENROUTER, OpenRouterProvider)
+    registry.register(Provider.THEGRID, TheGridProvider)
     registry.register(Provider.PALM, PaLMProvider)
     registry.register(Provider.PORTKEY, PortkeyProvider)
     registry.register(Provider.SAP_AI_CORE, SapAiCoreProvider)

--- a/mlflow/gateway/providers/thegrid.py
+++ b/mlflow/gateway/providers/thegrid.py
@@ -1,0 +1,8 @@
+from mlflow.gateway.config import _OpenAICompatibleConfig
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
+
+
+class TheGridProvider(OpenAICompatibleProvider):
+    DISPLAY_NAME = "The Grid"
+    CONFIG_TYPE = _OpenAICompatibleConfig
+    DEFAULT_API_BASE = "https://api.thegrid.ai/v1"

--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -484,6 +484,13 @@ def _get_provider_instance(
         config = _OpenAICompatibleConfig(api_key=os.environ.get("OPENROUTER_API_KEY"))
         return OpenRouterProvider(_get_route_config(config))
 
+    elif provider == Provider.THEGRID:
+        from mlflow.gateway.config import _OpenAICompatibleConfig
+        from mlflow.gateway.providers.thegrid import TheGridProvider
+
+        config = _OpenAICompatibleConfig(api_key=os.environ.get("THEGRID_API_KEY"))
+        return TheGridProvider(_get_route_config(config))
+
     elif provider == Provider.OLLAMA:
         from mlflow.gateway.providers.ollama import OllamaConfig, OllamaProvider
 

--- a/mlflow/server/js/src/gateway/utils/providerUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.ts
@@ -12,6 +12,7 @@ export const COMMON_PROVIDERS = [
   'deepseek',
   'portkey',
   'openrouter',
+  'thegrid',
   'ollama',
   'together_ai',
 ] as const;
@@ -40,6 +41,7 @@ const PROVIDER_DISPLAY_NAMES = {
   cerebras: 'Cerebras',
   deepseek: 'DeepSeek',
   openrouter: 'OpenRouter',
+  thegrid: 'The Grid',
   ollama: 'Ollama',
 } satisfies Record<string, string>;
 

--- a/mlflow/utils/providers.py
+++ b/mlflow/utils/providers.py
@@ -1067,6 +1067,7 @@ _CORE_PROVIDER_ENV_VARS = {
     "deepseek": "DEEPSEEK_API_KEY",
     "xai": "XAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "thegrid": "THEGRID_API_KEY",
     "togetherai": "TOGETHERAI_API_KEY",
     "bedrock": {
         "aws_access_key_id": "AWS_ACCESS_KEY_ID",

--- a/tests/gateway/providers/test_thegrid.py
+++ b/tests/gateway/providers/test_thegrid.py
@@ -1,0 +1,76 @@
+from unittest import mock
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.thegrid import TheGridProvider
+from mlflow.gateway.schemas import chat
+
+from tests.gateway.tools import MockAsyncResponse, mock_http_client
+
+
+def _make_provider() -> TheGridProvider:
+    endpoint_config = EndpointConfig(
+        name="thegrid-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "thegrid",
+            "name": "text-prime",
+            "config": {"api_key": "tg-test-key"},
+        },
+    )
+    return TheGridProvider(endpoint_config)
+
+
+def _chat_response():
+    return {
+        "id": "chatcmpl-tg-123",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "text-prime",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello from The Grid!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def test_default_api_base():
+    provider = _make_provider()
+    assert provider._api_base == "https://api.thegrid.ai/v1"
+
+
+def test_headers():
+    provider = _make_provider()
+    assert provider.headers == {"Authorization": "Bearer tg-test-key"}
+
+
+def test_name():
+    provider = _make_provider()
+    assert provider.DISPLAY_NAME == "The Grid"
+
+
+@pytest.mark.asyncio
+async def test_chat():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["id"] == "chatcmpl-tg-123"
+    assert result["choices"][0]["message"]["content"] == "Hello from The Grid!"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #23540

### What changes are proposed in this pull request?

Adds **The Grid** (https://thegrid.ai) as an OpenAI-compatible gateway provider, following the existing `OpenRouterProvider` pattern.

The Grid is an inference marketplace serving models from several labs behind one OpenAI-compatible API. Model names are **capability tiers** rather than a lab's model name — `text-standard`, `code-prime`, `agent-max` each route to a current model for that tier.

The provider is 8 lines, since `OpenAICompatibleProvider` does the work:

```python
class TheGridProvider(OpenAICompatibleProvider):
    DISPLAY_NAME = "The Grid"
    CONFIG_TYPE = _OpenAICompatibleConfig
    DEFAULT_API_BASE = "https://api.thegrid.ai/v1"
```

Registration points mirror `openrouter` one-for-one:

- `mlflow/gateway/providers/thegrid.py` (new)
- `mlflow/gateway/config.py` — `Provider.THEGRID`
- `mlflow/gateway/provider_registry.py` — import + `registry.register`
- `mlflow/utils/providers.py` — `THEGRID_API_KEY`
- `mlflow/metrics/genai/model_utils.py` — provider branch
- `mlflow/server/js/src/gateway/utils/providerUtils.ts` — list + display name
- `tests/gateway/providers/test_thegrid.py` (new)

Only `llm/v1/chat` is claimed. The Grid returns 404 for `/v1/completions` and `/v1/embeddings`, so those endpoint types are not implemented.

No `mlflow/utils/model_catalog/thegrid.json` is included: those files carry static per-token pricing, and The Grid is market-priced — its `/v1/models` currently returns `"pricing": null` — so committed numbers would be wrong shortly after merge. Happy to add a catalog entry if you'd like one without pricing.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

`tests/gateway/providers/test_thegrid.py` mirrors `test_openrouter.py` (default api base, headers, display name, and a mocked `chat()` round-trip).

Note: `tests/gateway/providers/` does not collect on a stock install in my environment — `tests/gateway/tools.py` imports `sentence_transformers` at module scope, and the existing `test_openrouter.py` fails collection the same way, so it is environmental rather than introduced here. Rather than claim a run I didn't do, I verified the same five assertions directly using inlined equivalents of the two mock helpers:

```
enum + registry + api_base + headers + display name: all OK
chat() round-trip: OK
```

I also ran it live against the real endpoint through the provider's own aiohttp path:

```
LIVE via MLflow gateway provider (aiohttp path): OK
  model  : openai/gpt-oss-120b
  content: 'hello'
  usage  : {'prompt_tokens': 85, 'completion_tokens': 59, ...}
```

That last check mattered because The Grid answers `/v1/*` with a 307 to a signed URL and some HTTP clients do not follow it. aiohttp does by default, so no special handling is needed.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds The Grid as a supported AI Gateway provider for `llm/v1/chat` endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Disclosure: I work on The Grid. The previous attempt (#25638) was auto-closed because I submitted it without filling in this template — apologies for the noise.

---

## Re: the automated checks

**DCO.** Resolved. The bot commented at `2026-09-06T07:48:54Z`; the current head `66269a69f` was committed at `2026-09-06T15:04:06Z` and carries `Signed-off-by: Luis Castillo <luisedcastillog@gmail.com>` matching the commit author. The DCO status on the current head reports `success`.

**Missing visual media.** This is a false alert, and I would rather explain why than attach a misleading screenshot.

The only front-end file touched is `mlflow/server/js/src/gateway/utils/providerUtils.ts`, which contains no JSX and renders nothing. It holds two constant collections, and the diff is two lines:

```diff
   'openrouter',
+  'thegrid',
   'ollama',
```
```diff
   openrouter: 'OpenRouter',
+  thegrid: 'The Grid',
   ollama: 'Ollama',
```

There is no before/after UI state to capture beyond one additional row appearing in the provider list, which is the intended effect of registering a provider and matches what every entry in that file already does. Nothing about layout, styling or component behaviour changes.

Happy to attach a screenshot of the provider list if you would still like one on the record.
