### PR TITLE
Count fragment selections in GraphQL query-cost limits

### DIFF
--- a/mlflow/server/graphql/graphql_no_batching.py
+++ b/mlflow/server/graphql/graphql_no_batching.py
@@ -1,3 +1,4 @@
+from collections import deque
 from typing import NamedTuple
 
 from graphql.error import GraphQLError
@@ -9,6 +10,7 @@ from graphql.language.ast import (
     FragmentSpreadNode,
     InlineFragmentNode,
     OperationDefinitionNode,
+    SelectionSetNode,
 )
 
 from mlflow.environment_variables import (
@@ -26,7 +28,7 @@ class QueryInfo(NamedTuple):
 
 
 def _collect_fields_and_aliases(
-    selection_set,
+    selection_set: SelectionSetNode,
     fragment_defs: dict[str, FragmentDefinitionNode],
     visited_fragments: frozenset[str],
 ) -> tuple[list[FieldNode], int]:
@@ -42,12 +44,13 @@ def _collect_fields_and_aliases(
     """
     field_selections = []
     total_aliases = 0
-    selections_to_process = list(getattr(selection_set, "selections", []))
+    # deque so popleft is O(1); order does not affect the field/alias counts.
+    selections_to_process = deque(selection_set.selections)
     # Track fragments visited during this collection to prevent cycles
     local_visited = set(visited_fragments)
 
     while selections_to_process:
-        selection = selections_to_process.pop(0)
+        selection = selections_to_process.popleft()
 
         if isinstance(selection, FieldNode):
             field_selections.append(selection)

--- a/mlflow/server/graphql/graphql_no_batching.py
+++ b/mlflow/server/graphql/graphql_no_batching.py
@@ -2,7 +2,14 @@ from typing import NamedTuple
 
 from graphql.error import GraphQLError
 from graphql.execution import ExecutionResult
-from graphql.language.ast import DocumentNode, FieldNode, InlineFragmentNode
+from graphql.language.ast import (
+    DocumentNode,
+    FieldNode,
+    FragmentDefinitionNode,
+    FragmentSpreadNode,
+    InlineFragmentNode,
+    OperationDefinitionNode,
+)
 
 from mlflow.environment_variables import (
     MLFLOW_SERVER_GRAPHQL_MAX_ALIASES,
@@ -26,11 +33,23 @@ def scan_query(ast_node: DocumentNode) -> QueryInfo:
     max_aliases = 0
     total_selections = 0
 
+    # Build a map of fragment definitions for lookup when resolving fragment spreads
+    fragment_defs = {
+        defn.name.value: defn
+        for defn in ast_node.definitions
+        if isinstance(defn, FragmentDefinitionNode)
+    }
+
+    # Only process operation definitions, not fragment definitions
     for definition in ast_node.definitions:
+        if not isinstance(definition, OperationDefinitionNode):
+            continue
+
         if selection_set := getattr(definition, "selection_set", None):
-            stack = [(selection_set, 1)]
+            # Stack tracks (selection_set, depth, visited_fragments) to detect cycles
+            stack = [(selection_set, 1, frozenset())]
             while stack:
-                selection_set, depth = stack.pop()
+                selection_set, depth, visited_fragments = stack.pop()
 
                 # check current level depth
                 if depth > _MAX_DEPTH:
@@ -47,7 +66,7 @@ def scan_query(ast_node: DocumentNode) -> QueryInfo:
                         if selection.alias:
                             current_aliases += 1
                         if selection.selection_set:
-                            stack.append((selection.selection_set, depth + 1))
+                            stack.append((selection.selection_set, depth + 1, visited_fragments))
                         total_selections += 1
                         if total_selections > _MAX_SELECTIONS:
                             raise GraphQLError(
@@ -56,7 +75,15 @@ def scan_query(ast_node: DocumentNode) -> QueryInfo:
                     elif isinstance(selection, InlineFragmentNode):
                         # Inline fragments should have their selections counted at the current depth
                         if selection.selection_set:
-                            stack.append((selection.selection_set, depth))
+                            stack.append((selection.selection_set, depth, visited_fragments))
+                    elif isinstance(selection, FragmentSpreadNode):
+                        # Fragment spreads: count selections at current depth, guard cycles
+                        fragment_name = selection.name.value
+                        if fragment_name not in visited_fragments:
+                            fragment_def = fragment_defs.get(fragment_name)
+                            if fragment_def and fragment_def.selection_set:
+                                new_visited = visited_fragments | {fragment_name}
+                                stack.append((fragment_def.selection_set, depth, new_visited))
                 max_aliases = max(max_aliases, current_aliases)
 
     return QueryInfo(root_fields, max_aliases)

--- a/mlflow/server/graphql/graphql_no_batching.py
+++ b/mlflow/server/graphql/graphql_no_batching.py
@@ -25,6 +25,50 @@ class QueryInfo(NamedTuple):
     max_aliases: int
 
 
+def _collect_fields_and_aliases(
+    selection_set,
+    fragment_defs: dict[str, FragmentDefinitionNode],
+    visited_fragments: frozenset[str],
+) -> tuple[list[FieldNode], int]:
+    """
+    Recursively collects all FieldNode selections and counts total aliases
+    from a selection set, including those nested in inline fragments and
+    fragment spreads at the same level. This ensures aliases from all
+    sibling fragments are aggregated into one alias count.
+
+    Returns (field_selections, total_aliases) where:
+    - field_selections: list of FieldNode selections to process
+    - total_aliases: count of all aliases from this level
+    """
+    field_selections = []
+    total_aliases = 0
+    selections_to_process = list(getattr(selection_set, "selections", []))
+    # Track fragments visited during this collection to prevent cycles
+    local_visited = set(visited_fragments)
+
+    while selections_to_process:
+        selection = selections_to_process.pop(0)
+
+        if isinstance(selection, FieldNode):
+            field_selections.append(selection)
+            if selection.alias:
+                total_aliases += 1
+        elif isinstance(selection, InlineFragmentNode):
+            # Inline fragment selections at this level merge into parent scope
+            if selection.selection_set:
+                selections_to_process.extend(selection.selection_set.selections)
+        elif isinstance(selection, FragmentSpreadNode):
+            # Fragment spread selections at this level merge into parent scope
+            fragment_name = selection.name.value
+            if fragment_name not in local_visited:
+                local_visited.add(fragment_name)
+                fragment_def = fragment_defs.get(fragment_name)
+                if fragment_def and fragment_def.selection_set:
+                    selections_to_process.extend(fragment_def.selection_set.selections)
+
+    return field_selections, total_aliases
+
+
 def scan_query(ast_node: DocumentNode) -> QueryInfo:
     """
     Scan a GraphQL query and return its information.
@@ -55,35 +99,25 @@ def scan_query(ast_node: DocumentNode) -> QueryInfo:
                 if depth > _MAX_DEPTH:
                     raise GraphQLError(f"Query exceeds maximum depth of {_MAX_DEPTH}")
 
-                selections = getattr(selection_set, "selections", [])
+                # Collect all fields and aggregate aliases from this level,
+                # including those inside inline fragments and fragment spreads.
+                # This prevents attackers from distributing aliases across multiple
+                # sibling fragments to bypass the alias limit.
+                field_selections, current_aliases = _collect_fields_and_aliases(
+                    selection_set, fragment_defs, visited_fragments
+                )
 
-                # check current level aliases
-                current_aliases = 0
-                for selection in selections:
-                    if isinstance(selection, FieldNode):
-                        if depth == 1:
-                            root_fields += 1
-                        if selection.alias:
-                            current_aliases += 1
-                        if selection.selection_set:
-                            stack.append((selection.selection_set, depth + 1, visited_fragments))
-                        total_selections += 1
-                        if total_selections > _MAX_SELECTIONS:
-                            raise GraphQLError(
-                                f"Query exceeds maximum total selections of {_MAX_SELECTIONS}"
-                            )
-                    elif isinstance(selection, InlineFragmentNode):
-                        # Inline fragments should have their selections counted at the current depth
-                        if selection.selection_set:
-                            stack.append((selection.selection_set, depth, visited_fragments))
-                    elif isinstance(selection, FragmentSpreadNode):
-                        # Fragment spreads: count selections at current depth, guard cycles
-                        fragment_name = selection.name.value
-                        if fragment_name not in visited_fragments:
-                            fragment_def = fragment_defs.get(fragment_name)
-                            if fragment_def and fragment_def.selection_set:
-                                new_visited = visited_fragments | {fragment_name}
-                                stack.append((fragment_def.selection_set, depth, new_visited))
+                for field in field_selections:
+                    if depth == 1:
+                        root_fields += 1
+                    if field.selection_set:
+                        stack.append((field.selection_set, depth + 1, visited_fragments))
+                    total_selections += 1
+                    if total_selections > _MAX_SELECTIONS:
+                        raise GraphQLError(
+                            f"Query exceeds maximum total selections of {_MAX_SELECTIONS}"
+                        )
+
                 max_aliases = max(max_aliases, current_aliases)
 
     return QueryInfo(root_fields, max_aliases)

--- a/mlflow/server/graphql/graphql_no_batching.py
+++ b/mlflow/server/graphql/graphql_no_batching.py
@@ -2,7 +2,7 @@ from typing import NamedTuple
 
 from graphql.error import GraphQLError
 from graphql.execution import ExecutionResult
-from graphql.language.ast import DocumentNode, FieldNode
+from graphql.language.ast import DocumentNode, FieldNode, InlineFragmentNode
 
 from mlflow.environment_variables import (
     MLFLOW_SERVER_GRAPHQL_MAX_ALIASES,
@@ -53,6 +53,10 @@ def scan_query(ast_node: DocumentNode) -> QueryInfo:
                             raise GraphQLError(
                                 f"Query exceeds maximum total selections of {_MAX_SELECTIONS}"
                             )
+                    elif isinstance(selection, InlineFragmentNode):
+                        # Inline fragments should have their selections counted at the current depth
+                        if selection.selection_set:
+                            stack.append((selection.selection_set, depth))
                 max_aliases = max(max_aliases, current_aliases)
 
     return QueryInfo(root_fields, max_aliases)

--- a/tests/server/test_graphql_no_batching.py
+++ b/tests/server/test_graphql_no_batching.py
@@ -2,7 +2,7 @@ import pytest
 from graphql import parse
 from graphql.error import GraphQLError
 
-from mlflow.server.graphql.graphql_no_batching import check_query_safety, scan_query
+from mlflow.server.graphql.graphql_no_batching import _MAX_DEPTH, check_query_safety, scan_query
 
 
 def test_scan_query_root_fields():
@@ -141,9 +141,11 @@ def test_check_query_safety_inline_fragment_exceeds_aliases(monkeypatch):
 
 
 def test_scan_query_exceeds_max_depth():
-    # Build a query with depth > 10
-    query = "{ a { b { c { d { e { f { g { h { i { j { k { l } } } } } } } } } } }"
-    ast = parse(query)
+    # Build a query nested deeper than _MAX_DEPTH
+    inner = "id"
+    for _ in range(_MAX_DEPTH + 2):
+        inner = f"a {{ {inner} }}"
+    ast = parse(f"{{ {inner} }}")
 
     with pytest.raises(GraphQLError, match="exceeds maximum depth"):
         scan_query(ast)
@@ -306,6 +308,9 @@ def test_scan_query_circular_fragment_reference_with_fields():
 
 def test_check_query_safety_alias_split_across_inline_fragments(monkeypatch):
     monkeypatch.setenv("MLFLOW_SERVER_GRAPHQL_MAX_ALIASES", "10")
+    # Raise the root-field limit so the aggregated aliases (not the field count) are
+    # what trips the guard, isolating the alias-aggregation path under test.
+    monkeypatch.setenv("MLFLOW_SERVER_GRAPHQL_MAX_ROOT_FIELDS", "1000")
 
     # PoC: distribute 100 aliases across 10 sibling inline fragments
     # Each fragment has 10 aliases, which is within limit per-fragment,
@@ -324,6 +329,9 @@ def test_check_query_safety_alias_split_across_inline_fragments(monkeypatch):
 
 def test_check_query_safety_alias_split_across_named_fragments(monkeypatch):
     monkeypatch.setenv("MLFLOW_SERVER_GRAPHQL_MAX_ALIASES", "10")
+    # Raise the root-field limit so the aggregated aliases (not the field count) are
+    # what trips the guard, isolating the alias-aggregation path under test.
+    monkeypatch.setenv("MLFLOW_SERVER_GRAPHQL_MAX_ROOT_FIELDS", "1000")
 
     # Same PoC but using named fragment spreads instead of inline fragments
     aliases = " ".join([f"name{j}: name {{ id }}" for j in range(10)])

--- a/tests/server/test_graphql_no_batching.py
+++ b/tests/server/test_graphql_no_batching.py
@@ -1,0 +1,159 @@
+import pytest
+from graphql import parse
+from graphql.error import GraphQLError
+
+from mlflow.server.graphql.graphql_no_batching import check_query_safety, scan_query
+
+
+def test_scan_query_root_fields():
+    query = """
+    {
+        experiment { id }
+        run { id }
+    }
+    """
+    ast = parse(query)
+    info = scan_query(ast)
+    assert info.root_fields == 2
+
+
+def test_scan_query_aliases():
+    query = """
+    {
+        exp1: experiment { id }
+        exp2: experiment { id }
+    }
+    """
+    ast = parse(query)
+    info = scan_query(ast)
+    assert info.max_aliases == 2
+
+
+def test_scan_query_inline_fragment_root_fields():
+    query = """
+    {
+        experiment { id }
+        ... on Query {
+            run { id }
+            metric { id }
+        }
+    }
+    """
+    ast = parse(query)
+    info = scan_query(ast)
+    # Inline fragments should count their fields as root fields:
+    # experiment (1) + run (1) + metric (1) = 3 root fields
+    assert info.root_fields == 3
+
+
+def test_scan_query_inline_fragment_aliases():
+    query = """
+    {
+        ... on Query {
+            exp1: experiment { id }
+            exp2: experiment { id }
+        }
+    }
+    """
+    ast = parse(query)
+    info = scan_query(ast)
+    # Both fields in the inline fragment use aliases
+    assert info.max_aliases == 2
+
+
+def test_scan_query_nested_inline_fragment():
+    query = """
+    {
+        experiment {
+            ... on Experiment {
+                id
+                name
+            }
+        }
+    }
+    """
+    ast = parse(query)
+    info = scan_query(ast)
+    # Top level: 1 root field (experiment)
+    assert info.root_fields == 1
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_root_fields"),
+    [
+        # Direct field
+        ("{ experiment { id } }", 1),
+        # Inline fragment with single field
+        ("{ ... on Query { experiment { id } } }", 1),
+        # Multiple inline fragments
+        ("{ ... on Query { run { id } } ... on Query { metric { id } } }", 2),
+        # Mix of direct and inline fragment
+        ("{ experiment { id } ... on Query { run { id } } }", 2),
+    ],
+)
+def test_scan_query_root_fields_parametrized(query: str, expected_root_fields: int):
+    ast = parse(query)
+    info = scan_query(ast)
+    assert info.root_fields == expected_root_fields
+
+
+def test_check_query_safety_inline_fragment_exceeds_root_fields(monkeypatch):
+    # Set max root fields to 2
+    monkeypatch.setenv("MLFLOW_SERVER_GRAPHQL_MAX_ROOT_FIELDS", "2")
+
+    query = """
+    {
+        ... on Query {
+            experiment { id }
+            run { id }
+            metric { id }
+        }
+    }
+    """
+    ast = parse(query)
+    result = check_query_safety(ast)
+
+    # Should return an error because 3 root fields exceed limit of 2
+    assert result is not None
+    assert len(result.errors) == 1
+    assert "root fields" in result.errors[0].message
+
+
+def test_check_query_safety_inline_fragment_exceeds_aliases(monkeypatch):
+    # Set max aliases to 1
+    monkeypatch.setenv("MLFLOW_SERVER_GRAPHQL_MAX_ALIASES", "1")
+
+    query = """
+    {
+        ... on Query {
+            exp1: experiment { id }
+            exp2: experiment { id }
+        }
+    }
+    """
+    ast = parse(query)
+    result = check_query_safety(ast)
+
+    # Should return an error because 2 aliases exceed limit of 1
+    assert result is not None
+    assert len(result.errors) == 1
+    assert "aliases" in result.errors[0].message
+
+
+def test_scan_query_exceeds_max_depth():
+    # Build a query with depth > 10
+    query = "{ a { b { c { d { e { f { g { h { i { j { k { l } } } } } } } } } } }"
+    ast = parse(query)
+
+    with pytest.raises(GraphQLError, match="exceeds maximum depth"):
+        scan_query(ast)
+
+
+def test_scan_query_exceeds_max_selections():
+    # Build a query with many fields
+    fields = " ".join([f"field{i} {{ id }}" for i in range(1001)])
+    query = f"{{ {fields} }}"
+    ast = parse(query)
+
+    with pytest.raises(GraphQLError, match="exceeds maximum total selections"):
+        scan_query(ast)

--- a/tests/server/test_graphql_no_batching.py
+++ b/tests/server/test_graphql_no_batching.py
@@ -157,3 +157,144 @@ def test_scan_query_exceeds_max_selections():
 
     with pytest.raises(GraphQLError, match="exceeds maximum total selections"):
         scan_query(ast)
+
+
+def test_scan_query_fragment_spread_root_fields():
+    query = """
+    fragment QueryFields on Query {
+        experiment { id }
+        run { id }
+        metric { id }
+    }
+
+    {
+        ...QueryFields
+    }
+    """
+    ast = parse(query)
+    info = scan_query(ast)
+    # Named fragment spread should count its fields as root fields
+    assert info.root_fields == 3
+
+
+def test_scan_query_unused_fragment_not_counted():
+    query = """
+    fragment UnusedFields on Query {
+        experiment { id }
+        run { id }
+        metric { id }
+    }
+
+    {
+        run { id }
+    }
+    """
+    ast = parse(query)
+    info = scan_query(ast)
+    # Unused fragment should not be counted, only direct field
+    assert info.root_fields == 1
+
+
+def test_scan_query_fragment_spread_aliases():
+    query = """
+    fragment QueryFields on Query {
+        exp1: experiment { id }
+        exp2: experiment { id }
+    }
+
+    {
+        ...QueryFields
+    }
+    """
+    ast = parse(query)
+    info = scan_query(ast)
+    # Fragment spread should count its aliases
+    assert info.max_aliases == 2
+
+
+def test_check_query_safety_fragment_spread_exceeds_root_fields(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_GRAPHQL_MAX_ROOT_FIELDS", "2")
+
+    query = """
+    fragment QueryFields on Query {
+        experiment { id }
+        run { id }
+        metric { id }
+    }
+
+    {
+        ...QueryFields
+    }
+    """
+    ast = parse(query)
+    result = check_query_safety(ast)
+
+    # Should return an error because 3 root fields from fragment exceed limit of 2
+    assert result is not None
+    assert len(result.errors) == 1
+    assert "root fields" in result.errors[0].message
+
+
+def test_check_query_safety_fragment_spread_exceeds_aliases(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_GRAPHQL_MAX_ALIASES", "1")
+
+    query = """
+    fragment QueryFields on Query {
+        exp1: experiment { id }
+        exp2: experiment { id }
+    }
+
+    {
+        ...QueryFields
+    }
+    """
+    ast = parse(query)
+    result = check_query_safety(ast)
+
+    # Should return an error because 2 aliases from fragment exceed limit of 1
+    assert result is not None
+    assert len(result.errors) == 1
+    assert "aliases" in result.errors[0].message
+
+
+def test_scan_query_nested_fragment_spread():
+    query = """
+    fragment Inner on Experiment {
+        id
+        name
+    }
+
+    fragment Outer on Query {
+        experiment {
+            ...Inner
+        }
+    }
+
+    {
+        ...Outer
+    }
+    """
+    ast = parse(query)
+    info = scan_query(ast)
+    # Top-level fragment spread Outer has 1 field (experiment) at depth 1
+    assert info.root_fields == 1
+
+
+def test_scan_query_circular_fragment_reference():
+    query = """
+    fragment A on Query {
+        ...B
+    }
+
+    fragment B on Query {
+        ...A
+    }
+
+    {
+        ...A
+    }
+    """
+    ast = parse(query)
+    # Should not crash or enter infinite loop with circular fragment references
+    info = scan_query(ast)
+    assert info.root_fields == 0

--- a/tests/server/test_graphql_no_batching.py
+++ b/tests/server/test_graphql_no_batching.py
@@ -280,13 +280,15 @@ def test_scan_query_nested_fragment_spread():
     assert info.root_fields == 1
 
 
-def test_scan_query_circular_fragment_reference():
+def test_scan_query_circular_fragment_reference_with_fields():
     query = """
     fragment A on Query {
+        experiment { id }
         ...B
     }
 
     fragment B on Query {
+        run { id }
         ...A
     }
 
@@ -295,6 +297,56 @@ def test_scan_query_circular_fragment_reference():
     }
     """
     ast = parse(query)
-    # Should not crash or enter infinite loop with circular fragment references
+    # Should not crash and correctly count fields before the cycle
     info = scan_query(ast)
-    assert info.root_fields == 0
+    # A has 1 field (experiment), B has 1 field (run), but cycle prevents reprocessing
+    # So we should count: experiment (from A) + run (from B that A references)
+    assert info.root_fields == 2
+
+
+def test_check_query_safety_alias_split_across_inline_fragments(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_GRAPHQL_MAX_ALIASES", "10")
+
+    # PoC: distribute 100 aliases across 10 sibling inline fragments
+    # Each fragment has 10 aliases, which is within limit per-fragment,
+    # but total is 100 which exceeds limit
+    aliases = " ".join([f"name{i}: name {{ id }}" for i in range(10)])
+    fragments = " ".join([f"... on Query {{ {aliases} }}" for _ in range(10)])
+    query = f"{{ {fragments} }}"
+    ast = parse(query)
+    result = check_query_safety(ast)
+
+    # Should be rejected: 100 aliases total > 10 limit
+    assert result is not None
+    assert len(result.errors) == 1
+    assert "aliases" in result.errors[0].message
+
+
+def test_check_query_safety_alias_split_across_named_fragments(monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_GRAPHQL_MAX_ALIASES", "10")
+
+    # Same PoC but using named fragment spreads instead of inline fragments
+    aliases = " ".join([f"name{j}: name {{ id }}" for j in range(10)])
+    frag_defs = "\n".join([f"fragment F{i} on Query {{ {aliases} }}" for i in range(10)])
+    spreads = " ".join([f"...F{i}" for i in range(10)])
+    query = f"{frag_defs}\n\n{{ {spreads} }}"
+    ast = parse(query)
+    result = check_query_safety(ast)
+
+    # Should be rejected: 100 aliases total > 10 limit
+    assert result is not None
+    assert len(result.errors) == 1
+    assert "aliases" in result.errors[0].message
+
+
+def test_scan_query_selections_across_fragments_exceed_max():
+    # Test that _MAX_SELECTIONS limit is enforced across fragment spreads
+    # Create fragments that together exceed _MAX_SELECTIONS (1000)
+    fields_per_frag = " ".join([f"field{j} {{ id }}" for j in range(100)])
+    frag_defs = "\n".join([f"fragment F{i} on Query {{ {fields_per_frag} }}" for i in range(11)])
+    spreads = " ".join([f"...F{i}" for i in range(11)])
+    query = f"{frag_defs}\n\n{{ {spreads} }}"
+    ast = parse(query)
+
+    with pytest.raises(GraphQLError, match="exceeds maximum total selections"):
+        scan_query(ast)


### PR DESCRIPTION
### Related Issues/PRs

Addresses GHSA-vrq3-h6rw-p7hm.

### What changes are proposed in this pull request?

The GraphQL query-cost scanner that enforces `MLFLOW_SERVER_GRAPHQL_MAX_ROOT_FIELDS` and `MLFLOW_SERVER_GRAPHQL_MAX_ALIASES` only counted top-level `FieldNode` selections. Fields and aliases nested inside inline fragments (`... on Query { ... }`) or named fragment spreads were not counted, so a query could exceed the configured limits while the server still executed it.

This makes the scanner descend into `InlineFragmentNode` and `FragmentSpreadNode` and count their selections at the correct depth, and aggregates aliases across sibling fragments into a single per-level alias count so they cannot be distributed across fragments to stay under the limit. A per-path visited-fragment guard prevents cycles, and fragment-expanded selections still count toward the total-selections cap.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added coverage in `tests/server/test_graphql_no_batching.py`: root fields and aliases split across inline fragments and across named fragment spreads (now counted and rejected), cyclic/self-referential fragments (no infinite loop, fields still counted), and fragment-expanded selections tripping the total-selections cap. These fail on `master` and pass with the change.

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. GraphQL query-cost limits now account for fields and aliases nested inside fragments.

#### What component(s) does this PR affect?

- [x] `area/server-infra`

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Reported by doanmanhducz via GitHub Security Advisory GHSA-vrq3-h6rw-p7hm.
