### PR TITLE
basic-auth: serve the web UI to non-admins under fail-closed authorization

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -359,7 +359,9 @@ from mlflow.server.auth.routes import (
     REMOVE_ROLE_PERMISSION,
     REVOKE_USER_PERMISSION,
     SEARCH_DATASETS,
+    SERVER_VERSION,
     SIGNUP,
+    UI_TELEMETRY,
     UNASSIGN_ROLE,
     UPDATE_ROLE,
     UPDATE_ROLE_PERMISSION,
@@ -2990,6 +2992,21 @@ BEFORE_REQUEST_VALIDATORS.update({
     (GATEWAY_SUPPORTED_MODELS, "GET"): _allow_authenticated,
     (GATEWAY_PROVIDER_CONFIG, "GET"): _allow_authenticated,
     (GATEWAY_SECRETS_CONFIG, "GET"): _allow_authenticated,
+    # The web UI itself, for any signed-in user: the SPA shell, the server version
+    # string the bundle reads, and the UI's own telemetry config. None carries
+    # tenant-scoped data, and none has a permission that could sensibly be checked.
+    # These are plain Flask routes on ``app`` rather than handler endpoints, so
+    # ``get_endpoints`` never surfaced them to the coverage guard and no decision was
+    # registered; the fail-closed net then denies them, and a non-admin's browser gets
+    # "Permission denied" instead of MLflow. ``/static-files/<path>`` already serves
+    # that same shell unauthenticated via ``_UNPROTECTED_PATH_PREFIXES``.
+    #
+    # HOME and SERVER_VERSION are bare paths and take the static prefix here;
+    # UI_TELEMETRY comes from ``_get_ajax_path``, which has already applied it.
+    (_add_static_prefix(HOME), "GET"): _allow_authenticated,
+    (_add_static_prefix(SERVER_VERSION), "GET"): _allow_authenticated,
+    (UI_TELEMETRY, "GET"): _allow_authenticated,
+    (UI_TELEMETRY, "POST"): _allow_authenticated,
     # Online scoring configuration (excluded from the auto generated map above).
     (ONLINE_SCORING_CONFIGS, "GET"): validate_can_read_online_scoring_configs,
     (AJAX_ONLINE_SCORING_CONFIGS, "GET"): validate_can_read_online_scoring_configs,

--- a/mlflow/server/auth/routes.py
+++ b/mlflow/server/auth/routes.py
@@ -1,6 +1,8 @@
 from mlflow.server.handlers import _add_static_prefix, _get_ajax_path, _get_rest_path
 
 HOME = "/"
+# Bare like HOME: callers apply the static prefix themselves.
+SERVER_VERSION = "/version"
 SIGNUP = "/signup"
 CREATE_USER = _get_rest_path("/mlflow/users/create")
 AJAX_CREATE_USER = _get_ajax_path("/mlflow/users/create")
@@ -96,3 +98,4 @@ INVOKE_ISSUE_DETECTION = _get_ajax_path("/mlflow/issues/invoke", version=3)
 INVOKE_GENAI_EVALUATE = _get_ajax_path("/mlflow/genai/evaluate/invoke", version=3)
 DEMO_GENERATE = _get_ajax_path("/mlflow/demo/generate", version=3)
 DEMO_DELETE = _get_ajax_path("/mlflow/demo/delete", version=3)
+UI_TELEMETRY = _get_ajax_path("/mlflow/ui-telemetry", version=3)

--- a/tests/server/auth/test_fail_closed_flag.py
+++ b/tests/server/auth/test_fail_closed_flag.py
@@ -151,3 +151,31 @@ def test_before_request_serves_the_web_ui_to_a_non_admin_when_fail_closed(monkey
         with app.test_request_context(path, method=method):
             resp = a._before_request()
         assert resp is None, f"{method} {path} denied for a non-admin: {resp}"
+
+
+def test_before_request_still_requires_authentication_for_the_web_ui(monkeypatch):
+    # The guarantee is "authentication stays required, only authorization is skipped".
+    # The wrong fix -- adding these paths to _UNPROTECTED_PATH_PREFIXES -- would pass the
+    # positive tests above while dropping the login requirement, because
+    # is_unprotected_route short-circuits ahead of authenticate_request. So pin the
+    # negative case: an unauthenticated caller must get the 401 back, not the UI.
+    import flask
+
+    monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "true")
+    monkeypatch.setattr(a, "authenticate_request", a.make_basic_auth_response)
+    monkeypatch.setattr(a, "sender_is_admin", lambda: False)
+
+    app = flask.Flask(__name__)
+    for path, method in (
+        ("/", "GET"),
+        ("/version", "GET"),
+        ("/ajax-api/3.0/mlflow/ui-telemetry", "GET"),
+        ("/ajax-api/3.0/mlflow/ui-telemetry", "POST"),
+    ):
+        with app.test_request_context(path, method=method):
+            resp = a._before_request()
+        assert resp is not None, f"{method} {path} served to an unauthenticated caller"
+        assert resp.status_code == 401, f"{method} {path}: expected 401, got {resp.status_code}"
+        assert resp.headers.get("WWW-Authenticate") == 'Basic realm="mlflow"', (
+            f"{method} {path}: not the authentication challenge"
+        )

--- a/tests/server/auth/test_fail_closed_flag.py
+++ b/tests/server/auth/test_fail_closed_flag.py
@@ -61,6 +61,42 @@ def test_public_routes_recognized_under_static_prefix(monkeypatch):
     assert a._authorized_outside_before_request(_Req("/custom-prefix/graphql"))
 
 
+def test_web_ui_entry_points_resolve_a_validator():
+    # `/` serves the SPA shell, `/version` the version string the bundle reads, and
+    # ui-telemetry the UI's own config. None carries tenant data, and none is a handler
+    # endpoint, so get_endpoints() never surfaced them to the coverage guard -- without a
+    # validator the fail-closed net denies them and a non-admin browser gets a plain
+    # "Permission denied" instead of MLflow.
+    for path, method in (
+        ("/", "GET"),
+        ("/version", "GET"),
+        ("/ajax-api/3.0/mlflow/ui-telemetry", "GET"),
+        ("/ajax-api/3.0/mlflow/ui-telemetry", "POST"),
+    ):
+        validator = a._find_validator(_Req(path, method))
+        assert validator is not None, f"{method} {path} resolves no authorization decision"
+        assert validator() is True, f"{method} {path} is denied for an authenticated user"
+
+
+def test_web_ui_entry_points_resolve_a_validator_under_static_prefix(monkeypatch):
+    # The keys are built at import time from the static prefix, so this reloads the
+    # route table with one configured rather than reusing the module-level map.
+    import importlib
+
+    from mlflow.server.handlers import STATIC_PREFIX_ENV_VAR
+
+    monkeypatch.setenv(STATIC_PREFIX_ENV_VAR, "/custom-prefix")
+    routes = importlib.reload(importlib.import_module("mlflow.server.auth.routes"))
+    try:
+        assert routes.UI_TELEMETRY == "/custom-prefix/ajax-api/3.0/mlflow/ui-telemetry"
+        # HOME and SERVER_VERSION stay bare; the auth module prefixes them itself.
+        assert routes.HOME == "/"
+        assert routes.SERVER_VERSION == "/version"
+    finally:
+        monkeypatch.delenv(STATIC_PREFIX_ENV_VAR)
+        importlib.reload(routes)
+
+
 def _fake_basic_auth():
     from werkzeug.datastructures import Authorization
 
@@ -92,3 +128,26 @@ def test_before_request_allows_ungated_route_when_flag_off(monkeypatch):
     with app.test_request_context("/api/3.0/mlflow/brand-new-feature/do-thing", method="POST"):
         resp = a._before_request()
     assert resp is None
+
+
+def test_before_request_serves_the_web_ui_to_a_non_admin_when_fail_closed(monkeypatch):
+    # Regression: with the net on, a non-admin got 403 on `GET /` and the browser showed
+    # the string "Permission denied" instead of the UI. Admins were unaffected because
+    # sender_is_admin() returns before the authorization branch, so this must pin the
+    # non-admin case specifically.
+    import flask
+
+    monkeypatch.setenv("MLFLOW_BASIC_AUTH_FAIL_CLOSED", "true")
+    monkeypatch.setattr(a, "authenticate_request", _fake_basic_auth)
+    monkeypatch.setattr(a, "sender_is_admin", lambda: False)
+
+    app = flask.Flask(__name__)
+    for path, method in (
+        ("/", "GET"),
+        ("/version", "GET"),
+        ("/ajax-api/3.0/mlflow/ui-telemetry", "GET"),
+        ("/ajax-api/3.0/mlflow/ui-telemetry", "POST"),
+    ):
+        with app.test_request_context(path, method=method):
+            resp = a._before_request()
+        assert resp is None, f"{method} {path} denied for a non-admin: {resp}"

--- a/tests/server/auth/test_fail_closed_flag.py
+++ b/tests/server/auth/test_fail_closed_flag.py
@@ -1,8 +1,11 @@
 # Tests for the MLFLOW_BASIC_AUTH_FAIL_CLOSED flag: wiring, the decision predicates,
 # and the end-to-end 403 that _before_request returns when the flag is on.
 
+import importlib
+
 from mlflow.environment_variables import MLFLOW_BASIC_AUTH_FAIL_CLOSED
 from mlflow.server import auth as a
+from mlflow.server.handlers import STATIC_PREFIX_ENV_VAR
 
 
 class _Req:
@@ -51,8 +54,6 @@ def test_public_suffix_not_matched_as_incidental_tail():
 def test_public_routes_recognized_under_static_prefix(monkeypatch):
     # Under --static-prefix the request path carries the prefix; public/internal routes
     # must still be recognized (else they wrongly fail closed).
-    from mlflow.server.handlers import STATIC_PREFIX_ENV_VAR
-
     monkeypatch.setenv(STATIC_PREFIX_ENV_VAR, "/custom-prefix")
     assert a._authorized_outside_before_request(_Req("/custom-prefix/api/3.0/mlflow/server-info"))
     assert a._authorized_outside_before_request(
@@ -81,10 +82,6 @@ def test_web_ui_entry_points_resolve_a_validator():
 def test_web_ui_entry_points_resolve_a_validator_under_static_prefix(monkeypatch):
     # The keys are built at import time from the static prefix, so this reloads the
     # route table with one configured rather than reusing the module-level map.
-    import importlib
-
-    from mlflow.server.handlers import STATIC_PREFIX_ENV_VAR
-
     monkeypatch.setenv(STATIC_PREFIX_ENV_VAR, "/custom-prefix")
     routes = importlib.reload(importlib.import_module("mlflow.server.auth.routes"))
     try:


### PR DESCRIPTION
### Related Issues/PRs

Closes #25670

### What changes are proposed in this pull request?

Since fail-closed authorization became the default in 3.16.0 (#25308), `GET /` returns
`403 Permission denied` to every user without the server-wide `is_admin` flag. The web UI is
therefore unreachable for exactly the users RBAC exists for — a browser shows the plain string
`Permission denied` instead of MLflow. `/version`, which the UI bundle reads, and the UI's own
telemetry routes are denied the same way. Admins are unaffected, because `sender_is_admin()`
returns before the authorization branch.

Worth stressing, because it makes the impact larger than it looks: RBAC permissions do not help,
only the `is_admin` boolean does. A user holding `MANAGE` on `resource_type=workspace`,
`resource_pattern=*` — the strongest grant RBAC can express — is still denied. In a deployment
where humans are regular RBAC users and admin rights are granted per workspace, no human can open
the UI at all.

**Why these routes had no decision.** They are plain Flask routes on `app` rather than handler
endpoints, so `get_endpoints()` never surfaced them to the coverage guard in
`test_authorization_coverage.py` and no authorization decision was ever registered. The net then
denies them. None carries tenant-scoped data: `/` serves the SPA shell, `/version` a version
string, ui-telemetry the UI's own config. That the shell is not meant to be access-controlled is
already settled elsewhere — `/static-files/<path>` serves the very same document
*unauthenticated* via `_UNPROTECTED_PATH_PREFIXES`.

**The fix.** Map them to `_allow_authenticated`, alongside the gateway discovery and demo routes.
That keeps authentication required and only skips the authorization decision, which is exactly the
behaviour these routes had before the net existed. `is_unprotected_route` would have been the wrong
place: it short-circuits ahead of `authenticate_request()` and would drop the login requirement
altogether.

One matching subtlety, in case a shorter patch looks tempting: `/` cannot simply be appended to
`_PUBLIC_ROUTE_SUFFIXES`, because `_matches_route_suffix` would then also match `/api/2.0/` (the
remainder after stripping the suffix is exactly an API-version prefix); and in
`_KNOWN_UNGATED_ROUTE_MARKERS`, a marker of `/` matches every path through the `marker in path`
branch. `HOME` and the new `SERVER_VERSION` are bare paths and take the static prefix at the call
site; `UI_TELEMETRY` gets it from `_get_ajax_path`.

**Two routes deliberately left alone**, both mentioned in the issue:

- `/signup` and `POST /api/2.0/mlflow/users/create-ui` are denied now too, but gating self-service
  signup may well be intended, so that seems a call for maintainers rather than something to
  quietly re-open.
- `GET /api/3.0/mlflow/workspaces/<name>` resolves no validator at all. The net denying it is
  *correct* — with the flag off it returns a workspace's name and description to a caller with no
  grants on it, while the workspace *list* endpoint self-filters. It wants a real permission check,
  not an exemption, so it is out of scope here.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `tests/server/auth/test_fail_closed_flag.py`: that each UI entry point resolves a
validator which allows an authenticated caller, that `_before_request` returns no response for a
**non-admin** on those paths with the flag on (the regression itself), and that the route constants
carry the static prefix as expected. All three fail without the source change — the end-to-end one
with `GET / denied for a non-admin: <Response 17 bytes [403 FORBIDDEN]>`.

Existing suites re-run green locally: `test_fail_closed_flag.py`,
`test_authorization_coverage.py`, `test_fastapi_fail_closed.py`, `test_custom_auth_bridge.py`,
`test_permissions.py`, `test_read_write_routing.py` — 146 tests. `test_auth.py` was still running
when this was opened, so I am leaving that one to CI rather than claiming a result I have not seen.

Manual check against a real server (`mlflow server --app-name basic-auth`, uvicorn, stock basic
auth, a non-admin user `alice` created through the documented admin API):

| | before | after |
|---|---|---|
| `GET /` as alice | 403 `Permission denied` | 200 (UI) |
| `GET /version` as alice | 403 | 200 |
| `GET /` as admin | 200 | 200 |
| `GET /static-files/index.html` as alice | 200 | 200 |

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

With `basic-auth` and fail-closed authorization (the default since 3.16.0), the web UI is again
reachable for users without the server-wide `is_admin` flag; `GET /`, `/version` and the UI
telemetry routes previously returned `403 Permission denied` to them.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
