### PR TITLE
Require model_id permission for LogMetric/LogBatch metric routing

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -945,10 +945,8 @@ def _get_permission_from_run_id() -> Permission:
     )
 
 
-def _get_permission_from_model_id(model_id: str | None = None) -> Permission:
+def _get_model_permission(model_id: str) -> Permission:
     # logged model permissions inherit from parent resource (experiment)
-    if model_id is None:
-        model_id = _get_request_param("model_id")
     model = _get_tracking_store().get_logged_model(model_id)
     experiment_id = model.experiment_id
     username = authenticate_request().username
@@ -962,6 +960,10 @@ def _get_permission_from_model_id(model_id: str | None = None) -> Permission:
             workspace_label="experiment",
         ),
     )
+
+
+def _get_permission_from_model_id() -> Permission:
+    return _get_model_permission(_get_request_param("model_id"))
 
 
 def _get_permission_from_prompt_optimization_job_id() -> Permission:
@@ -1200,39 +1202,18 @@ def validate_can_update_run():
     return _get_permission_from_run_id().can_update
 
 
-def validate_can_update_run_with_model_metrics():
-    # LogMetric/LogBatch can optionally write metrics to logged models via model_id.
-    # Require UPDATE on the run AND on any model_id present in the metrics to prevent
-    # a user with UPDATE on their own run from injecting metrics onto another user's models.
+def _validate_can_update_run_and_models(model_ids: set[str]) -> bool:
+    # Require UPDATE on the run AND on any model_id the metrics target, so a user with
+    # UPDATE on their own run cannot inject metrics onto another user's logged models.
     if not _get_permission_from_run_id().can_update:
         return False
 
-    # Parse request through proto to handle camelCase aliases and nested batch metrics.
-    # Extract model_ids from BOTH LogBatch and LogMetric shapes (union them).
-    # A LogMetric request parsed as LogBatch yields empty metrics (harmless).
-    # A LogBatch request parsed as LogMetric yields empty model_id (harmless).
-    model_ids: set[str] = set()
-
-    # Try LogBatch first (for nested metrics)
-    try:
-        batch_msg = _get_request_message(LogBatch())
-        model_ids |= {m.model_id for m in batch_msg.metrics if m.model_id}
-    except MlflowException:
-        return False
-
-    # Also try LogMetric (for top-level model_id)
-    try:
-        metric_msg = _get_request_message(LogMetric())
-        if metric_msg.model_id:
-            model_ids.add(metric_msg.model_id)
-    except MlflowException:
-        return False
-
-    # Check UPDATE permission on each distinct model_id.
-    # Catch RESOURCE_DOES_NOT_EXIST (nonexistent model_id) and deny uniformly with 403.
+    # Check UPDATE permission on each distinct model_id. Catch RESOURCE_DOES_NOT_EXIST
+    # (nonexistent model_id) and deny uniformly with 403 so the response can't be used
+    # as an oracle for which model_ids exist.
     for model_id in model_ids:
         try:
-            if not _get_permission_from_model_id(model_id=model_id).can_update:
+            if not _get_model_permission(model_id).can_update:
                 return False
         except MlflowException as e:
             if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
@@ -1240,6 +1221,23 @@ def validate_can_update_run_with_model_metrics():
             raise
 
     return True
+
+
+def validate_can_log_metric():
+    # LogMetric can optionally write the metric to a logged model via model_id. Parse
+    # through the proto so the camelCase `modelId` alias is covered. Only the LogMetric
+    # shape is parsed so fields the endpoint ignores never affect authorization.
+    msg = _get_request_message(LogMetric())
+    model_ids = {msg.model_id} if msg.model_id else set()
+    return _validate_can_update_run_and_models(model_ids)
+
+
+def validate_can_log_batch():
+    # LogBatch can optionally write metrics to logged models via per-metric model_id.
+    # Parse through the proto (covers the camelCase `modelId` alias on nested metrics).
+    msg = _get_request_message(LogBatch())
+    model_ids = {m.model_id for m in msg.metrics if m.model_id}
+    return _validate_can_update_run_and_models(model_ids)
 
 
 def validate_can_delete_run():
@@ -2723,8 +2721,8 @@ BEFORE_REQUEST_HANDLERS = {
     DeleteRun: validate_can_delete_run,
     RestoreRun: validate_can_delete_run,
     UpdateRun: validate_can_update_run,
-    LogMetric: validate_can_update_run_with_model_metrics,
-    LogBatch: validate_can_update_run_with_model_metrics,
+    LogMetric: validate_can_log_metric,
+    LogBatch: validate_can_log_batch,
     LogInputs: validate_can_update_run,
     LogModel: validate_can_update_run,
     LogOutputs: validate_can_update_run,

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -1217,21 +1217,27 @@ def validate_can_update_run_with_model_metrics():
     try:
         batch_msg = _get_request_message(LogBatch())
         model_ids |= {m.model_id for m in batch_msg.metrics if m.model_id}
-    except Exception:
-        pass
+    except MlflowException:
+        return False
 
     # Also try LogMetric (for top-level model_id)
     try:
         metric_msg = _get_request_message(LogMetric())
         if metric_msg.model_id:
             model_ids.add(metric_msg.model_id)
-    except Exception:
-        pass
+    except MlflowException:
+        return False
 
-    # Check UPDATE permission on each distinct model_id
+    # Check UPDATE permission on each distinct model_id.
+    # Catch RESOURCE_DOES_NOT_EXIST (nonexistent model_id) and deny uniformly with 403.
     for model_id in model_ids:
-        if not _get_permission_from_model_id(model_id=model_id).can_update:
-            return False
+        try:
+            if not _get_permission_from_model_id(model_id=model_id).can_update:
+                return False
+        except MlflowException as e:
+            if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                return False
+            raise
 
     return True
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -945,9 +945,10 @@ def _get_permission_from_run_id() -> Permission:
     )
 
 
-def _get_permission_from_model_id() -> Permission:
+def _get_permission_from_model_id(model_id: str | None = None) -> Permission:
     # logged model permissions inherit from parent resource (experiment)
-    model_id = _get_request_param("model_id")
+    if model_id is None:
+        model_id = _get_request_param("model_id")
     model = _get_tracking_store().get_logged_model(model_id)
     experiment_id = model.experiment_id
     username = authenticate_request().username
@@ -1197,6 +1198,42 @@ def validate_can_read_run():
 
 def validate_can_update_run():
     return _get_permission_from_run_id().can_update
+
+
+def validate_can_update_run_with_model_metrics():
+    # LogMetric/LogBatch can optionally write metrics to logged models via model_id.
+    # Require UPDATE on the run AND on any model_id present in the metrics to prevent
+    # a user with UPDATE on their own run from injecting metrics onto another user's models.
+    if not _get_permission_from_run_id().can_update:
+        return False
+
+    # Parse request through proto to handle camelCase aliases and nested batch metrics.
+    # Extract model_ids from BOTH LogBatch and LogMetric shapes (union them).
+    # A LogMetric request parsed as LogBatch yields empty metrics (harmless).
+    # A LogBatch request parsed as LogMetric yields empty model_id (harmless).
+    model_ids: set[str] = set()
+
+    # Try LogBatch first (for nested metrics)
+    try:
+        batch_msg = _get_request_message(LogBatch())
+        model_ids |= {m.model_id for m in batch_msg.metrics if m.model_id}
+    except Exception:
+        pass
+
+    # Also try LogMetric (for top-level model_id)
+    try:
+        metric_msg = _get_request_message(LogMetric())
+        if metric_msg.model_id:
+            model_ids.add(metric_msg.model_id)
+    except Exception:
+        pass
+
+    # Check UPDATE permission on each distinct model_id
+    for model_id in model_ids:
+        if not _get_permission_from_model_id(model_id=model_id).can_update:
+            return False
+
+    return True
 
 
 def validate_can_delete_run():
@@ -2680,8 +2717,8 @@ BEFORE_REQUEST_HANDLERS = {
     DeleteRun: validate_can_delete_run,
     RestoreRun: validate_can_delete_run,
     UpdateRun: validate_can_update_run,
-    LogMetric: validate_can_update_run,
-    LogBatch: validate_can_update_run,
+    LogMetric: validate_can_update_run_with_model_metrics,
+    LogBatch: validate_can_update_run_with_model_metrics,
     LogInputs: validate_can_update_run,
     LogModel: validate_can_update_run,
     LogOutputs: validate_can_update_run,

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -1771,6 +1771,22 @@ def test_log_batch_and_metric_require_update_on_model_ids(
     assert response.status_code == 403
     assert "Permission denied" in response.text
 
+    # Test 11: Nonexistent/garbage model_id should return 403 (not 404 oracle)
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-metric",
+        json_payload={
+            "run_id": run_id,
+            "key": "metric_bogus_model",
+            "value": 13.0,
+            "timestamp": timestamp,
+            "model_id": "m-bogus-nonexistent-model-id",
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+    assert "Permission denied" in response.text
+
 
 def _wait(url: str, timeout: int = 10) -> None:
     t = time.time()

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -1548,269 +1548,286 @@ def test_create_model_version_empty_source_id_does_not_bypass(
     assert "Permission denied" in response.text
 
 
-@pytest.mark.parametrize(
-    "client",
-    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
-    indirect=True,
-)
-def test_log_batch_and_metric_require_update_on_model_ids(
-    client: MlflowClient, monkeypatch: pytest.MonkeyPatch
-):
+@pytest.fixture
+def metric_model_authz(client: MlflowClient, monkeypatch: pytest.MonkeyPatch):
+    # user2 (the actor) owns the run but has no permission on either model's experiment:
+    # user1 owns model_id1's experiment and user3 owns model_id3's.
     username1, password1 = create_user(client.tracking_uri)
     username2, password2 = create_user(client.tracking_uri)
     username3, password3 = create_user(client.tracking_uri)
 
     with User(username1, password1, monkeypatch):
         exp_id1 = client.create_experiment("metric-authz-model-exp-1")
-        model1 = client.create_logged_model(experiment_id=exp_id1)
-        model_id1 = model1.model_id
+        model_id1 = client.create_logged_model(experiment_id=exp_id1).model_id
 
     with User(username3, password3, monkeypatch):
         exp_id3 = client.create_experiment("metric-authz-model-exp-3")
-        model3 = client.create_logged_model(experiment_id=exp_id3)
-        model_id3 = model3.model_id
+        model_id3 = client.create_logged_model(experiment_id=exp_id3).model_id
 
     with User(username2, password2, monkeypatch):
         exp_id2 = client.create_experiment("metric-authz-run-exp")
-        run = client.create_run(exp_id2)
-        run_id = run.info.run_id
+        run_id = client.create_run(exp_id2).info.run_id
 
-    timestamp = int(time.time() * 1000)
+    return SimpleNamespace(
+        tracking_uri=client.tracking_uri,
+        user2=(username2, password2),
+        exp_id1=exp_id1,
+        model_id1=model_id1,
+        model_id3=model_id3,
+        run_id=run_id,
+        timestamp=int(time.time() * 1000),
+    )
 
-    # Test 1: LogMetric (single, not batch) with unauthorized top-level model_id should fail
+
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
+def test_log_metric_model_id_requires_update(metric_model_authz):
+    # LogMetric can route a metric to a logged model via model_id; a user with UPDATE on
+    # the run but not on the model_id's experiment must be denied.
+    a = metric_model_authz
+
+    # Unauthorized top-level model_id is denied.
     response = _send_rest_tracking_post_request(
-        client.tracking_uri,
+        a.tracking_uri,
         "/api/2.0/mlflow/runs/log-metric",
         json_payload={
-            "run_id": run_id,
+            "run_id": a.run_id,
             "key": "metric_with_model",
             "value": 1.0,
-            "timestamp": timestamp,
-            "model_id": model_id1,
+            "timestamp": a.timestamp,
+            "model_id": a.model_id1,
         },
-        auth=(username2, password2),
+        auth=a.user2,
     )
     assert response.status_code == 403
     assert "Permission denied" in response.text
 
-    # Test 2: LogMetric with camelCase modelId alias on unauthorized model should fail
+    # The camelCase `modelId` alias is covered too.
     response = _send_rest_tracking_post_request(
-        client.tracking_uri,
+        a.tracking_uri,
         "/api/2.0/mlflow/runs/log-metric",
         json_payload={
-            "run_id": run_id,
+            "run_id": a.run_id,
             "key": "metric_with_camel_model",
             "value": 2.0,
-            "timestamp": timestamp,
-            "modelId": model_id1,  # camelCase variant
+            "timestamp": a.timestamp,
+            "modelId": a.model_id1,
         },
-        auth=(username2, password2),
+        auth=a.user2,
     )
     assert response.status_code == 403
     assert "Permission denied" in response.text
 
-    # Test 3: LogBatch with nested model_id on unauthorized model should fail
+    # A nonexistent model_id returns a uniform 403, not a 404 existence oracle.
     response = _send_rest_tracking_post_request(
-        client.tracking_uri,
+        a.tracking_uri,
+        "/api/2.0/mlflow/runs/log-metric",
+        json_payload={
+            "run_id": a.run_id,
+            "key": "metric_bogus_model",
+            "value": 13.0,
+            "timestamp": a.timestamp,
+            "model_id": "m-bogus-nonexistent-model-id",
+        },
+        auth=a.user2,
+    )
+    assert response.status_code == 403
+    assert "Permission denied" in response.text
+
+    # No model_id: only run UPDATE is required, so it succeeds.
+    response = _send_rest_tracking_post_request(
+        a.tracking_uri,
+        "/api/2.0/mlflow/runs/log-metric",
+        json_payload={
+            "run_id": a.run_id,
+            "key": "metric_no_model",
+            "value": 7.0,
+            "timestamp": a.timestamp,
+        },
+        auth=a.user2,
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
+def test_log_batch_model_id_requires_update(metric_model_authz):
+    # LogBatch can route per-metric metrics to logged models via nested model_id; any
+    # referenced model the caller lacks UPDATE on must deny the whole batch.
+    a = metric_model_authz
+
+    # Unauthorized nested model_id is denied.
+    response = _send_rest_tracking_post_request(
+        a.tracking_uri,
         "/api/2.0/mlflow/runs/log-batch",
         json_payload={
-            "run_id": run_id,
+            "run_id": a.run_id,
             "metrics": [
                 {
                     "key": "batch_metric_with_model",
                     "value": 3.0,
-                    "timestamp": timestamp,
-                    "model_id": model_id1,
+                    "timestamp": a.timestamp,
+                    "model_id": a.model_id1,
                 }
             ],
         },
-        auth=(username2, password2),
+        auth=a.user2,
     )
     assert response.status_code == 403
     assert "Permission denied" in response.text
 
-    # Test 4: LogBatch with camelCase modelId alias on unauthorized model should fail
+    # The camelCase `modelId` alias on a nested metric is covered too.
     response = _send_rest_tracking_post_request(
-        client.tracking_uri,
+        a.tracking_uri,
         "/api/2.0/mlflow/runs/log-batch",
         json_payload={
-            "run_id": run_id,
+            "run_id": a.run_id,
             "metrics": [
                 {
                     "key": "batch_metric_with_camel_model",
                     "value": 4.0,
-                    "timestamp": timestamp,
-                    "modelId": model_id1,  # camelCase variant
+                    "timestamp": a.timestamp,
+                    "modelId": a.model_id1,
                 }
             ],
         },
-        auth=(username2, password2),
+        auth=a.user2,
     )
     assert response.status_code == 403
     assert "Permission denied" in response.text
 
-    # Test 5: LogBatch with multiple distinct model_ids, one unauthorized should fail
+    # A batch referencing a distinct unauthorized model is denied.
     response = _send_rest_tracking_post_request(
-        client.tracking_uri,
+        a.tracking_uri,
         "/api/2.0/mlflow/runs/log-batch",
         json_payload={
-            "run_id": run_id,
+            "run_id": a.run_id,
             "metrics": [
                 {
                     "key": "metric1",
                     "value": 5.0,
-                    "timestamp": timestamp,
-                    "model_id": model_id1,
+                    "timestamp": a.timestamp,
+                    "model_id": a.model_id1,
                 },
                 {
                     "key": "metric2",
                     "value": 6.0,
-                    "timestamp": timestamp,
-                    "model_id": model_id3,
+                    "timestamp": a.timestamp,
+                    "model_id": a.model_id3,
                 },
             ],
         },
-        auth=(username2, password2),
+        auth=a.user2,
     )
     assert response.status_code == 403
     assert "Permission denied" in response.text
 
-    # Test 6: LogMetric without model_id should still work
+    # No model_id on any metric: only run UPDATE is required, so it succeeds.
     response = _send_rest_tracking_post_request(
-        client.tracking_uri,
-        "/api/2.0/mlflow/runs/log-metric",
-        json_payload={
-            "run_id": run_id,
-            "key": "metric_no_model",
-            "value": 7.0,
-            "timestamp": timestamp,
-        },
-        auth=(username2, password2),
-    )
-    assert response.status_code == 200
-
-    # Test 7: LogBatch without model_id should still work
-    response = _send_rest_tracking_post_request(
-        client.tracking_uri,
+        a.tracking_uri,
         "/api/2.0/mlflow/runs/log-batch",
         json_payload={
-            "run_id": run_id,
+            "run_id": a.run_id,
             "metrics": [
-                {
-                    "key": "batch_metric_1",
-                    "value": 8.0,
-                    "timestamp": timestamp,
-                },
-                {
-                    "key": "batch_metric_2",
-                    "value": 9.0,
-                    "timestamp": timestamp,
-                },
+                {"key": "batch_metric_1", "value": 8.0, "timestamp": a.timestamp},
+                {"key": "batch_metric_2", "value": 9.0, "timestamp": a.timestamp},
             ],
         },
-        auth=(username2, password2),
+        auth=a.user2,
     )
     assert response.status_code == 200
 
-    # Grant user2 UPDATE on model1's experiment
-    grant_role_permission(
-        client.tracking_uri,
-        username2,
-        "experiment",
-        exp_id1,
-        "EDIT",
-    )
 
-    # Test 8: After permission grant, LogMetric with model_id1 should succeed
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
+def test_log_metric_and_batch_model_id_allowed_after_grant(metric_model_authz):
+    # After user2 is granted UPDATE on model_id1's experiment (but not model_id3's),
+    # metrics targeting model_id1 succeed while model_id3 stays denied.
+    a = metric_model_authz
+    grant_role_permission(a.tracking_uri, a.user2[0], "experiment", a.exp_id1, "EDIT")
+
+    # Authorized model_id via LogMetric succeeds.
     response = _send_rest_tracking_post_request(
-        client.tracking_uri,
+        a.tracking_uri,
         "/api/2.0/mlflow/runs/log-metric",
         json_payload={
-            "run_id": run_id,
+            "run_id": a.run_id,
             "key": "metric_with_perm",
             "value": 10.0,
-            "timestamp": timestamp,
-            "model_id": model_id1,
+            "timestamp": a.timestamp,
+            "model_id": a.model_id1,
         },
-        auth=(username2, password2),
+        auth=a.user2,
     )
     assert response.status_code == 200
 
-    # Test 9: After permission grant, LogBatch with model_id1 should succeed
+    # Authorized model_id via LogBatch succeeds.
     response = _send_rest_tracking_post_request(
-        client.tracking_uri,
+        a.tracking_uri,
         "/api/2.0/mlflow/runs/log-batch",
         json_payload={
-            "run_id": run_id,
+            "run_id": a.run_id,
             "metrics": [
                 {
                     "key": "batch_metric_with_perm",
                     "value": 11.0,
-                    "timestamp": timestamp,
-                    "model_id": model_id1,
+                    "timestamp": a.timestamp,
+                    "model_id": a.model_id1,
                 }
             ],
         },
-        auth=(username2, password2),
+        auth=a.user2,
     )
     assert response.status_code == 200
 
-    # Test 9b: mixed-permission batch - model_id1 is now authorized but model_id3 is not.
-    # Ordering the authorized model first ensures every distinct model_id is checked, not
-    # just the first one that passes.
+    # Mixed-permission batch: the authorized model is listed first, so the 403 proves
+    # every distinct model_id is checked, not just the first one that passes.
     response = _send_rest_tracking_post_request(
-        client.tracking_uri,
+        a.tracking_uri,
         "/api/2.0/mlflow/runs/log-batch",
         json_payload={
-            "run_id": run_id,
+            "run_id": a.run_id,
             "metrics": [
                 {
                     "key": "batch_authorized_model",
                     "value": 11.5,
-                    "timestamp": timestamp,
-                    "model_id": model_id1,
+                    "timestamp": a.timestamp,
+                    "model_id": a.model_id1,
                 },
                 {
                     "key": "batch_unauthorized_model",
                     "value": 11.6,
-                    "timestamp": timestamp,
-                    "model_id": model_id3,
+                    "timestamp": a.timestamp,
+                    "model_id": a.model_id3,
                 },
             ],
         },
-        auth=(username2, password2),
+        auth=a.user2,
     )
     assert response.status_code == 403
     assert "Permission denied" in response.text
 
-    # Test 10: But metrics with model_id3 (still no permission) should still fail
+    # A model in a still-unauthorized experiment remains denied.
     response = _send_rest_tracking_post_request(
-        client.tracking_uri,
+        a.tracking_uri,
         "/api/2.0/mlflow/runs/log-metric",
         json_payload={
-            "run_id": run_id,
+            "run_id": a.run_id,
             "key": "metric_without_perm",
             "value": 12.0,
-            "timestamp": timestamp,
-            "model_id": model_id3,
+            "timestamp": a.timestamp,
+            "model_id": a.model_id3,
         },
-        auth=(username2, password2),
-    )
-    assert response.status_code == 403
-    assert "Permission denied" in response.text
-
-    # Test 11: Nonexistent/garbage model_id should return 403 (not 404 oracle)
-    response = _send_rest_tracking_post_request(
-        client.tracking_uri,
-        "/api/2.0/mlflow/runs/log-metric",
-        json_payload={
-            "run_id": run_id,
-            "key": "metric_bogus_model",
-            "value": 13.0,
-            "timestamp": timestamp,
-            "model_id": "m-bogus-nonexistent-model-id",
-        },
-        auth=(username2, password2),
+        auth=a.user2,
     )
     assert response.status_code == 403
     assert "Permission denied" in response.text

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -1755,6 +1755,34 @@ def test_log_batch_and_metric_require_update_on_model_ids(
     )
     assert response.status_code == 200
 
+    # Test 9b: mixed-permission batch - model_id1 is now authorized but model_id3 is not.
+    # Ordering the authorized model first ensures every distinct model_id is checked, not
+    # just the first one that passes.
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-batch",
+        json_payload={
+            "run_id": run_id,
+            "metrics": [
+                {
+                    "key": "batch_authorized_model",
+                    "value": 11.5,
+                    "timestamp": timestamp,
+                    "model_id": model_id1,
+                },
+                {
+                    "key": "batch_unauthorized_model",
+                    "value": 11.6,
+                    "timestamp": timestamp,
+                    "model_id": model_id3,
+                },
+            ],
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+    assert "Permission denied" in response.text
+
     # Test 10: But metrics with model_id3 (still no permission) should still fail
     response = _send_rest_tracking_post_request(
         client.tracking_uri,

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -1548,6 +1548,230 @@ def test_create_model_version_empty_source_id_does_not_bypass(
     assert "Permission denied" in response.text
 
 
+@pytest.mark.parametrize(
+    "client",
+    [{"MLFLOW_AUTH_CONFIG_PATH": "fixtures/no_permission_auth.ini"}],
+    indirect=True,
+)
+def test_log_batch_and_metric_require_update_on_model_ids(
+    client: MlflowClient, monkeypatch: pytest.MonkeyPatch
+):
+    username1, password1 = create_user(client.tracking_uri)
+    username2, password2 = create_user(client.tracking_uri)
+    username3, password3 = create_user(client.tracking_uri)
+
+    with User(username1, password1, monkeypatch):
+        exp_id1 = client.create_experiment("metric-authz-model-exp-1")
+        model1 = client.create_logged_model(experiment_id=exp_id1)
+        model_id1 = model1.model_id
+
+    with User(username3, password3, monkeypatch):
+        exp_id3 = client.create_experiment("metric-authz-model-exp-3")
+        model3 = client.create_logged_model(experiment_id=exp_id3)
+        model_id3 = model3.model_id
+
+    with User(username2, password2, monkeypatch):
+        exp_id2 = client.create_experiment("metric-authz-run-exp")
+        run = client.create_run(exp_id2)
+        run_id = run.info.run_id
+
+    timestamp = int(time.time() * 1000)
+
+    # Test 1: LogMetric (single, not batch) with unauthorized top-level model_id should fail
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-metric",
+        json_payload={
+            "run_id": run_id,
+            "key": "metric_with_model",
+            "value": 1.0,
+            "timestamp": timestamp,
+            "model_id": model_id1,
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+    assert "Permission denied" in response.text
+
+    # Test 2: LogMetric with camelCase modelId alias on unauthorized model should fail
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-metric",
+        json_payload={
+            "run_id": run_id,
+            "key": "metric_with_camel_model",
+            "value": 2.0,
+            "timestamp": timestamp,
+            "modelId": model_id1,  # camelCase variant
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+    assert "Permission denied" in response.text
+
+    # Test 3: LogBatch with nested model_id on unauthorized model should fail
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-batch",
+        json_payload={
+            "run_id": run_id,
+            "metrics": [
+                {
+                    "key": "batch_metric_with_model",
+                    "value": 3.0,
+                    "timestamp": timestamp,
+                    "model_id": model_id1,
+                }
+            ],
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+    assert "Permission denied" in response.text
+
+    # Test 4: LogBatch with camelCase modelId alias on unauthorized model should fail
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-batch",
+        json_payload={
+            "run_id": run_id,
+            "metrics": [
+                {
+                    "key": "batch_metric_with_camel_model",
+                    "value": 4.0,
+                    "timestamp": timestamp,
+                    "modelId": model_id1,  # camelCase variant
+                }
+            ],
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+    assert "Permission denied" in response.text
+
+    # Test 5: LogBatch with multiple distinct model_ids, one unauthorized should fail
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-batch",
+        json_payload={
+            "run_id": run_id,
+            "metrics": [
+                {
+                    "key": "metric1",
+                    "value": 5.0,
+                    "timestamp": timestamp,
+                    "model_id": model_id1,
+                },
+                {
+                    "key": "metric2",
+                    "value": 6.0,
+                    "timestamp": timestamp,
+                    "model_id": model_id3,
+                },
+            ],
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+    assert "Permission denied" in response.text
+
+    # Test 6: LogMetric without model_id should still work
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-metric",
+        json_payload={
+            "run_id": run_id,
+            "key": "metric_no_model",
+            "value": 7.0,
+            "timestamp": timestamp,
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 200
+
+    # Test 7: LogBatch without model_id should still work
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-batch",
+        json_payload={
+            "run_id": run_id,
+            "metrics": [
+                {
+                    "key": "batch_metric_1",
+                    "value": 8.0,
+                    "timestamp": timestamp,
+                },
+                {
+                    "key": "batch_metric_2",
+                    "value": 9.0,
+                    "timestamp": timestamp,
+                },
+            ],
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 200
+
+    # Grant user2 UPDATE on model1's experiment
+    grant_role_permission(
+        client.tracking_uri,
+        username2,
+        "experiment",
+        exp_id1,
+        "EDIT",
+    )
+
+    # Test 8: After permission grant, LogMetric with model_id1 should succeed
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-metric",
+        json_payload={
+            "run_id": run_id,
+            "key": "metric_with_perm",
+            "value": 10.0,
+            "timestamp": timestamp,
+            "model_id": model_id1,
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 200
+
+    # Test 9: After permission grant, LogBatch with model_id1 should succeed
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-batch",
+        json_payload={
+            "run_id": run_id,
+            "metrics": [
+                {
+                    "key": "batch_metric_with_perm",
+                    "value": 11.0,
+                    "timestamp": timestamp,
+                    "model_id": model_id1,
+                }
+            ],
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 200
+
+    # Test 10: But metrics with model_id3 (still no permission) should still fail
+    response = _send_rest_tracking_post_request(
+        client.tracking_uri,
+        "/api/2.0/mlflow/runs/log-metric",
+        json_payload={
+            "run_id": run_id,
+            "key": "metric_without_perm",
+            "value": 12.0,
+            "timestamp": timestamp,
+            "model_id": model_id3,
+        },
+        auth=(username2, password2),
+    )
+    assert response.status_code == 403
+    assert "Permission denied" in response.text
+
+
 def _wait(url: str, timeout: int = 10) -> None:
     t = time.time()
     while time.time() - t < timeout:


### PR DESCRIPTION
### Related Issues/PRs

Addresses GHSA-j6gw-m35q-8j63.

### What changes are proposed in this pull request?

`LogMetric` and `LogBatch` accept an optional per-metric `model_id` that routes the metric onto the named `LoggedModel`. Both endpoints were gated only by `validate_can_update_run`, which resolves permission from `run_id` alone — nothing checked permission on the `model_id`. A user with UPDATE on their own run could therefore write metric records onto any `LoggedModel` in the instance.

This adds `validate_can_update_run_with_model_metrics` for `LogMetric`/`LogBatch`, which keeps the run-level UPDATE check and additionally requires UPDATE permission on every `model_id` referenced in the request:

- The request is parsed through the proto (both `LogBatch` nested metrics and `LogMetric`), so nested batch `model_id`s and the `modelId` camelCase alias are both covered.
- `_get_permission_from_model_id` now accepts an explicit `model_id` (backward compatible; existing callers unchanged).
- A nonexistent `model_id` fails closed with a uniform `403` (no existence oracle).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added coverage in `tests/server/auth/test_auth.py`: `LogMetric` and `LogBatch` with an unauthorized `model_id` (403), the `modelId` camelCase alias (403), a batch with multiple distinct `model_id`s, a nonexistent `model_id` (uniform 403), and the no-`model_id` / post-grant happy paths. These fail on `master` and pass with the change.

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `LogMetric`/`LogBatch` now require update permission on any `model_id` referenced by a metric, not just the run.

#### What component(s) does this PR affect?

- [x] `area/tracking`
- [x] `area/server-infra`

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Reported by mtholmquist via GitHub Security Advisory GHSA-j6gw-m35q-8j63.
