### PR TITLE
Fix strands cross-version tests broken by 1.54.0 cache-token reporting

### DIFF
--- a/tests/strands/test_strands_tracing.py
+++ b/tests/strands/test_strands_tracing.py
@@ -15,6 +15,12 @@ from mlflow.tracing.provider import trace_disabled
 from tests.tracing.helper import get_traces
 
 
+def _core_token_usage(usage: dict[str, int]) -> dict[str, int]:
+    # strands >= 1.54 also reports (often zero) cache-token counts in the usage metadata.
+    # Restrict to the core keys so these assertions stay robust across strands versions.
+    return {k: usage[k] for k in ("input_tokens", "output_tokens", "total_tokens")}
+
+
 async def sum_tool(tool_use, **_):
     a = tool_use["input"]["a"]
     b = tool_use["input"]["b"]
@@ -178,12 +184,12 @@ def test_strands_autolog_single_trace():
 
     usage_spans = [span for span in spans if span.attributes.get(SpanAttributeKey.CHAT_USAGE)]
     assert usage_spans, "expected at least one child span recording token usage"
-    assert usage_spans[0].attributes[SpanAttributeKey.CHAT_USAGE] == {
+    assert _core_token_usage(usage_spans[0].attributes[SpanAttributeKey.CHAT_USAGE]) == {
         "input_tokens": 1,
         "output_tokens": 2,
         "total_tokens": 3,
     }
-    assert traces[0].info.token_usage == {
+    assert _core_token_usage(traces[0].info.token_usage) == {
         "input_tokens": 1,
         "output_tokens": 2,
         "total_tokens": 3,
@@ -265,13 +271,13 @@ def test_multiple_agents_single_trace():
     assert agent2_span.outputs.strip() == "hi"
     # top-level span should contain the sum of both the chat spans. this is set
     # when we translate the genai semantic conventions into mlflow attributes.
-    assert agent1_span.attributes[SpanAttributeKey.CHAT_USAGE] == {
+    assert _core_token_usage(agent1_span.attributes[SpanAttributeKey.CHAT_USAGE]) == {
         "input_tokens": 2,
         "output_tokens": 2,
         "total_tokens": 4,
     }
     # agent2 span should contain the token usage for its single chat span
-    assert agent2_span.attributes[SpanAttributeKey.CHAT_USAGE] == {
+    assert _core_token_usage(agent2_span.attributes[SpanAttributeKey.CHAT_USAGE]) == {
         "input_tokens": 1,
         "output_tokens": 1,
         "total_tokens": 2,


### PR DESCRIPTION
### Related Issues/PRs

Relates to the daily `cross-version-tests` failures on the `strands / autologging` job (red on strands 1.54.0).

### What changes are proposed in this pull request?

strands 1.54.0 added cache-token counts (`cache_read_input_tokens`, `cache_creation_input_tokens`, typically `0`) to the usage metadata it emits on its OpenTelemetry spans. MLflow's gen_ai semantic-convention translation records those in `CHAT_USAGE` (and the aggregated trace-level `token_usage`) whenever the attributes are present, so `test_strands_autolog_single_trace` and `test_multiple_agents_single_trace` failed on strands 1.54.0, which asserted an exact 3-key usage dict.

Because `cross-version-tests` runs `tests/strands` against the whole supported range (min `1.7.1` through the latest release), the assertions must pass on both older versions that omit the cache keys and newer ones that include them. This adds a `_core_token_usage` helper that restricts a usage dict to the core `input_tokens`/`output_tokens`/`total_tokens` keys, and uses it in the affected assertions so they tolerate the optional cache keys either way. The token counts themselves are unchanged.

Verified `tests/strands/test_strands_tracing.py` passes against both strands 1.54.0 (cache keys present) and 1.10.0 (absent).

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s) does this PR affect?

- [x] `area/tracing`

#### How should the PR be classified in the release notes?

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
