### PR TITLE
Add a `timeout` option to the `@scorer` decorator

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -3,7 +3,9 @@ import importlib
 import inspect
 import json
 import logging
-from contextvars import ContextVar
+import math
+import threading
+from contextvars import ContextVar, copy_context
 from dataclasses import asdict, dataclass, fields
 from enum import Enum
 from typing import Any, Callable, ClassVar, Literal, TypeAlias, TypeVar, overload
@@ -33,6 +35,7 @@ from mlflow.tracking._tracking_service.utils import get_tracking_uri
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import is_databricks_uri
+from mlflow.utils.timeout import MlflowTimeoutError
 
 _logger = logging.getLogger(__name__)
 
@@ -43,8 +46,15 @@ SCORER_BACKEND_DATABRICKS = "databricks"
 # Context variable to track if we're in a scorer call (prevents nested telemetry)
 _in_scorer_call: ContextVar[bool] = ContextVar("mlflow_scorer_call_context", default=False)
 
+# Set while a scorer runs inside its timeout worker thread, so the re-entrant `run()` there
+# doesn't spawn another timeout thread.
+_in_scorer_timeout: ContextVar[bool] = ContextVar("mlflow_scorer_timeout", default=False)
+
 # Serialization version for tracking changes to the serialization format
 _SERIALIZATION_VERSION = 1
+
+# Default per-invocation timeout (seconds) for @scorer scorers that don't set an explicit timeout.
+DEFAULT_SCORER_TIMEOUT = 300
 _AggregationFunc: TypeAlias = Callable[[list[int | float]], float]
 _AggregationType: TypeAlias = (
     Literal["min", "max", "mean", "median", "variance", "p90"] | _AggregationFunc
@@ -163,6 +173,9 @@ class SerializedScorer:
     aggregations: list[str] | None = None
     description: str | None = None
     is_session_level_scorer: bool = False
+    # Per-invocation timeout (seconds). Defaults to `0` (no timeout) so scorers serialized before
+    # this field existed (legacy scorers) stay unbounded; a fresh scorer serializes `None`.
+    timeout: int | float | None = 0
 
     # Version metadata
     mlflow_version: str = mlflow.__version__
@@ -291,6 +304,9 @@ class Scorer(BaseModel):
     name: str
     aggregations: list[_AggregationType] | None = None
     description: str | None = None
+    # Per-invocation timeout (seconds) enforced by `run()`. `None` (default) uses
+    # DEFAULT_SCORER_TIMEOUT; `0` disables the timeout.
+    timeout: int | float | None = None
 
     _cached_dump: dict[str, Any] | None = PrivateAttr(default=None)
     _sampling_config: ScorerSamplingConfig | None = PrivateAttr(default=None)
@@ -427,6 +443,7 @@ class Scorer(BaseModel):
             description=self.description,
             aggregations=self.aggregations,
             is_session_level_scorer=self.is_session_level_scorer,
+            timeout=self.timeout,
             mlflow_version=mlflow.__version__,
             serialization_version=_SERIALIZATION_VERSION,
             call_source=source_info.get("call_source"),
@@ -708,6 +725,7 @@ class Scorer(BaseModel):
             name=serialized.name,
             description=serialized.description,
             aggregations=serialized.aggregations,
+            timeout=serialized.timeout,
         )
         # Cache the serialized data to prevent re-serialization issues with dynamic functions
         original_serialized_data = asdict(serialized)
@@ -715,6 +733,17 @@ class Scorer(BaseModel):
         return scorer_instance
 
     def run(self, *, inputs=None, outputs=None, expectations=None, trace=None, session=None):
+        if not _in_scorer_timeout.get():
+            if timeout := (DEFAULT_SCORER_TIMEOUT if self.timeout is None else self.timeout):
+                return self._run_with_timeout(
+                    timeout,
+                    inputs=inputs,
+                    outputs=outputs,
+                    expectations=expectations,
+                    trace=trace,
+                    session=session,
+                )
+
         from mlflow.evaluation import Assessment as LegacyAssessment
 
         merged = {
@@ -767,6 +796,36 @@ class Scorer(BaseModel):
             result.name = self.name
 
         return result
+
+    def _run_with_timeout(self, timeout: int | float, **kwargs: Any) -> Any:
+        # Daemon thread re-enters run() (guarded by _in_scorer_timeout) instead of calling the
+        # scorer directly, so a Scorer.run frame stays on its stack for telemetry callsite lookup.
+        ctx = copy_context()
+        outcome: dict[str, Any] = {}
+
+        def _target() -> None:
+            _in_scorer_timeout.set(True)
+            try:
+                outcome["value"] = self.run(**kwargs)
+            except BaseException as e:  # re-surface whatever the scorer raised on the caller
+                outcome["error"] = e
+
+        thread = threading.Thread(
+            target=lambda: ctx.run(_target), name=f"MlflowScorer-{self.name}", daemon=True
+        )
+        thread.start()
+        # Thread.join rejects values above TIMEOUT_MAX; clamp so a huge timeout just means "wait".
+        thread.join(min(timeout, threading.TIMEOUT_MAX))
+        if thread.is_alive():
+            # Warn so a climbing thread count from timed-out scorers is diagnosable.
+            _logger.warning("Scorer '%s' timed out after %s seconds.", self.name, timeout)
+            raise MlflowTimeoutError(
+                f"Scorer '{self.name}' timed out after {timeout} seconds. Set a longer timeout "
+                f"with `@scorer(timeout=...)`, or `timeout=0` to disable the timeout."
+            )
+        if "error" in outcome:
+            raise outcome["error"]
+        return outcome["value"]
 
     def __call__(
         self,
@@ -1273,6 +1332,7 @@ def scorer(
     description: str | None = None,
     aggregations: list[_AggregationType] | None = None,
     pass_if: Callable[[Any], bool] | None = None,
+    timeout: int | float | None = None,
 ) -> Scorer: ...
 
 
@@ -1284,6 +1344,7 @@ def scorer(
     description: str | None = None,
     aggregations: list[_AggregationType] | None = None,
     pass_if: Callable[[Any], bool] | None = None,
+    timeout: int | float | None = None,
 ) -> Callable[[_F], Scorer]: ...
 
 
@@ -1294,6 +1355,7 @@ def scorer(
     description: str | None = None,
     aggregations: list[_AggregationType] | None = None,
     pass_if: Callable[[Any], bool] | None = None,
+    timeout: int | float | None = None,
 ) -> Scorer | Callable[[_F], Scorer]:
     """
     A decorator to define a custom scorer that can be used in ``mlflow.genai.evaluate()``.
@@ -1380,6 +1442,9 @@ def scorer(
             Use it for scorers whose value is not a ``yes``/``no`` rating or a ``bool``
             (e.g. a numeric score): ``@scorer(pass_if=lambda v: v >= 0.8)``. When omitted,
             the default rule applies (a ``yes`` rating or ``True`` passes).
+        timeout: Maximum seconds a single scorer invocation may run during
+            ``mlflow.genai.evaluate`` and monitoring before it is recorded as a
+            ``SCORER_ERROR`` failure. Defaults to ``None`` (300 seconds); ``0`` disables it.
 
     Example:
 
@@ -1461,6 +1526,17 @@ def scorer(
             )
     """
 
+    if timeout is not None and not (
+        isinstance(timeout, (int, float))
+        and not isinstance(timeout, bool)
+        and math.isfinite(timeout)
+        and timeout >= 0
+    ):
+        raise MlflowException.invalid_parameter_value(
+            f"`timeout` must be a non-negative, finite number of seconds or None "
+            f"(use 0 to disable the timeout), got {timeout!r}."
+        )
+
     if func is None:
         return functools.partial(
             scorer,
@@ -1468,6 +1544,7 @@ def scorer(
             description=description,
             aggregations=aggregations,
             pass_if=pass_if,
+            timeout=timeout,
         )
 
     func_params = set(inspect.signature(func).parameters.keys())
@@ -1521,6 +1598,7 @@ def scorer(
         name=name or func.__name__,
         description=description,
         aggregations=aggregations,
+        timeout=timeout,
     )
 
 

--- a/tests/genai/evaluate/test_rate_limiter.py
+++ b/tests/genai/evaluate/test_rate_limiter.py
@@ -494,8 +494,9 @@ def test_scorer_thread_sees_retry_flags_single():
 
     assert len(captured) == 1
     thread_name, litellm_disabled, http_disabled = captured[0]
+    # The scorer runs off the caller thread (default @scorer timeout runs it in its own
+    # timeout worker) and the retry flags propagate into whatever thread it runs in.
     assert thread_name != threading.current_thread().name
-    assert thread_name.startswith("MlflowGenAIEvalScorer")
     assert litellm_disabled is True
     assert http_disabled is True
 
@@ -506,7 +507,7 @@ def test_scorer_threads_see_retry_flags_under_concurrency():
     assert len(captured) == 5
     worker_threads = {name for name, _, _ in captured}
     assert len(worker_threads) > 1
-    assert all(name.startswith("MlflowGenAIEvalScorer") for name, _, _ in captured)
+    assert threading.current_thread().name not in worker_threads
     assert all(litellm and http for _, litellm, http in captured)
 
 

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -1,3 +1,5 @@
+import threading
+import time
 from collections import defaultdict
 from unittest.mock import call, patch
 
@@ -7,12 +9,14 @@ import pytest
 import mlflow
 from mlflow.entities import Assessment, AssessmentSource, AssessmentSourceType, Feedback
 from mlflow.entities.assessment_error import AssessmentError
+from mlflow.exceptions import MlflowException
 from mlflow.genai import Scorer, scorer
 from mlflow.genai.judges import make_judge
 from mlflow.genai.judges.utils import CategoricalRating
 from mlflow.genai.scorers import Correctness, Guidelines, RetrievalGroundedness
 from mlflow.genai.scorers.base import SerializedScorer
 from mlflow.genai.scorers.registry import get_scorer, list_scorers
+from mlflow.utils.timeout import MlflowTimeoutError
 
 
 @pytest.fixture(autouse=True)
@@ -544,3 +548,119 @@ def test_scorer_pass_if_is_exposed():
         return True
 
     assert plain.pass_if is None
+
+
+def test_scorer_default_timeout_is_none_sentinel():
+    @scorer
+    def s(outputs) -> bool:
+        return True
+
+    assert s.timeout is None
+
+
+def test_scorer_default_timeout_uses_constant(monkeypatch):
+    # A scorer with no explicit timeout is bounded by DEFAULT_SCORER_TIMEOUT.
+    monkeypatch.setattr("mlflow.genai.scorers.base.DEFAULT_SCORER_TIMEOUT", 0.2)
+    release = threading.Event()
+
+    @scorer
+    def slow(outputs) -> bool:
+        release.wait(10)
+        return True
+
+    try:
+        with pytest.raises(MlflowTimeoutError, match="timed out after 0.2 seconds"):
+            slow.run(outputs="x")
+    finally:
+        release.set()
+
+
+@pytest.mark.parametrize("timeout", [None, 0, 30, 5.5])
+def test_scorer_timeout_value_preserved(timeout):
+    @scorer(timeout=timeout)
+    def s(outputs) -> bool:
+        return True
+
+    assert s.timeout == timeout
+
+
+@pytest.mark.parametrize("bad", [-1, True, False, "5", float("inf"), float("nan")])
+def test_scorer_rejects_invalid_timeout(bad):
+    with pytest.raises(MlflowException, match="must be a non-negative"):
+
+        @scorer(timeout=bad)
+        def s(outputs) -> bool:
+            return True
+
+
+def test_scorer_run_times_out_slow_scorer():
+    # Event (released below) instead of a bare sleep so the abandoned daemon thread doesn't linger.
+    release = threading.Event()
+
+    @scorer(timeout=0.2)
+    def slow(outputs) -> bool:
+        release.wait(10)
+        return True
+
+    start = time.time()
+    try:
+        with pytest.raises(MlflowTimeoutError, match="timed out after 0.2 seconds"):
+            slow.run(outputs="x")
+        # Abandoned well before the 10s the scorer would otherwise take.
+        assert time.time() - start < 3
+    finally:
+        release.set()
+
+
+def test_scorer_run_within_timeout_returns_normally():
+    @scorer(timeout=5)
+    def ok(outputs) -> bool:
+        return outputs == "good"
+
+    assert ok.run(outputs="good") is True
+    assert ok.run(outputs="bad") is False
+
+
+def test_scorer_run_propagates_non_timeout_exception():
+    @scorer(timeout=5)
+    def boom(outputs) -> bool:
+        raise ValueError("boom in scorer")
+
+    with pytest.raises(ValueError, match="boom in scorer"):
+        boom.run(outputs="x")
+
+
+def test_scorer_timeout_zero_runs_unbounded(monkeypatch):
+    # `timeout=0` disables the timeout even when the default is tiny.
+    monkeypatch.setattr("mlflow.genai.scorers.base.DEFAULT_SCORER_TIMEOUT", 0.05)
+
+    @scorer(timeout=0)
+    def slow(outputs) -> bool:
+        time.sleep(0.2)
+        return True
+
+    assert slow.run(outputs="x") is True
+
+
+def test_scorer_timeout_becomes_error_feedback_in_evaluate(sample_data, is_in_databricks):
+    release = threading.Event()
+
+    @scorer(timeout=0.2)
+    def slow_scorer(inputs) -> bool:
+        release.wait(10)
+        return True
+
+    @scorer
+    def fast_scorer(inputs) -> bool:
+        return True
+
+    try:
+        results = mlflow.genai.evaluate(data=sample_data, scorers=[slow_scorer, fast_scorer])
+    finally:
+        release.set()
+
+    # The fast scorer yields its metric; the timed-out one errors and is excluded. The control
+    # scorer makes the absence specifically a timeout, not scorers being dropped wholesale.
+    metrics = results.metrics.keys()
+    assert any("fast_scorer" in metric for metric in metrics)
+    assert all("slow_scorer" not in metric for metric in metrics)

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -898,3 +898,33 @@ def test_from_dict_unknown_field_falls_back_to_unknown_serialized_version():
     log_message = _formatted_error_logs(mock_logger)
     assert "unknown" in log_message
     assert "mystery_field" in log_message
+
+
+@pytest.mark.parametrize("timeout", [30, 5.5, None, 0])
+def test_timeout_round_trip(timeout):
+    @scorer(timeout=timeout)
+    def my_scorer(outputs):
+        return outputs == "correct"
+
+    serialized = my_scorer.model_dump()
+    assert (
+        serialized["timeout"] == timeout if timeout is not None else serialized["timeout"] is None
+    )
+
+    deserialized = Scorer.model_validate(serialized)
+    assert deserialized.timeout == timeout if timeout is not None else deserialized.timeout is None
+    assert deserialized(outputs="correct") is True
+
+
+def test_scorer_serialized_before_timeout_existed_deserializes_to_zero():
+    @scorer(timeout=30)
+    def my_scorer(outputs):
+        return outputs == "correct"
+
+    # Emulate a payload written before the `timeout` field existed.
+    serialized = my_scorer.model_dump()
+    del serialized["timeout"]
+
+    deserialized = Scorer.model_validate(serialized)
+    # Legacy scorers reload unbounded (timeout disabled), not with the new default.
+    assert deserialized.timeout == 0


### PR DESCRIPTION
### Related Issues/PRs

Relates to N/A

### What changes are proposed in this pull request?

Adds a `timeout` option to the `@scorer` decorator so a single custom scorer invocation can
be bounded during `mlflow.genai.evaluate` and online monitoring.

Custom scorers can hang indefinitely (e.g. a wedged LLM call in a judge scorer), which
stalls the entire evaluation because there is no way to bound one invocation. `@scorer`
now accepts `timeout` (seconds), enforced in `Scorer.run()` — the single point every
execution path funnels through (offline harness, session scorers, online monitoring, and
ensemble sub-scorers). On overrun it raises `MlflowTimeoutError`, which the harness already
converts into a `SCORER_ERROR` feedback like any other scorer failure, so a slow scorer
degrades to one failed row instead of a hang.

- `timeout` defaults to `None`, which uses `DEFAULT_SCORER_TIMEOUT` (**300 seconds**).
- Pass `timeout=0` to disable the timeout for a scorer, or a positive number for an explicit
  per-scorer limit.
- Scorers serialized before this field existed (legacy registered scorers) reload with
  `timeout=0`, so existing monitoring workloads keep running unbounded — only freshly created
  scorers pick up the default.
- The scorer runs in a daemon thread, so a hang never blocks interpreter exit. The worker
  re-enters `run()` (guarded by the `_in_scorer_timeout` context variable) so the scorer still
  executes through a `Scorer.run` frame — the frame telemetry walks the stack for to attribute
  a scorer's callsite. A `signal.alarm`-based timeout cannot be used because scorers run inside
  the harness's worker threads, where `SIGALRM` is unavailable.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `tests/genai/scorers/test_scorer.py` and `tests/genai/scorers/test_serialization.py`
cover the default sentinel, the default bounding a scorer, `timeout=0` disabling it, explicit
values, invalid-value rejection (including `bool`), enforcement (a slow scorer raises
`MlflowTimeoutError` well before it would finish), non-timeout exception propagation,
serialization round-trip, the legacy-payload reload to `0`, and an end-to-end
`mlflow.genai.evaluate` run where a timed-out scorer becomes an error feedback while a fast
scorer still produces its metric.

**Backward-compatibility confirmation:**

| Scorer | Reloaded `timeout` | Behavior |
| --- | --- | --- |
| Already-registered before this change (serialized JSON has no `timeout` key) | `0` | **Unaffected** — runs inline, unbounded, exactly as today |
| Any newly created scorer (no explicit `timeout`) | `None` | Bounded by `DEFAULT_SCORER_TIMEOUT` (**300 s**) |
| `@scorer(timeout=0)` | `0` | Opt-out, unbounded |
| `@scorer(timeout=N)` | `N` | Bounded at `N` seconds |

Manual test script and its output:

<details>
<summary>manual_test.py</summary>

```python
import tempfile
import time
from unittest.mock import patch

import pandas as pd

import mlflow
from mlflow.genai.scorers import Scorer, scorer
from mlflow.genai.scorers import base as scorer_base
from mlflow.utils.timeout import MlflowTimeoutError


def hr(title):
    print("\n" + "=" * 72 + f"\n{title}\n" + "=" * 72)


# 1. Default: timeout=None uses DEFAULT_SCORER_TIMEOUT (300s)
hr("1. Default: timeout=None uses DEFAULT_SCORER_TIMEOUT (300s)")


@scorer
def relevance(outputs) -> bool:
    return "spark" in str(outputs).lower()


print("relevance.timeout       =", relevance.timeout, "(None -> use the default)")
print("DEFAULT_SCORER_TIMEOUT  =", scorer_base.DEFAULT_SCORER_TIMEOUT, "seconds")
print("relevance.run(...)      =", relevance.run(outputs="Spark is great"))


# 2. A slow scorer with the default is bounded by DEFAULT_SCORER_TIMEOUT
hr("2. A slow scorer with the default is bounded by DEFAULT_SCORER_TIMEOUT")


@scorer
def hanging_default(outputs) -> bool:
    time.sleep(30)  # a wedged LLM call, no explicit timeout set
    return True


with patch.object(scorer_base, "DEFAULT_SCORER_TIMEOUT", 1):
    start = time.time()
    try:
        hanging_default.run(outputs="anything")
        print("!!! expected a timeout")
    except MlflowTimeoutError as e:
        print(f"default timeout fired after {time.time() - start:.2f}s:")
        print("   ", e)


# 3. timeout=0 disables the timeout (runs unbounded)
hr("3. timeout=0 disables the timeout (runs unbounded)")


@scorer(timeout=0)
def self_managed(outputs) -> bool:
    time.sleep(0.2)
    return True


with patch.object(scorer_base, "DEFAULT_SCORER_TIMEOUT", 0.05):
    print("self_managed.timeout =", self_managed.timeout)
    print("runs despite tiny default ->", self_managed.run(outputs="x"))


# 4. Explicit numeric timeout, slow scorer -> MlflowTimeoutError (fast)
hr("4. Explicit numeric timeout, slow scorer -> MlflowTimeoutError (fast)")


@scorer(timeout=1)
def hanging_judge(outputs) -> bool:
    time.sleep(30)
    return True


start = time.time()
try:
    hanging_judge.run(outputs="anything")
    print("!!! expected a timeout")
except MlflowTimeoutError as e:
    print(f"raised after {time.time() - start:.2f}s (not 30s):")
    print("   ", e)


# 5. Invalid timeout is rejected at decoration time
hr("5. Invalid timeout is rejected at decoration time")

for bad in (-5, True, False, "10"):
    try:

        @scorer(timeout=bad)
        def _s(outputs) -> bool:
            return True

    except Exception as e:
        print(f"@scorer(timeout={bad!r}) -> {type(e).__name__}: {e}")


# 6. Serialization: value round-trips; legacy payloads reload as 0
hr("6. Serialization: value round-trips; legacy payloads reload as 0")


@scorer(timeout=10)
def persisted(outputs) -> bool:
    return outputs == "correct"


serialized = persisted.model_dump()
print("serialized['timeout']  =", serialized["timeout"])
with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
    restored = Scorer.model_validate(serialized)
    print("restored.timeout       =", restored.timeout)

    old_payload = dict(serialized)
    del old_payload["timeout"]  # emulate a payload from before the field existed
    old = Scorer.model_validate(old_payload)
print("legacy payload -> timeout =", old.timeout, "(grandfathered, unbounded)")


# 7. End to end: mlflow.genai.evaluate -- slow scorer degrades to a failure
hr("7. End to end: mlflow.genai.evaluate")

mlflow.set_tracking_uri(f"sqlite:///{tempfile.mkdtemp()}/mlflow.db")
mlflow.set_experiment("scorer_timeout_demo")

data = pd.DataFrame({
    "inputs": [{"q": "what is spark?"}, {"q": "how to tune spark?"}],
    "outputs": ["Spark is a distributed engine.", "Use broadcast joins and caching."],
})


@scorer
def fast_scorer(outputs) -> bool:
    return len(str(outputs)) > 0


@scorer(timeout=1)
def slow_scorer(outputs) -> bool:
    time.sleep(30)  # hangs on every row
    return True


results = mlflow.genai.evaluate(data=data, scorers=[fast_scorer, slow_scorer])
metrics = results.metrics
print("\nmetric keys:", sorted(metrics))
print("fast_scorer present :", any("fast_scorer" in k for k in metrics))
print("slow_scorer present :", any("slow_scorer" in k for k in metrics), "(timed out -> error, excluded)")
```

</details>

<details>
<summary>output</summary>

```text
1. Default: timeout=None uses DEFAULT_SCORER_TIMEOUT (300s)
relevance.timeout       = None (None -> use the default)
DEFAULT_SCORER_TIMEOUT  = 300 seconds
relevance.run(...)      = True

2. A slow scorer with the default is bounded by DEFAULT_SCORER_TIMEOUT
default timeout fired after 1.00s:
    Scorer 'hanging_default' timed out after 1 seconds. Set a longer timeout with `@scorer(timeout=...)`, or `timeout=0` to disable the timeout.

3. timeout=0 disables the timeout (runs unbounded)
self_managed.timeout = 0
runs despite tiny default -> True

4. Explicit numeric timeout, slow scorer -> MlflowTimeoutError (fast)
raised after 1.00s (not 30s):
    Scorer 'hanging_judge' timed out after 1 seconds. Set a longer timeout with `@scorer(timeout=...)`, or `timeout=0` to disable the timeout.

5. Invalid timeout is rejected at decoration time
@scorer(timeout=-5) -> MlflowException: `timeout` must be a non-negative, finite number of seconds or None (use 0 to disable the timeout), got -5.
@scorer(timeout=True) -> MlflowException: `timeout` must be a non-negative, finite number of seconds or None (use 0 to disable the timeout), got True.
@scorer(timeout=False) -> MlflowException: `timeout` must be a non-negative, finite number of seconds or None (use 0 to disable the timeout), got False.
@scorer(timeout='10') -> MlflowException: `timeout` must be a non-negative, finite number of seconds or None (use 0 to disable the timeout), got '10'.

6. Serialization: value round-trips; legacy payloads reload as 0
serialized['timeout']  = 10
restored.timeout       = 10
legacy payload -> timeout = 0 (grandfathered, unbounded)

7. End to end: mlflow.genai.evaluate
metric keys: ['fast_scorer/mean']
fast_scorer present : True
slow_scorer present : False (timed out -> error, excluded)
```

</details>

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`@scorer` now accepts a `timeout` (seconds) argument that bounds how long a single custom
scorer invocation may run during evaluation and monitoring; a scorer that exceeds it is
recorded as a failure instead of hanging the run. Defaults to 300 seconds; pass `timeout=0`
to disable it. Scorers registered before this change keep running unbounded.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
