### PR TITLE
Surface NaiLaOpus non-approval reasons

### DIFF
--- a/.github/workflows/nailaopus.yml
+++ b/.github/workflows/nailaopus.yml
@@ -175,7 +175,7 @@ jobs:
           # open a new PR that updates this SHA to the latest mlflow/internal
           # main after reviewing the diff. We'll migrate to release tags once
           # the bump cadence is stable; see mlflow/internal for the policy.
-          ref: 5e5f9229e16b97822ea3349b31285370be36b4d1
+          ref: 893db451740abb76e142bff410462548a9a227b2
           sparse-checkout: |
             nailaopus
           path: internal


### PR DESCRIPTION
### Related Issues/PRs

Relates to mlflow/internal#85

### What changes are proposed in this pull request?

Bump the pinned NaiLaOpus orchestrator revision to deploy the stamp-gate explanation added in mlflow/internal#85. When a review has no findings but cannot auto-approve, the bot now surfaces the reason, such as unresolved review threads or a missing size label.

### How is this PR tested?

- [x] Existing unit/integration tests

The internal change includes deterministic stamp-gate and summary-rendering tests. I also ran `uv run --only-group lint pre-commit run --files .github/workflows/nailaopus.yml`.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
