### PR TITLE
Assert EvaluationResult.passed only over this run's scorer columns

### DIFF
--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -260,6 +260,11 @@ class EvaluationResult:
     # Per-scorer ``pass_if`` predicates, keyed by scorer name. Populated by the
     # evaluation harness from the scorers that declare one. In-process only.
     pass_criteria: dict[str, Callable[[Any], bool]] = field(default_factory=dict)
+    # Names of the scorers this evaluation ran. Populated by the harness so
+    # ``passed``/``reason`` assert only over values produced by this run's
+    # scorers; other ``/value`` columns in ``result_df`` (e.g. dataset
+    # expectations) are reference data, not assertions. In-process only.
+    scorer_names: set[str] = field(default_factory=set)
 
     def __repr__(self) -> str:
         metrics_str = "\n    ".join([f"{k}: {v}" for k, v in self.metrics.items()])
@@ -308,7 +313,17 @@ class EvaluationResult:
         if self.result_df is None:
             return []
 
-        value_cols = [c for c in self.result_df.columns if c.endswith("/value")]
+        value_cols = [
+            c
+            for c in self.result_df.columns
+            if c.endswith("/value")
+            # Assert only over values produced by this run's scorers. Other
+            # /value columns (e.g. dataset expectations carried in result_df
+            # for comparison) are reference data, not verdicts. When
+            # scorer_names is unset (direct construction, pre-existing callers)
+            # keep the historical behavior of asserting every /value column.
+            and (not self.scorer_names or c.removesuffix("/value") in self.scorer_names)
+        ]
         if not value_cols:
             return []
 

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -801,6 +801,7 @@ def run(
         result_df=construct_eval_result_df(run_id, traces, eval_results),
         metrics=aggregated_metrics,
         pass_criteria=pass_criteria,
+        scorer_names={scorer.name for scorer in (scorers or [])},
     )
 
 

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -990,14 +990,16 @@ def construct_eval_result_df(
 def _get_assessment_values(assessments: list[dict[str, Any]], run_id: str) -> dict[str, Any]:
     result = {}
     for a in assessments:
-        if (
-            # Exclude feedbacks from other evaluation runs
-            (source_run_id := a.get("metadata", {}).get(AssessmentMetadataKey.SOURCE_RUN_ID))
-            and source_run_id != run_id
-        ):
-            continue
         name = a["assessment_name"]
         if feedback := a.get("feedback"):
+            # Only feedbacks logged by this evaluation run are this run's
+            # assertions. The harness stamps every feedback it logs with
+            # mlflow.assessment.sourceRunId, so require it to match: feedback
+            # without the stamp was logged outside the evaluation (e.g. by the
+            # application under test via mlflow.log_assessment) and must not
+            # flow into the run's verdict columns.
+            if a.get("metadata", {}).get(AssessmentMetadataKey.SOURCE_RUN_ID) != run_id:
+                continue
             result[f"{name}/value"] = feedback.get("value")
             # Carry the rationale and any scorer error so downstream consumers (e.g.
             # EvaluationResult.passed/reason) can surface them. Emitted only when
@@ -1007,6 +1009,9 @@ def _get_assessment_values(assessments: list[dict[str, Any]], run_id: str) -> di
             if (error := feedback.get("error")) and (msg := error.get("error_message")):
                 result[f"{name}/error_message"] = msg
         elif expectation := a.get("expectation"):
+            # Expectations are reference values from the dataset: keep them in
+            # the result DataFrame for comparison, but they are not assertions
+            # (EvaluationResult._failures skips them via the scorer name set).
             result[f"{name}/value"] = expectation.get("value")
 
     return result

--- a/tests/genai/evaluate/test_entities.py
+++ b/tests/genai/evaluate/test_entities.py
@@ -189,3 +189,48 @@ def test_sparse_columns_are_skipped():
     ])
     result = EvaluationResult(run_id="r1", metrics={}, result_df=df)
     assert result.passed, result.reason
+
+
+def test_passed_ignores_expectation_columns_with_scorer_names():
+    df = pd.DataFrame([
+        {
+            "expected_response/value": "some string",
+            "max_length/value": 10,
+            "correctness/value": "yes",
+        }
+    ])
+    result = EvaluationResult(
+        run_id="r1",
+        metrics={},
+        result_df=df,
+        scorer_names={"correctness"},
+    )
+    assert result.passed
+    assert result.reason == ""
+
+
+def test_passed_reports_scorer_failure_alongside_expectations():
+    df = pd.DataFrame([
+        {
+            "expected_response/value": "some string",
+            "correctness/value": "no",
+        }
+    ])
+    result = EvaluationResult(
+        run_id="r1",
+        metrics={},
+        result_df=df,
+        scorer_names={"correctness"},
+    )
+    assert not result.passed
+    assert "correctness" in result.reason
+    assert "expected_response" not in result.reason
+
+
+def test_passed_without_scorer_names_asserts_all_value_columns():
+    # Direct construction without scorer_names keeps the historical behavior
+    # of asserting every /value column, including dataset expectations.
+    df = pd.DataFrame([{"expected_response/value": "some string", "correctness/value": "yes"}])
+    result = EvaluationResult(run_id="r1", metrics={}, result_df=df)
+    assert not result.passed
+    assert "expected_response" in result.reason

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -1751,3 +1751,35 @@ def test_evaluate_with_trace_column_preserves_traces():
     remaining_traces = get_traces()
     remaining_trace_ids = {t.info.trace_id for t in remaining_traces}
     assert original_trace_id in remaining_trace_ids
+
+
+def test_get_assessment_values_includes_only_this_runs_feedback():
+    from mlflow.genai.utils.trace_utils import _get_assessment_values
+    from mlflow.tracing.constant import AssessmentMetadataKey
+
+    assessments = [
+        {
+            "assessment_name": "correctness",
+            "feedback": {"value": "yes"},
+            "metadata": {AssessmentMetadataKey.SOURCE_RUN_ID: "run-1"},
+        },
+        # Feedback without the source-run stamp (e.g. logged by the
+        # application under test via mlflow.log_assessment) must not become
+        # an assertion column for this run.
+        {"assessment_name": "app_self_grade", "feedback": {"value": "yes"}},
+        # Feedback stamped with a different evaluation run.
+        {
+            "assessment_name": "old_run_score",
+            "feedback": {"value": "yes"},
+            "metadata": {AssessmentMetadataKey.SOURCE_RUN_ID: "run-2"},
+        },
+        # Expectations stay in the result DataFrame as reference values.
+        {"assessment_name": "expected_response", "expectation": {"value": "some string"}},
+    ]
+
+    values = _get_assessment_values(assessments, "run-1")
+
+    assert values == {
+        "correctness/value": "yes",
+        "expected_response/value": "some string",
+    }


### PR DESCRIPTION
### Related Issues/PRs

Relates to the verdict-integrity defect described below; no existing issue tracked it at the time of filing.

### What changes are proposed in this pull request?

`EvaluationResult.passed` documents itself as "True when every scorer passed for every row", but `_failures` asserts over every column in `result_df` whose name ends in `/value`. Two kinds of columns that are not this run's scorer verdicts land in that shape:

1. Dataset expectations. `_get_assessment_values` writes each Expectation value into a `<name>/value` column, so a dataset carrying expectations (a string `expected_response`, an int `max_length`) makes `passed` False for every run, with failure lines naming the expectations rather than any scorer.
2. Foreign feedback. The provenance filter excluded feedback only when the `mlflow.assessment.sourceRunId` metadata was present and pointed at another run; feedback without the stamp passed straight through. The harness stamps every feedback it logs, but the public `mlflow.log_assessment` API does not, so feedback an application logged on its own traces before evaluation became assertion columns in this run's verdict: a pre-logged "yes" self-grade appears as a passing assertion, and pre-logged junk of any other shape forces the evaluation to fail.

Proposed changes:

- The harness passes the scorer name set to `EvaluationResult` (new in-process field `scorer_names`), and `_failures` asserts only over those columns. Direct construction without the set keeps the historical behavior of asserting every `/value` column.
- `_get_assessment_values` includes feedback only when its `mlflow.assessment.sourceRunId` matches the evaluation run, which is the documented purpose of the stamp (`AssessmentMetadataKey.SOURCE_RUN_ID`: "When the assessment is generated by an eval run, log the run ID here").
- Expectations remain in `result_df` as reference values; they are no longer asserted.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests in `tests/genai/evaluate/test_entities.py` and `tests/genai/utils/test_trace_utils.py`:

- expectations plus a passing scorer column, with `scorer_names` set: `passed` is True and the reason no longer names the expectations
- a failing scorer is still reported alongside expectations
- direct construction without `scorer_names` keeps the historical behavior
- `_get_assessment_values` includes only same-run feedback: metadata-less and foreign-run feedback are excluded, the same-run feedback and the expectation are included

Both new failure-path tests fail on the pre-fix code (one on the assertion, showing `app_self_grade` flowing into the assertion columns) and the full local run passes after the change: 107 passed across `test_entities.py` and `test_trace_utils.py` (the two `test_convert_predict_fn` cases that call the live OpenAI API are excluded; they fail auth in any offline environment, before and after this change).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

The documented behavior of `passed` ("every scorer passed") is unchanged; this PR makes the implementation match it.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.
