### PR TITLE
Fix `mlflow agent setup` tests on Windows

### DIFF
--- a/tests/agent/test_setup_sh_unit.py
+++ b/tests/agent/test_setup_sh_unit.py
@@ -48,7 +48,12 @@ def test_trim_whitespace():
 
 
 def test_json_escape():
-    result = run_shell('json_escape "$1"', 'a\\path"with-quote')
+    result = run_shell(
+        r"""
+value='a\path"with-quote'
+json_escape "$value"
+"""
+    )
 
     assert result.returncode == 0, result.stderr
     assert result.stdout == 'a\\\\path\\"with-quote'
@@ -296,18 +301,17 @@ validate_tracking_uri
     assert "Do not include credentials" in result.stderr
 
 
-def test_json_experiment_strings_fallback_handles_compact_response(tmp_path: Path):
-    for command in ("head", "sed"):
-        (tmp_path / command).symlink_to(Path("/usr/bin") / command)
+def test_json_experiment_strings_fallback_handles_compact_response():
     result = run_shell(
         """
-PATH=$1
+sed_bin=$(command -v sed)
+PATH=
+sed() { "$sed_bin" "$@"; }
 printf '%s%s\n' \
     '{"experiments":[{"experiment_id":"1","name":"one"},' \
     '{"experiment_id":"2","name":"two"}]}' |
     json_experiment_strings name
-""",
-        str(tmp_path),
+"""
     )
 
     assert result.returncode == 0, result.stderr
@@ -472,7 +476,7 @@ printf '%s\n' "$DATABRICKS_BIN"
 
     expected = tmp_path / "bin" / "databricks"
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == str(expected)
+    assert Path(result.stdout.strip()) == expected
     assert expected.exists()
 
 
@@ -497,20 +501,16 @@ cat "$setup_tmp_dir/experiments.json"
     assert '"name":"second"' in result.stdout
 
 
-def test_local_server_always_prints_mlflow_command(tmp_path: Path):
-    curl = tmp_path / "curl"
-    curl.write_text("#!/bin/sh\n")
-    curl.chmod(0o755)
-
+def test_local_server_always_prints_mlflow_command():
     result = run_shell(
         """
-PATH=$1
+PATH=
+curl() { :; }
 run_with_spinner() { :; }
 success() { :; }
 EXPERIMENT_NAME=test
 configure_local
-""",
-        str(tmp_path),
+"""
     )
 
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
### Related Issues/PRs

Relates to #24418 and #25687

### What changes are proposed in this pull request?

Make the shell setup unit tests portable across POSIX and Windows Git Bash:

- Keep the JSON escaping fixture inside the shell instead of passing it through MSYS argument conversion.
- Replace temporary POSIX symlinks with shell-function stubs when testing the no-`jq` and local-server paths.
- Compare the installed Databricks CLI path semantically rather than comparing Windows path separators as strings.

The production setup script is unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests

```text
31 passed in tests/agent/test_setup_sh_unit.py
```

Pre-commit hooks pass for `tests/agent/test_setup_sh_unit.py`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: A release that increments the second part of the version number. Minor releases include larger changes, improvements, and non-critical bug fixes.
- Patch release: A release that increments the third part of the version number. Patch releases are reserved for critical regressions or security fixes.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
