### PR TITLE
Fix lightgbm skops cross-version tests broken by joblib 1.6.0

### DIFF
--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import NamedTuple
 from unittest import mock
 
-import cloudpickle
 import lightgbm as lgb
 import numpy as np
 import pandas as pd
@@ -592,7 +591,9 @@ def test_sklearn_model_save_load_by_skops(lgb_sklearn_model, model_path):
         )
     ]
     assert f"skops=={skops.__version__}" in logged_reqs
-    assert f"cloudpickle=={cloudpickle.__version__}" not in logged_reqs
+    # No cloudpickle-absence assertion: joblib>=1.6.0 depends on cloudpickle (previously it
+    # vendored its own copy), so requirement inference captures it transitively for any
+    # sklearn-based model regardless of the serialization format.
 
     reloaded_model = mlflow.lightgbm.load_model(model_uri=model_path)
     reloaded_pyfunc = pyfunc.load_model(model_uri=model_path)
@@ -632,7 +633,9 @@ def test_sklearn_regressor_model_save_load_by_skops(lgb_sklearn_regressor_model,
         )
     ]
     assert f"skops=={skops.__version__}" in logged_reqs
-    assert f"cloudpickle=={cloudpickle.__version__}" not in logged_reqs
+    # No cloudpickle-absence assertion: joblib>=1.6.0 depends on cloudpickle (previously it
+    # vendored its own copy), so requirement inference captures it transitively for any
+    # sklearn-based model regardless of the serialization format.
 
     reloaded_model = mlflow.lightgbm.load_model(model_uri=model_path)
     reloaded_pyfunc = pyfunc.load_model(model_uri=model_path)


### PR DESCRIPTION
### Related Issues/PRs

Relates to the daily `cross-version-tests` failures on the lightgbm `models` jobs (red since 2026-09-02). Follows the same class of fix as #24208.

### What changes are proposed in this pull request?

The lightgbm skops model tests assert that a skops-serialized model's inferred `requirements.txt` does **not** contain `cloudpickle`. That assumption broke with **joblib 1.6.0**, which replaced its vendored `joblib.externals.cloudpickle` with a dependency on the standalone `cloudpickle` package (`cloudpickle>=3.0`) and imports it at import time. scikit-learn depends on joblib, so loading a skops-serialized sklearn/lightgbm model now imports `cloudpickle` transitively, and MLflow's requirement inference records it in the model's `requirements.txt`.

This drops the two now-invalid `cloudpickle not in logged_reqs` assertions in `test_sklearn_model_save_load_by_skops` and `test_sklearn_regressor_model_save_load_by_skops` (and the now-unused `cloudpickle` import). The positive `skops` requirement check and the reload/predict assertions are unchanged.

Verified the root cause directly: `import joblib` pulls in top-level `cloudpickle` under joblib 1.6.0 but not under 1.5.3, and joblib 1.6.0 declares `cloudpickle>=3.0` as a runtime dependency.

### How is this PR tested?

- [x] Existing unit/integration tests

The change only removes stale negative assertions, so the affected tests can no longer fail on that line; the remaining reload and prediction assertions still exercise the skops save/load path.

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s) does this PR affect?

- [x] `area/models`

#### How should the PR be classified in the release notes?

- [x] `rn/none` - This PR does not require a release note

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
