### PR TITLE
Gate skops model loading behind MLFLOW_ALLOW_PICKLE_DESERIALIZATION

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -521,18 +521,23 @@ def _load_model_from_local_file(path, serialization_format, skops_trusted_types=
             error_code=INVALID_PARAMETER_VALUE,
         )
 
-    if serialization_format != SERIALIZATION_FORMAT_SKOPS:
-        if (
-            not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get()
-            and not is_in_databricks_runtime()
-            and not is_in_databricks_model_serving_environment()
-        ):
-            raise MlflowException(
-                "Deserializing model using pickle is disallowed, but this model is saved "
-                "in pickle format. To address this issue, you need to set environment variable "
-                "'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true', or save the model in "
-                "'skops' format."
-            )
+    # Loading a serialized model can execute arbitrary code from the model artifact. This
+    # includes the skops format: skops only blocks untrusted types via its `trusted` allow-list,
+    # and that list is read from the model's own MLmodel file, so a crafted model can whitelist
+    # dangerous types. Gate every serialization format behind MLFLOW_ALLOW_PICKLE_DESERIALIZATION
+    # so the flag is a real safety control rather than one the skops format silently bypasses.
+    if (
+        not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get()
+        and not is_in_databricks_runtime()
+        and not is_in_databricks_model_serving_environment()
+    ):
+        raise MlflowException(
+            "Deserializing this model is disallowed because 'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' "
+            "is set to 'false'. Loading a model can execute arbitrary code from the model "
+            "artifact, including models saved in the 'skops' format, whose trusted-types "
+            "allow-list is read from the model itself. Only load models from trusted sources; set "
+            "'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true' to allow loading."
+        )
 
     if serialization_format == SERIALIZATION_FORMAT_SKOPS:
         import skops.io

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -526,6 +526,8 @@ def _load_model_from_local_file(path, serialization_format, skops_trusted_types=
     # and that list is read from the model's own MLmodel file, so a crafted model can whitelist
     # dangerous types. Gate every serialization format behind MLFLOW_ALLOW_PICKLE_DESERIALIZATION
     # so the flag is a real safety control rather than one the skops format silently bypasses.
+    # The is_in_databricks_* carve-outs are pre-existing and shared with the pickle/cloudpickle
+    # paths: those managed runtimes permit model deserialization regardless of the flag.
     if (
         not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get()
         and not is_in_databricks_runtime()
@@ -533,7 +535,7 @@ def _load_model_from_local_file(path, serialization_format, skops_trusted_types=
     ):
         raise MlflowException(
             "Deserializing this model is disallowed because 'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' "
-            "is set to 'false'. Loading a model can execute arbitrary code from the model "
+            "is not set to 'true'. Loading a model can execute arbitrary code from the model "
             "artifact, including models saved in the 'skops' format, whose trusted-types "
             "allow-list is read from the model itself. Only load models from trusted sources; set "
             "'MLFLOW_ALLOW_PICKLE_DESERIALIZATION' to 'true' to allow loading."

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -215,6 +215,24 @@ def test_model_skops_format_trusted_type(sklearn_knn_model, model_path):
     )
 
 
+def test_skops_load_blocked_when_pickle_deserialization_disallowed(
+    sklearn_knn_model, model_path, monkeypatch
+):
+    # skops must honor MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false too: its trusted-types allow-list
+    # is read from the (untrusted) MLmodel, so it is not a safe bypass of the deserialization guard.
+    mlflow.sklearn.save_model(
+        sk_model=sklearn_knn_model.model,
+        path=model_path,
+        serialization_format="skops",
+        skops_trusted_types=sklearn_knn_model_skops_trusted_types,
+    )
+    monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
+    with pytest.raises(MlflowException, match="MLFLOW_ALLOW_PICKLE_DESERIALIZATION"):
+        mlflow.sklearn.load_model(model_uri=model_path)
+    with pytest.raises(MlflowException, match="MLFLOW_ALLOW_PICKLE_DESERIALIZATION"):
+        pyfunc.load_model(model_uri=model_path)
+
+
 def test_log_model_skops_no_pip_requirements_warning(sklearn_logreg_model, recwarn):
     with mlflow.start_run():
         mlflow.sklearn.log_model(

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -215,9 +215,7 @@ def test_model_skops_format_trusted_type(sklearn_knn_model, model_path):
     )
 
 
-def test_skops_load_blocked_when_pickle_deserialization_disallowed(
-    sklearn_knn_model, model_path, monkeypatch
-):
+def test_skops_load_honors_pickle_deserialization_flag(sklearn_knn_model, model_path, monkeypatch):
     # skops must honor MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false too: its trusted-types allow-list
     # is read from the (untrusted) MLmodel, so it is not a safe bypass of the deserialization guard.
     mlflow.sklearn.save_model(
@@ -226,11 +224,17 @@ def test_skops_load_blocked_when_pickle_deserialization_disallowed(
         serialization_format="skops",
         skops_trusted_types=sklearn_knn_model_skops_trusted_types,
     )
+    # false -> both load paths are blocked
     monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "false")
     with pytest.raises(MlflowException, match="MLFLOW_ALLOW_PICKLE_DESERIALIZATION"):
         mlflow.sklearn.load_model(model_uri=model_path)
     with pytest.raises(MlflowException, match="MLFLOW_ALLOW_PICKLE_DESERIALIZATION"):
         pyfunc.load_model(model_uri=model_path)
+
+    # true -> the skops model still loads (guards against an accidentally-inverted condition)
+    monkeypatch.setenv("MLFLOW_ALLOW_PICKLE_DESERIALIZATION", "true")
+    mlflow.sklearn.load_model(model_uri=model_path)
+    pyfunc.load_model(model_uri=model_path)
 
 
 def test_log_model_skops_no_pip_requirements_warning(sklearn_logreg_model, recwarn):


### PR DESCRIPTION
### Related Issues/PRs

Addresses GHSA-w582-9x45-8mpx.

### What changes are proposed in this pull request?

The sklearn and lightgbm skops loaders were exempt from the `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` guard, and skops' `trusted` types allow-list is read verbatim from the model's own `MLmodel` file. A user who set `MLFLOW_ALLOW_PICKLE_DESERIALIZATION=false` and followed the guard's own advice to "save the model in skops format" was therefore not actually protected: a crafted model could whitelist dangerous types and execute code on load.

This applies the deserialization guard to every serialization format, including skops (both flavors funnel through `mlflow/sklearn/__init__.py:_load_model_from_local_file`), and corrects the error message that recommended skops as a safe bypass. `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` defaults to `true`, so default load behavior is unchanged; only callers who opt into `false` now have skops blocked too. Loading a model from an untrusted source remains unsafe regardless of format.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added `test_skops_load_blocked_when_pickle_deserialization_disallowed`: saves a skops model, sets the flag to `false`, and asserts both `mlflow.sklearn.load_model` and `pyfunc.load_model` raise. Verified locally that default (flag `true`) skops loads still succeed.

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s) does this PR affect?

- [x] `area/models`

#### How should the PR be classified in the release notes?

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

Reported by zolbooo via GitHub Security Advisory GHSA-w582-9x45-8mpx.
