### PR TITLE
Add native Crusoe gateway provider

### DIFF
--- a/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
+++ b/docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx
@@ -34,6 +34,7 @@ The AI Gateway supports providers across these categories:
 | **Groq**         | Yes  | No         | Open-source models                   |
 | **Together AI**  | Yes  | Yes        | Open-source models                   |
 | **Fireworks AI** | Yes  | Yes        | Open-source models                   |
+| **Crusoe**       | Yes  | No         | Open-source models                   |
 | **Ollama**       | Yes  | Yes        | Local models                         |
 | **Databricks**   | Yes  | Yes        | Foundation Model APIs                |
 | **Portkey**      | Yes  | Yes        | Unified gateway for any LLM provider |

--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -66,6 +66,7 @@ class Provider(str, Enum):
     VERTEX_AI = "vertex_ai"
     PORTKEY = "portkey"
     SAP_AI_CORE = "sap-ai-core"
+    CRUSOE = "crusoe"
 
     @classmethod
     def values(cls):

--- a/mlflow/gateway/provider_registry.py
+++ b/mlflow/gateway/provider_registry.py
@@ -43,6 +43,7 @@ def _register_default_providers(registry: ProviderRegistry):
     from mlflow.gateway.providers.anthropic import AnthropicProvider
     from mlflow.gateway.providers.bedrock import AmazonBedrockProvider
     from mlflow.gateway.providers.cohere import CohereProvider
+    from mlflow.gateway.providers.crusoe import CrusoeProvider
     from mlflow.gateway.providers.databricks import DatabricksProvider
     from mlflow.gateway.providers.deepseek import DeepSeekProvider
     from mlflow.gateway.providers.gemini import GeminiProvider
@@ -68,6 +69,7 @@ def _register_default_providers(registry: ProviderRegistry):
     registry.register(Provider.AZURE, OpenAIProvider)
     registry.register(Provider.BEDROCK, AmazonBedrockProvider)
     registry.register(Provider.COHERE, CohereProvider)
+    registry.register(Provider.CRUSOE, CrusoeProvider)
     registry.register(Provider.DATABRICKS, DatabricksProvider)
     registry.register(Provider.DATABRICKS_MODEL_SERVING, DatabricksProvider)
     registry.register(Provider.DEEPSEEK, DeepSeekProvider)

--- a/mlflow/gateway/providers/crusoe.py
+++ b/mlflow/gateway/providers/crusoe.py
@@ -1,0 +1,8 @@
+from mlflow.gateway.config import _OpenAICompatibleConfig
+from mlflow.gateway.providers.openai_compatible import OpenAICompatibleProvider
+
+
+class CrusoeProvider(OpenAICompatibleProvider):
+    DISPLAY_NAME = "Crusoe"
+    CONFIG_TYPE = _OpenAICompatibleConfig
+    DEFAULT_API_BASE = "https://api.inference.crusoecloud.com/v1"

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -425,6 +425,7 @@ def _build_endpoint_config(
         Provider.XAI,
         Provider.OPENROUTER,
         Provider.OLLAMA,
+        Provider.CRUSOE,
     }:
         provider_config = _build_openai_compatible_config(model_config)
     elif model_config.provider == Provider.PORTKEY:

--- a/tests/gateway/providers/test_crusoe.py
+++ b/tests/gateway/providers/test_crusoe.py
@@ -1,0 +1,77 @@
+from unittest import mock
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+
+from mlflow.gateway.config import EndpointConfig
+from mlflow.gateway.providers.crusoe import CrusoeProvider
+from mlflow.gateway.schemas import chat
+
+from tests.gateway.tools import MockAsyncResponse, mock_http_client
+
+
+def _make_provider() -> CrusoeProvider:
+    endpoint_config = EndpointConfig(
+        name="crusoe-endpoint",
+        endpoint_type="llm/v1/chat",
+        model={
+            "provider": "crusoe",
+            "name": "zai/GLM-5.3",
+            "config": {"api_key": "crusoe_test_key"},
+        },
+    )
+    return CrusoeProvider(endpoint_config)
+
+
+def _chat_response():
+    return {
+        "id": "chatcmpl-crusoe-123",
+        "object": "chat.completion",
+        "created": 1700000000,
+        "model": "zai/GLM-5.3",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello from Crusoe!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "headers": {"Content-Type": "application/json"},
+    }
+
+
+def test_default_api_base():
+    provider = _make_provider()
+    assert provider._api_base == "https://api.inference.crusoecloud.com/v1"
+
+
+def test_headers():
+    provider = _make_provider()
+    assert provider.headers == {"Authorization": "Bearer crusoe_test_key"}
+
+
+def test_name():
+    provider = _make_provider()
+    assert provider.DISPLAY_NAME == "Crusoe"
+
+
+@pytest.mark.asyncio
+async def test_chat():
+    provider = _make_provider()
+    mock_client = mock_http_client(MockAsyncResponse(_chat_response()))
+
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        payload = chat.RequestPayload(
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        response = await provider.chat(payload)
+
+    result = jsonable_encoder(response)
+    assert result["id"] == "chatcmpl-crusoe-123"
+    assert result["choices"][0]["message"]["content"] == "Hello from Crusoe!"
+    assert result["usage"]["total_tokens"] == 30


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add Crusoe Managed Inference as a native gateway provider extending `OpenAICompatibleProvider`, in the same shape as the Groq (#21991) and DeepSeek (#21992) providers. Removes the need for LiteLLM when using Crusoe models through the AI Gateway.

Provider: `crusoe` | Default API base: `https://api.inference.crusoecloud.com/v1`

Changes:

- `mlflow/gateway/providers/crusoe.py`: `CrusoeProvider` (display name, `_OpenAICompatibleConfig`, default API base)
- `mlflow/gateway/config.py`: `Provider.CRUSOE`
- `mlflow/gateway/provider_registry.py`: register the provider
- `mlflow/server/gateway_api.py`: build an OpenAI-compatible config for `crusoe` endpoints
- `docs/docs/genai/governance/ai-gateway/endpoints/model-providers.mdx`: add Crusoe to the Additional Providers table (chat only; Crusoe does not currently serve embedding models)
- `tests/gateway/providers/test_crusoe.py`: default API base, auth header, display name, chat round trip

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`pytest tests/gateway/providers/test_crusoe.py tests/gateway/test_provider_registry.py tests/gateway/test_gateway_config_parsing.py` passes locally (34 tests). `ruff check` and `ruff format --check` pass on the changed files.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added Crusoe Managed Inference as a native AI Gateway provider (`provider: crusoe`), so Crusoe endpoints can be created without installing LiteLLM.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
