### PR TITLE
Fix Assistant Bash execution on Windows selector loops

### DIFF
--- a/mlflow/assistant/providers/tool_executor.py
+++ b/mlflow/assistant/providers/tool_executor.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import shlex
+import subprocess
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -202,13 +203,7 @@ async def _execute_bash_on_host(
         if full_access:
             # Shell required: LLM-generated commands may use pipes, redirects, or && chaining.
             # Safe here because full access has no allowlist to bypass in the first place.
-            proc = await asyncio.create_subprocess_shell(
-                command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=cwd,
-                env=env,
-            )
+            run_args = command
         else:
             # Restricted mode: static_permission_error only validates argv[0] against the
             # allowlist. Running the raw string through a shell would let shell operators
@@ -219,19 +214,22 @@ async def _execute_bash_on_host(
             # is passed as a literal argument to the allowlisted program and never
             # interpreted as a separate command.
             try:
-                argv = shlex.split(command)
+                run_args = shlex.split(command)
             except ValueError:
                 return "Permission denied: malformed command", True
-            proc = await asyncio.create_subprocess_exec(
-                *argv,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                cwd=cwd,
-                env=env,
-            )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
-        output = stdout.decode("utf-8", errors="replace")
-        err_output = stderr.decode("utf-8", errors="replace")
+
+        proc = await asyncio.to_thread(
+            subprocess.run,
+            run_args,
+            shell=full_access,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+            timeout=120,
+        )
+        output = proc.stdout.decode("utf-8", errors="replace")
+        err_output = proc.stderr.decode("utf-8", errors="replace")
 
         if proc.returncode != 0:
             result = (
@@ -240,7 +238,7 @@ async def _execute_bash_on_host(
             return result.strip(), True
 
         return (output + err_output).strip() or "(no output)", False
-    except asyncio.TimeoutError:
+    except subprocess.TimeoutExpired:
         return "Command timed out after 120 seconds", True
 
 

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -1,4 +1,5 @@
 import asyncio
+import subprocess
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -6,7 +7,11 @@ import pytest
 
 from mlflow.assistant.config import PermissionsConfig
 from mlflow.assistant.providers.base import assistant_sandbox_enabled
-from mlflow.assistant.providers.tool_executor import _execute_bash_in_sandbox, execute_tool
+from mlflow.assistant.providers.tool_executor import (
+    _execute_bash_in_sandbox,
+    _execute_bash_on_host,
+    execute_tool,
+)
 from mlflow.server.sandbox import SandboxResult, SandboxUnavailableError
 
 
@@ -258,6 +263,44 @@ def test_bash_full_access_allows_any_command():
     result, is_error = _run(execute_tool("Bash", {"command": "echo hello"}, permissions=perms))
     assert not is_error
     assert "hello" in result
+
+
+@pytest.mark.parametrize(
+    ("command", "full_access"),
+    [
+        ("python -c \"print('hello')\"", False),
+        ("echo hello", True),
+    ],
+)
+def test_execute_bash_on_host_without_asyncio_subprocess_support(command, full_access):
+    with (
+        mock.patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=NotImplementedError("subprocesses are unsupported by this event loop"),
+        ),
+        mock.patch(
+            "asyncio.create_subprocess_shell",
+            side_effect=NotImplementedError("subprocesses are unsupported by this event loop"),
+        ),
+    ):
+        result, is_error = _run(
+            _execute_bash_on_host(command, cwd=None, tracking_uri=None, full_access=full_access)
+        )
+
+    assert not is_error
+    assert result == "hello"
+
+
+def test_execute_bash_on_host_timeout():
+    with mock.patch(
+        "mlflow.assistant.providers.tool_executor.subprocess.run",
+        side_effect=subprocess.TimeoutExpired("echo hello", 120),
+    ):
+        result = _run(
+            _execute_bash_on_host("echo hello", cwd=None, tracking_uri=None, full_access=True)
+        )
+
+    assert result == ("Command timed out after 120 seconds", True)
 
 
 def test_full_access_bypasses_permission_checks(workspace):

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -266,13 +266,15 @@ def test_bash_full_access_allows_any_command():
 
 
 @pytest.mark.parametrize(
-    ("command", "full_access"),
+    ("command", "full_access", "expected_run_args"),
     [
-        ("python -c \"print('hello')\"", False),
-        ("echo hello", True),
+        ("python -c \"print('hello')\"", False, ["python", "-c", "print('hello')"]),
+        ("echo hello", True, "echo hello"),
     ],
 )
-def test_execute_bash_on_host_without_asyncio_subprocess_support(command, full_access):
+def test_execute_bash_on_host_without_asyncio_subprocess_support(
+    command, full_access, expected_run_args
+):
     with (
         mock.patch(
             "asyncio.create_subprocess_exec",
@@ -282,6 +284,9 @@ def test_execute_bash_on_host_without_asyncio_subprocess_support(command, full_a
             "asyncio.create_subprocess_shell",
             side_effect=NotImplementedError("subprocesses are unsupported by this event loop"),
         ) as create_subprocess_shell,
+        mock.patch(
+            "mlflow.assistant.providers.tool_executor.subprocess.run", wraps=subprocess.run
+        ) as run,
     ):
         result, is_error = _run(
             _execute_bash_on_host(command, cwd=None, tracking_uri=None, full_access=full_access)
@@ -291,6 +296,9 @@ def test_execute_bash_on_host_without_asyncio_subprocess_support(command, full_a
     assert result == "hello"
     create_subprocess_exec.assert_not_called()
     create_subprocess_shell.assert_not_called()
+    run.assert_called_once()
+    assert run.call_args.args == (expected_run_args,)
+    assert run.call_args.kwargs["shell"] is full_access
 
 
 def test_execute_bash_on_host_timeout():

--- a/tests/assistant/test_tool_executor.py
+++ b/tests/assistant/test_tool_executor.py
@@ -277,11 +277,11 @@ def test_execute_bash_on_host_without_asyncio_subprocess_support(command, full_a
         mock.patch(
             "asyncio.create_subprocess_exec",
             side_effect=NotImplementedError("subprocesses are unsupported by this event loop"),
-        ),
+        ) as create_subprocess_exec,
         mock.patch(
             "asyncio.create_subprocess_shell",
             side_effect=NotImplementedError("subprocesses are unsupported by this event loop"),
-        ),
+        ) as create_subprocess_shell,
     ):
         result, is_error = _run(
             _execute_bash_on_host(command, cwd=None, tracking_uri=None, full_access=full_access)
@@ -289,18 +289,21 @@ def test_execute_bash_on_host_without_asyncio_subprocess_support(command, full_a
 
     assert not is_error
     assert result == "hello"
+    create_subprocess_exec.assert_not_called()
+    create_subprocess_shell.assert_not_called()
 
 
 def test_execute_bash_on_host_timeout():
     with mock.patch(
         "mlflow.assistant.providers.tool_executor.subprocess.run",
         side_effect=subprocess.TimeoutExpired("echo hello", 120),
-    ):
+    ) as run:
         result = _run(
             _execute_bash_on_host("echo hello", cwd=None, tracking_uri=None, full_access=True)
         )
 
     assert result == ("Command timed out after 120 seconds", True)
+    run.assert_called_once()
 
 
 def test_full_access_bypasses_permission_checks(workspace):


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24418

### What changes are proposed in this pull request?

Run host-side Assistant Bash commands with `subprocess.run` in a worker thread instead of asyncio's subprocess APIs. This preserves the existing restricted argv and full-access shell behavior while allowing Bash tool calls to work with the Windows selector event loop used by multiworker and reload servers.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Test with Codex and Claude on UI and make sure they run a shell command. 
<img width="1800" height="1100" alt="new-feature-assistant-bash-codex" src="https://github.com/user-attachments/assets/f5bfbdfa-7d18-4cc8-a50e-7d0c58240584" />
<img width="1600" height="1000" alt="new-feature-assistant-bash-claude" src="https://github.com/user-attachments/assets/321f8a33-ad3f-45d9-aafb-87abf244697b" />


### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Assistant Bash tool calls now work when MLflow runs with a Windows selector event loop.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
