### PR TITLE
Return None for unset deployment_job_state in UC model-version converters

### DIFF
--- a/mlflow/store/_unity_catalog/registry/uc_native_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_native_rest_store.py
@@ -144,8 +144,10 @@ def model_version_from_uc_native_proto(uc_proto: ModelVersionInfo) -> ModelVersi
             )
             for metric in (uc_proto.model_metrics or [])
         ],
-        deployment_job_state=ModelVersionDeploymentJobState.from_proto(
-            uc_proto.deployment_job_state
+        deployment_job_state=(
+            ModelVersionDeploymentJobState.from_proto(uc_proto.deployment_job_state)
+            if uc_proto.HasField("deployment_job_state")
+            else None
         ),
     )
 
@@ -188,8 +190,10 @@ def model_version_search_from_uc_native_proto(
         status=uc_model_version_status_to_string(uc_proto.status),
         aliases=[],
         tags=[],
-        deployment_job_state=ModelVersionDeploymentJobState.from_proto(
-            uc_proto.deployment_job_state
+        deployment_job_state=(
+            ModelVersionDeploymentJobState.from_proto(uc_proto.deployment_job_state)
+            if uc_proto.HasField("deployment_job_state")
+            else None
         ),
     )
 

--- a/mlflow/utils/_unity_catalog_utils.py
+++ b/mlflow/utils/_unity_catalog_utils.py
@@ -93,8 +93,10 @@ def model_version_from_uc_proto(uc_proto: ProtoModelVersion) -> ModelVersion:
             )
             for metric in (uc_proto.model_metrics or [])
         ],
-        deployment_job_state=ModelVersionDeploymentJobState.from_proto(
-            uc_proto.deployment_job_state
+        deployment_job_state=(
+            ModelVersionDeploymentJobState.from_proto(uc_proto.deployment_job_state)
+            if uc_proto.HasField("deployment_job_state")
+            else None
         ),
     )
 
@@ -113,8 +115,10 @@ def model_version_search_from_uc_proto(uc_proto: ProtoModelVersion) -> ModelVers
         status_message=uc_proto.status_message,
         aliases=[],
         tags=[],
-        deployment_job_state=ModelVersionDeploymentJobState.from_proto(
-            uc_proto.deployment_job_state
+        deployment_job_state=(
+            ModelVersionDeploymentJobState.from_proto(uc_proto.deployment_job_state)
+            if uc_proto.HasField("deployment_job_state")
+            else None
         ),
     )
 

--- a/tests/utils/test_unity_catalog_utils.py
+++ b/tests/utils/test_unity_catalog_utils.py
@@ -161,13 +161,7 @@ def test_model_version_search_from_uc_proto():
         status_message="status_message",
         aliases=[],
         tags=[],
-        deployment_job_state=ModelVersionDeploymentJobState(
-            "",
-            "",
-            "DEPLOYMENT_JOB_CONNECTION_STATE_UNSPECIFIED",
-            "DEPLOYMENT_JOB_RUN_STATE_UNSPECIFIED",
-            "",
-        ),
+        deployment_job_state=None,
     )
     uc_proto = ProtoModelVersion(
         name="name",
@@ -493,6 +487,24 @@ def test_model_version_from_uc_native_proto():
     assert model_version_from_uc_native_proto(uc_proto) == expected_model_version
 
 
+def test_model_version_converters_without_deployment_job_state_return_none():
+    # A proto with no deployment_job_state must hydrate to None, not a truthy empty
+    # ModelVersionDeploymentJobState (mirrors the OSS ModelVersion.from_proto guard).
+    uc_proto = ProtoModelVersion(
+        name="name", version="1", status=ProtoModelVersionStatus.Value("READY")
+    )
+    assert model_version_from_uc_proto(uc_proto).deployment_job_state is None
+
+    native_proto = ModelVersionInfo(
+        model_name="model",
+        catalog_name="catalog",
+        schema_name="schema",
+        version=1,
+        status=OssProtoModelVersionStatus.Value("READY"),
+    )
+    assert model_version_from_uc_native_proto(native_proto).deployment_job_state is None
+
+
 def test_registered_model_search_from_uc_native_proto():
     expected_registered_model = RegisteredModelSearch(
         name="catalog.schema.name",
@@ -529,13 +541,7 @@ def test_model_version_search_from_uc_native_proto():
         status="READY",
         aliases=[],
         tags=[],
-        deployment_job_state=ModelVersionDeploymentJobState(
-            "",
-            "",
-            "DEPLOYMENT_JOB_CONNECTION_STATE_UNSPECIFIED",
-            "DEPLOYMENT_JOB_RUN_STATE_UNSPECIFIED",
-            "",
-        ),
+        deployment_job_state=None,
     )
     uc_proto = ModelVersionInfo(
         model_name="model",


### PR DESCRIPTION
### Related Issues/PRs

Follow-up to #25635 / #25634.

### What changes are proposed in this pull request?

#25635 added a `HasField("deployment_job_state")` guard to `ModelVersion.from_proto` so a model version with no deployment job state hydrates to `None` instead of a truthy, empty `ModelVersionDeploymentJobState`. The four Unity Catalog converters were left with the same latent bug:

- `model_version_from_uc_proto` and `model_version_search_from_uc_proto` in `mlflow/utils/_unity_catalog_utils.py`
- `model_version_from_uc_native_proto` and `model_version_search_from_uc_native_proto` in `mlflow/store/_unity_catalog/registry/uc_native_rest_store.py`

They called `ModelVersionDeploymentJobState.from_proto(uc_proto.deployment_job_state)` unconditionally, so an unset `deployment_job_state` produced a truthy object full of empty strings (`job_id=""`, `job_state="DEPLOYMENT_JOB_CONNECTION_STATE_UNSPECIFIED"`, ...) rather than `None`.

This guards all four sites with `uc_proto.HasField("deployment_job_state")` (verified a singular message field on both the `ModelVersion` and `ModelVersionInfo` protos, so `HasField` is valid). Two search-converter tests that asserted the empty-object behavior are updated to expect `None`, and a regression test covers the unset case for both proto paths.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Updated `test_model_version_search_from_uc_proto` / `test_model_version_search_from_uc_native_proto` and added `test_model_version_converters_without_deployment_job_state_return_none`; all `model_version` converter tests pass.

### Does this PR require documentation update?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. A Unity Catalog model version with no deployment job state now reports `deployment_job_state=None`, consistent with the OSS registry, instead of an empty state object.

#### What component(s) does this PR affect?

- [x] `area/model-registry`

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
