### PR TITLE
fix: treat .jsonl and .env files as text/plain in mime type detection

### DIFF
--- a/mlflow/utils/mime_type_utils.py
+++ b/mlflow/utils/mime_type_utils.py
@@ -32,6 +32,8 @@ def get_text_extensions():
         "tsv",
         "md",
         "rst",
+        "jsonl",
+        ".env",
     ]
 
     if not IS_TRACING_SDK_ONLY:

--- a/tests/utils/test_mime_type_utils.py
+++ b/tests/utils/test_mime_type_utils.py
@@ -15,6 +15,8 @@ from mlflow.utils.os import is_windows
         ("/a/b/c.pdf", "application/pdf"),
         ("/a/b/MLmodel", "text/plain"),
         ("/a/b/mlproject", "text/plain"),
+        ("/a/b/data.jsonl", "text/plain"),
+        ("/a/b/.env", "text/plain"),
     ],
 )
 def test_guess_mime_type(file_path, expected_mime_type):


### PR DESCRIPTION
.jsonl (JSON Lines, common for LLM traces/datasets) and .env files were falling back to application/octet-stream, causing UIs to treat them as binary instead of rendering as text.

### Related Issues/PRs
N/A

### What changes are proposed in this pull request?
Adds `.jsonl` and `.env` to `get_text_extensions()` in `mlflow/utils/mime_type_utils.py` so these files are correctly detected as `text/plain` instead of `application/octet-stream`. `.jsonl` is widely used for LLM traces/eval datasets in MLflow, and `.env` is a dotfile whose extension detection needed the leading dot handled explicitly. Added 2 new parametrized test cases to `tests/utils/test_mime_type_utils.py` covering both file types.

### How is this PR tested?
- [x] New unit/integration tests

### Does this PR require documentation update?
- [x] No.

### Does this PR require updating the MLflow Skills repository?
- [x] No.

### Release Notes

#### Is this a user-facing change?
- [x] Yes. Fixed `.jsonl` and `.env` files being incorrectly treated as binary (application/octet-stream) instead of text/plain in the UI.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

### How should the PR be classified in the release notes? Choose one:
- [x] rn/bug-fix - A user-facing bug fix worth mentioning in the release notes

### Is this PR a critical bugfix or security fix that should go into the next patch release?
- [x] This PR can wait for the next minor release