### PR TITLE
Authorize `scorer/invoke` and bind traces to the caller's experiment (GHSA-6c27-cp6h-c66m)

### DIFF
--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -2977,8 +2977,8 @@ BEFORE_REQUEST_VALIDATORS.update({
     (CREATE_PROMPTLAB_RUN, "POST"): validate_can_create_promptlab_run,
     (GATEWAY_PROXY, "GET"): validate_gateway_proxy,
     (GATEWAY_PROXY, "POST"): validate_gateway_proxy,
-    (INVOKE_SCORER, "POST"): validate_gateway_proxy,
     # Invoke endpoints create runs in an experiment -> require update on it.
+    (INVOKE_SCORER, "POST"): validate_can_update_experiment,
     (INVOKE_ISSUE_DETECTION, "POST"): validate_can_update_experiment,
     (INVOKE_GENAI_EVALUATE, "POST"): validate_can_update_experiment,
     # Demo: generate is open to any authenticated user; delete is admin-only.

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -7167,6 +7167,8 @@ def _invoke_scorer_handler():
             "Please select at least one trace to evaluate.",
             error_code=INVALID_PARAMETER_VALUE,
         )
+    # Deduplicate while preserving order so a repeated trace_id is not fetched or scored twice.
+    trace_ids = list(dict.fromkeys(trace_ids))
     if (scorer_name is None) != (scorer_version is None):
         raise MlflowException.invalid_parameter_value(
             "scorer_name and scorer_version must be specified together"

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -110,7 +110,9 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
     INVALID_STATE,
     NOT_IMPLEMENTED,
+    PERMISSION_DENIED,
     RESOURCE_DOES_NOT_EXIST,
+    ErrorCode,
 )
 from mlflow.protos.issues_pb2 import (
     CreateIssue,
@@ -7201,6 +7203,46 @@ def _invoke_scorer_handler():
         serialized_scorer = registered_scorer.serialized_scorer
 
     scorer = Scorer.model_validate_json(serialized_scorer)
+
+    # Verify that all requested traces belong to the authorized experiment.
+    # This prevents users from writing assessments to traces in other experiments.
+    try:
+        trace_infos = tracking_store.batch_get_trace_infos(trace_ids)
+    except MlflowNotImplementedException:
+        # Fallback to per-trace fetches for stores that don't implement batch_get_trace_infos.
+        # Catch RESOURCE_DOES_NOT_EXIST (missing trace) to maintain consistency with the batch
+        # path, which returns a partial list. This ensures a missing trace flows into the
+        # set-comparison check below (generic 403), not into a 404 that leaks the trace_id.
+        trace_infos = []
+        for trace_id in trace_ids:
+            try:
+                trace_infos.append(tracking_store.get_trace_info(trace_id))
+            except MlflowException as e:
+                if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                    # Trace not found; treat as missing (do not re-raise)
+                    pass
+                else:
+                    # Re-raise any other exception (connection errors, permission errors, etc.)
+                    raise
+
+    # Check that all requested traces were found and belong to the authorized experiment.
+    # Fail-closed: reject if any requested trace_id is missing or in a different experiment.
+    returned_ids = {trace_info.trace_id for trace_info in trace_infos}
+    requested_ids = set(trace_ids)
+    if returned_ids != requested_ids:
+        # Some requested traces were not found
+        raise MlflowException(
+            "Not all requested traces could be accessed.",
+            error_code=PERMISSION_DENIED,
+        )
+
+    for trace_info in trace_infos:
+        if str(trace_info.experiment_id) != str(experiment_id):
+            # Trace belongs to a different experiment than the one being scored
+            raise MlflowException(
+                "Not all requested traces could be accessed.",
+                error_code=PERMISSION_DENIED,
+            )
     batches = get_trace_batches_for_scorer(trace_ids, scorer, tracking_store)
 
     # Extract the authenticated username so that job subprocesses can make

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -7206,15 +7206,17 @@ def _invoke_scorer_handler():
 
     scorer = Scorer.model_validate_json(serialized_scorer)
 
-    # Verify that all requested traces belong to the authorized experiment.
-    # This prevents users from writing assessments to traces in other experiments.
+    # Verify that any requested trace that exists belongs to the authorized experiment.
+    # This prevents users from scoring or writing assessments to traces in other experiments.
+    # Traces that do not exist are left to fail downstream in the scorer job (reported as
+    # "Traces not found"); only traces that resolve to a *different* experiment are rejected here.
     try:
         trace_infos = tracking_store.batch_get_trace_infos(trace_ids)
     except MlflowNotImplementedException:
         # Fallback to per-trace fetches for stores that don't implement batch_get_trace_infos.
-        # Catch RESOURCE_DOES_NOT_EXIST (missing trace) to maintain consistency with the batch
-        # path, which returns a partial list. This ensures a missing trace flows into the
-        # set-comparison check below (generic 403), not into a 404 that leaks the trace_id.
+        # Drop RESOURCE_DOES_NOT_EXIST (missing trace) so the fallback returns the same partial
+        # list the batch path would: a missing trace is simply absent and flows through to the
+        # job, rather than raising a 404 here.
         trace_infos = []
         for trace_id in trace_ids:
             try:
@@ -7226,17 +7228,6 @@ def _invoke_scorer_handler():
                 else:
                     # Re-raise any other exception (connection errors, permission errors, etc.)
                     raise
-
-    # Check that all requested traces were found and belong to the authorized experiment.
-    # Fail-closed: reject if any requested trace_id is missing or in a different experiment.
-    returned_ids = {trace_info.trace_id for trace_info in trace_infos}
-    requested_ids = set(trace_ids)
-    if returned_ids != requested_ids:
-        # Some requested traces were not found
-        raise MlflowException(
-            "Not all requested traces could be accessed.",
-            error_code=PERMISSION_DENIED,
-        )
 
     for trace_info in trace_infos:
         if str(trace_info.experiment_id) != str(experiment_id):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4688,6 +4688,15 @@ def test_invoke_registered_scorer_resolves_exact_version(mock_tracking_store):
     serialized_scorer = json.dumps(Completeness(name="test_judge").model_dump())
     registered_scorer = mock.MagicMock(serialized_scorer=serialized_scorer)
     mock_tracking_store.get_scorer.return_value = registered_scorer
+    # The requested traces must belong to the authorized experiment (GHSA-6c27 trace-binding).
+    mock_tracking_store.batch_get_trace_infos.return_value = [
+        TraceInfo(
+            trace_id="trace1",
+            trace_location=EntityTraceLocation.from_experiment_id("exp-123"),
+            request_time=0,
+            state=TraceState.OK,
+        )
+    ]
 
     with mock.patch("mlflow.server.jobs.submit_job") as mock_submit:
         mock_submit.return_value.job_id = "test-job-123"

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4644,6 +4644,21 @@ def test_invoke_scorer_submits_jobs(mock_tracking_store):
         },
     })
 
+    # Mock traces that belong to the authorized experiment
+    trace1 = TraceInfo(
+        trace_id="trace1",
+        trace_location=EntityTraceLocation.from_experiment_id("exp-123"),
+        request_time=1234567890,
+        state=TraceState.OK,
+    )
+    trace2 = TraceInfo(
+        trace_id="trace2",
+        trace_location=EntityTraceLocation.from_experiment_id("exp-123"),
+        request_time=1234567891,
+        state=TraceState.OK,
+    )
+    mock_tracking_store.batch_get_trace_infos.return_value = [trace1, trace2]
+
     with mock.patch("mlflow.server.jobs.submit_job") as mock_submit:
         mock_job = mock.MagicMock()
         mock_job.job_id = "test-job-123"
@@ -4665,6 +4680,7 @@ def test_invoke_scorer_submits_jobs(mock_tracking_store):
             assert data["jobs"][0]["job_id"] == "test-job-123"
             assert data["jobs"][0]["trace_ids"] == ["trace1", "trace2"]
 
+        mock_tracking_store.batch_get_trace_infos.assert_called_once_with(["trace1", "trace2"])
         mock_submit.assert_called_once()
 
 
@@ -4746,6 +4762,262 @@ def test_invoke_scorer_rejects_invalid_json():
         )
     assert response.status_code == 400
     assert "serialized_scorer must be valid JSON" in response.get_json()["message"]
+
+
+def test_invoke_scorer_rejects_cross_experiment_traces(mock_tracking_store):
+    """Verify that traces from other experiments cannot be scored via invoke_scorer.
+
+    This is the key regression test for GHSA-6c27-cp6h-c66m: an authenticated user
+    who owns experiment A should not be able to invoke a scorer on traces from
+    experiment B, even if they supply experiment_id=A and trace_ids from B.
+    """
+    serialized_scorer = json.dumps({
+        "name": "test_judge",
+        "aggregations": [],
+        "description": None,
+        "is_session_level_scorer": False,
+        "mlflow_version": mlflow.__version__,
+        "serialization_version": 1,
+        "builtin_scorer_class": None,
+        "builtin_scorer_pydantic_data": None,
+        "call_source": None,
+        "call_signature": None,
+        "original_func_name": None,
+        "instructions_judge_pydantic_data": {
+            "instructions": "Test: {{ inputs }}",
+            "model": "openai:/gpt-4",
+            "feedback_value_type": {
+                "enum": ["Yes", "No"],
+                "title": "Result",
+                "type": "string",
+            },
+        },
+    })
+
+    # Mock a trace that belongs to a different experiment
+    victim_trace = TraceInfo(
+        trace_id="victim-trace-1",
+        trace_location=EntityTraceLocation.from_experiment_id("exp-999"),
+        request_time=1234567890,
+        state=TraceState.OK,
+    )
+
+    mock_tracking_store.batch_get_trace_infos.return_value = [victim_trace]
+
+    with mock.patch("mlflow.server.jobs.submit_job") as mock_submit:
+        with app.test_client() as c:
+            response = c.post(
+                "/ajax-api/3.0/mlflow/scorer/invoke",
+                json={
+                    "experiment_id": "exp-123",  # Attacker's experiment
+                    "serialized_scorer": serialized_scorer,
+                    "trace_ids": ["victim-trace-1"],  # Trace from different experiment
+                },
+            )
+        # Should be rejected with 403 (PERMISSION_DENIED)
+        assert response.status_code == 403
+        data = response.get_json()
+        # Verify that the error message does not leak the victim's experiment_id
+        assert "experiment_id" not in data["message"].lower()
+        # Verify that job was not submitted
+        mock_submit.assert_not_called()
+
+
+def test_invoke_scorer_rejects_missing_trace_batch_path(mock_tracking_store):
+    """Verify that missing traces via batch_get_trace_infos are rejected with generic 403.
+
+    When batch_get_trace_infos returns a partial list (missing traces just absent),
+    the set-comparison should catch it and reject with a generic 403 that doesn't leak
+    the trace_id or experiment_id.
+    """
+    serialized_scorer = json.dumps({
+        "name": "test_judge",
+        "aggregations": [],
+        "description": None,
+        "is_session_level_scorer": False,
+        "mlflow_version": mlflow.__version__,
+        "serialization_version": 1,
+        "builtin_scorer_class": None,
+        "builtin_scorer_pydantic_data": None,
+        "call_source": None,
+        "call_signature": None,
+        "original_func_name": None,
+        "instructions_judge_pydantic_data": {
+            "instructions": "Test: {{ inputs }}",
+            "model": "openai:/gpt-4",
+            "feedback_value_type": {
+                "enum": ["Yes", "No"],
+                "title": "Result",
+                "type": "string",
+            },
+        },
+    })
+
+    # Mock batch_get_trace_infos to return only one trace, but request two
+    existing_trace = TraceInfo(
+        trace_id="trace-1",
+        trace_location=EntityTraceLocation.from_experiment_id("exp-123"),
+        request_time=1234567890,
+        state=TraceState.OK,
+    )
+    mock_tracking_store.batch_get_trace_infos.return_value = [existing_trace]
+
+    with mock.patch("mlflow.server.jobs.submit_job") as mock_submit:
+        with app.test_client() as c:
+            response = c.post(
+                "/ajax-api/3.0/mlflow/scorer/invoke",
+                json={
+                    "experiment_id": "exp-123",
+                    "serialized_scorer": serialized_scorer,
+                    "trace_ids": ["trace-1", "trace-2"],  # Request two, get one back
+                },
+            )
+        # Should be rejected with 403 (PERMISSION_DENIED)
+        assert response.status_code == 403
+        data = response.get_json()
+        # Verify generic message without trace_id or experiment_id leak
+        assert "trace" not in data["message"].lower() or "not all" in data["message"].lower()
+        assert "experiment_id" not in data["message"].lower()
+        # Verify that job was not submitted
+        mock_submit.assert_not_called()
+
+
+def test_invoke_scorer_rejects_missing_trace_fallback_path(mock_tracking_store):
+    """Verify that missing traces via fallback get_trace_info are rejected with generic 403.
+
+    When get_trace_info raises RESOURCE_DOES_NOT_EXIST (because batch_get_trace_infos
+    is not implemented), the fallback should catch it and treat the trace as missing
+    (omit from trace_infos list), so the set-comparison catches it and returns generic 403.
+    """
+    serialized_scorer = json.dumps({
+        "name": "test_judge",
+        "aggregations": [],
+        "description": None,
+        "is_session_level_scorer": False,
+        "mlflow_version": mlflow.__version__,
+        "serialization_version": 1,
+        "builtin_scorer_class": None,
+        "builtin_scorer_pydantic_data": None,
+        "call_source": None,
+        "call_signature": None,
+        "original_func_name": None,
+        "instructions_judge_pydantic_data": {
+            "instructions": "Test: {{ inputs }}",
+            "model": "openai:/gpt-4",
+            "feedback_value_type": {
+                "enum": ["Yes", "No"],
+                "title": "Result",
+                "type": "string",
+            },
+        },
+    })
+
+    from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+
+    # Set batch_get_trace_infos to raise MlflowNotImplementedException, triggering fallback
+    mock_tracking_store.batch_get_trace_infos.side_effect = MlflowNotImplementedException(
+        "Not implemented"
+    )
+
+    # Mock get_trace_info to raise RESOURCE_DOES_NOT_EXIST for missing trace
+    def get_trace_side_effect(trace_id):
+        if trace_id == "trace-1":
+            return TraceInfo(
+                trace_id="trace-1",
+                trace_location=EntityTraceLocation.from_experiment_id("exp-123"),
+                request_time=1234567890,
+                state=TraceState.OK,
+            )
+        elif trace_id == "trace-missing":
+            # Simulate a missing trace
+            raise MlflowException(
+                f"Trace {trace_id} not found",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
+        raise Exception(f"Unexpected trace_id: {trace_id}")
+
+    mock_tracking_store.get_trace_info.side_effect = get_trace_side_effect
+
+    with mock.patch("mlflow.server.jobs.submit_job") as mock_submit:
+        with app.test_client() as c:
+            response = c.post(
+                "/ajax-api/3.0/mlflow/scorer/invoke",
+                json={
+                    "experiment_id": "exp-123",
+                    "serialized_scorer": serialized_scorer,
+                    "trace_ids": ["trace-1", "trace-missing"],
+                },
+            )
+        # Should be rejected with 403 (PERMISSION_DENIED)
+        assert response.status_code == 403
+        data = response.get_json()
+        # Verify generic message, no trace_id or experiment_id leak
+        assert "trace-missing" not in data["message"]
+        assert "experiment_id" not in data["message"].lower()
+        # Verify that job was not submitted
+        mock_submit.assert_not_called()
+
+
+def test_invoke_scorer_rejects_foreign_trace_fallback_path(mock_tracking_store):
+    """Verify cross-experiment traces via fallback get_trace_info are rejected with generic 403.
+
+    When the fallback path fetches a trace via get_trace_info that belongs to a different
+    experiment, it should be rejected with generic 403 (same as batch path).
+    """
+    serialized_scorer = json.dumps({
+        "name": "test_judge",
+        "aggregations": [],
+        "description": None,
+        "is_session_level_scorer": False,
+        "mlflow_version": mlflow.__version__,
+        "serialization_version": 1,
+        "builtin_scorer_class": None,
+        "builtin_scorer_pydantic_data": None,
+        "call_source": None,
+        "call_signature": None,
+        "original_func_name": None,
+        "instructions_judge_pydantic_data": {
+            "instructions": "Test: {{ inputs }}",
+            "model": "openai:/gpt-4",
+            "feedback_value_type": {
+                "enum": ["Yes", "No"],
+                "title": "Result",
+                "type": "string",
+            },
+        },
+    })
+
+    # Set batch_get_trace_infos to raise MlflowNotImplementedException, triggering fallback
+    mock_tracking_store.batch_get_trace_infos.side_effect = MlflowNotImplementedException(
+        "Not implemented"
+    )
+
+    # Mock get_trace_info to return a trace from a different experiment
+    foreign_trace = TraceInfo(
+        trace_id="foreign-trace",
+        trace_location=EntityTraceLocation.from_experiment_id("exp-999"),  # Different experiment
+        request_time=1234567890,
+        state=TraceState.OK,
+    )
+    mock_tracking_store.get_trace_info.return_value = foreign_trace
+
+    with mock.patch("mlflow.server.jobs.submit_job") as mock_submit:
+        with app.test_client() as c:
+            response = c.post(
+                "/ajax-api/3.0/mlflow/scorer/invoke",
+                json={
+                    "experiment_id": "exp-123",  # Attacker's experiment
+                    "serialized_scorer": serialized_scorer,
+                    "trace_ids": ["foreign-trace"],
+                },
+            )
+        # Should be rejected with 403 (PERMISSION_DENIED)
+        assert response.status_code == 403
+        data = response.get_json()
+        # Verify generic message, no experiment_id leak
+        assert "experiment_id" not in data["message"].lower()
+        # Verify that job was not submitted
+        mock_submit.assert_not_called()
 
 
 def test_get_ui_telemetry_handler(

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4682,6 +4682,7 @@ def test_invoke_scorer_submits_jobs(mock_tracking_store):
 
         mock_tracking_store.batch_get_trace_infos.assert_called_once_with(["trace1", "trace2"])
         mock_submit.assert_called_once()
+        assert mock_submit.call_args.kwargs["params"]["experiment_id"] == "exp-123"
 
 
 def test_invoke_registered_scorer_resolves_exact_version(mock_tracking_store):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4685,6 +4685,55 @@ def test_invoke_scorer_submits_jobs(mock_tracking_store):
         assert mock_submit.call_args.kwargs["params"]["experiment_id"] == "exp-123"
 
 
+def test_invoke_scorer_deduplicates_trace_ids(mock_tracking_store):
+    serialized_scorer = json.dumps({
+        "name": "test_judge",
+        "aggregations": [],
+        "description": None,
+        "is_session_level_scorer": False,
+        "mlflow_version": mlflow.__version__,
+        "serialization_version": 1,
+        "builtin_scorer_class": None,
+        "builtin_scorer_pydantic_data": None,
+        "call_source": None,
+        "call_signature": None,
+        "original_func_name": None,
+        "instructions_judge_pydantic_data": {
+            "instructions": "Test: {{ inputs }}",
+            "model": "openai:/gpt-4",
+            "feedback_value_type": {
+                "enum": ["Yes", "No"],
+                "title": "Result",
+                "type": "string",
+            },
+        },
+    })
+
+    trace1 = TraceInfo(
+        trace_id="trace1",
+        trace_location=EntityTraceLocation.from_experiment_id("exp-123"),
+        request_time=1234567890,
+        state=TraceState.OK,
+    )
+    mock_tracking_store.batch_get_trace_infos.return_value = [trace1]
+
+    with mock.patch("mlflow.server.jobs.submit_job") as mock_submit:
+        mock_submit.return_value = mock.MagicMock(job_id="test-job-123")
+        with app.test_client() as c:
+            response = c.post(
+                "/ajax-api/3.0/mlflow/scorer/invoke",
+                json={
+                    "experiment_id": "exp-123",
+                    "serialized_scorer": serialized_scorer,
+                    "trace_ids": ["trace1", "trace1"],  # duplicate
+                },
+            )
+        assert response.status_code == 200
+        # Duplicate is collapsed before fetch and before scoring: fetched and scored once.
+        mock_tracking_store.batch_get_trace_infos.assert_called_once_with(["trace1"])
+        assert response.get_json()["jobs"][0]["trace_ids"] == ["trace1"]
+
+
 def test_invoke_registered_scorer_resolves_exact_version(mock_tracking_store):
     serialized_scorer = json.dumps(Completeness(name="test_judge").model_dump())
     registered_scorer = mock.MagicMock(serialized_scorer=serialized_scorer)
@@ -4833,12 +4882,13 @@ def test_invoke_scorer_rejects_cross_experiment_traces(mock_tracking_store):
         mock_submit.assert_not_called()
 
 
-def test_invoke_scorer_rejects_missing_trace_batch_path(mock_tracking_store):
-    """Verify that missing traces via batch_get_trace_infos are rejected with generic 403.
+def test_invoke_scorer_fallback_drops_missing_trace(mock_tracking_store):
+    """A missing trace on the fallback path is dropped, not surfaced as a 404.
 
-    When batch_get_trace_infos returns a partial list (missing traces just absent),
-    the set-comparison should catch it and reject with a generic 403 that doesn't leak
-    the trace_id or experiment_id.
+    When batch_get_trace_infos is unimplemented, the per-trace fallback swallows
+    RESOURCE_DOES_NOT_EXIST so a missing trace is simply absent from the ownership check
+    (rather than leaking the trace_id via a 404). The request still submits the job; the
+    missing trace fails downstream in the job, matching the batch path.
     """
     serialized_scorer = json.dumps({
         "name": "test_judge",
@@ -4863,73 +4913,10 @@ def test_invoke_scorer_rejects_missing_trace_batch_path(mock_tracking_store):
         },
     })
 
-    # Mock batch_get_trace_infos to return only one trace, but request two
-    existing_trace = TraceInfo(
-        trace_id="trace-1",
-        trace_location=EntityTraceLocation.from_experiment_id("exp-123"),
-        request_time=1234567890,
-        state=TraceState.OK,
-    )
-    mock_tracking_store.batch_get_trace_infos.return_value = [existing_trace]
-
-    with mock.patch("mlflow.server.jobs.submit_job") as mock_submit:
-        with app.test_client() as c:
-            response = c.post(
-                "/ajax-api/3.0/mlflow/scorer/invoke",
-                json={
-                    "experiment_id": "exp-123",
-                    "serialized_scorer": serialized_scorer,
-                    "trace_ids": ["trace-1", "trace-2"],  # Request two, get one back
-                },
-            )
-        # Should be rejected with 403 (PERMISSION_DENIED)
-        assert response.status_code == 403
-        data = response.get_json()
-        # Verify generic message without trace_id or experiment_id leak
-        assert "trace" not in data["message"].lower() or "not all" in data["message"].lower()
-        assert "experiment_id" not in data["message"].lower()
-        # Verify that job was not submitted
-        mock_submit.assert_not_called()
-
-
-def test_invoke_scorer_rejects_missing_trace_fallback_path(mock_tracking_store):
-    """Verify that missing traces via fallback get_trace_info are rejected with generic 403.
-
-    When get_trace_info raises RESOURCE_DOES_NOT_EXIST (because batch_get_trace_infos
-    is not implemented), the fallback should catch it and treat the trace as missing
-    (omit from trace_infos list), so the set-comparison catches it and returns generic 403.
-    """
-    serialized_scorer = json.dumps({
-        "name": "test_judge",
-        "aggregations": [],
-        "description": None,
-        "is_session_level_scorer": False,
-        "mlflow_version": mlflow.__version__,
-        "serialization_version": 1,
-        "builtin_scorer_class": None,
-        "builtin_scorer_pydantic_data": None,
-        "call_source": None,
-        "call_signature": None,
-        "original_func_name": None,
-        "instructions_judge_pydantic_data": {
-            "instructions": "Test: {{ inputs }}",
-            "model": "openai:/gpt-4",
-            "feedback_value_type": {
-                "enum": ["Yes", "No"],
-                "title": "Result",
-                "type": "string",
-            },
-        },
-    })
-
-    from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
-
-    # Set batch_get_trace_infos to raise MlflowNotImplementedException, triggering fallback
     mock_tracking_store.batch_get_trace_infos.side_effect = MlflowNotImplementedException(
         "Not implemented"
     )
 
-    # Mock get_trace_info to raise RESOURCE_DOES_NOT_EXIST for missing trace
     def get_trace_side_effect(trace_id):
         if trace_id == "trace-1":
             return TraceInfo(
@@ -4938,17 +4925,18 @@ def test_invoke_scorer_rejects_missing_trace_fallback_path(mock_tracking_store):
                 request_time=1234567890,
                 state=TraceState.OK,
             )
-        elif trace_id == "trace-missing":
-            # Simulate a missing trace
-            raise MlflowException(
-                f"Trace {trace_id} not found",
-                error_code=RESOURCE_DOES_NOT_EXIST,
-            )
-        raise Exception(f"Unexpected trace_id: {trace_id}")
+        raise MlflowException(
+            f"Trace {trace_id} not found",
+            error_code=RESOURCE_DOES_NOT_EXIST,
+        )
 
     mock_tracking_store.get_trace_info.side_effect = get_trace_side_effect
 
     with mock.patch("mlflow.server.jobs.submit_job") as mock_submit:
+        mock_job = mock.MagicMock()
+        mock_job.job_id = "test-job-123"
+        mock_submit.return_value = mock_job
+
         with app.test_client() as c:
             response = c.post(
                 "/ajax-api/3.0/mlflow/scorer/invoke",
@@ -4958,14 +4946,12 @@ def test_invoke_scorer_rejects_missing_trace_fallback_path(mock_tracking_store):
                     "trace_ids": ["trace-1", "trace-missing"],
                 },
             )
-        # Should be rejected with 403 (PERMISSION_DENIED)
-        assert response.status_code == 403
+        assert response.status_code == 200
+        mock_submit.assert_called_once()
+        # The missing trace is forwarded to the job (which reports it as not found), not
+        # rejected at request time.
         data = response.get_json()
-        # Verify generic message, no trace_id or experiment_id leak
-        assert "trace-missing" not in data["message"]
-        assert "experiment_id" not in data["message"].lower()
-        # Verify that job was not submitted
-        mock_submit.assert_not_called()
+        assert data["jobs"][0]["trace_ids"] == ["trace-1", "trace-missing"]
 
 
 def test_invoke_scorer_rejects_foreign_trace_fallback_path(mock_tracking_store):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -4876,8 +4876,9 @@ def test_invoke_scorer_rejects_cross_experiment_traces(mock_tracking_store):
         # Should be rejected with 403 (PERMISSION_DENIED)
         assert response.status_code == 403
         data = response.get_json()
-        # Verify that the error message does not leak the victim's experiment_id
-        assert "experiment_id" not in data["message"].lower()
+        # Generic message that does not reveal the victim's experiment_id or that the trace exists.
+        assert data["message"] == "Not all requested traces could be accessed."
+        assert "exp-999" not in data["message"]
         # Verify that job was not submitted
         mock_submit.assert_not_called()
 
@@ -5010,8 +5011,9 @@ def test_invoke_scorer_rejects_foreign_trace_fallback_path(mock_tracking_store):
         # Should be rejected with 403 (PERMISSION_DENIED)
         assert response.status_code == 403
         data = response.get_json()
-        # Verify generic message, no experiment_id leak
-        assert "experiment_id" not in data["message"].lower()
+        # Generic message that does not reveal the victim's experiment_id or that the trace exists.
+        assert data["message"] == "Not all requested traces could be accessed."
+        assert "exp-999" not in data["message"]
         # Verify that job was not submitted
         mock_submit.assert_not_called()
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to GHSA-6c27-cp6h-c66m (private security advisory).

### What changes are proposed in this pull request?

Fixes a missing-authorization / broken-object-authorization issue on `POST /ajax-api/3.0/mlflow/scorer/invoke`, where any authenticated user could run scorers against, and write assessments to, traces in experiments they cannot access.

**Part A - authorize the endpoint** (`mlflow/server/auth/__init__.py`): the route was mapped to the no-op `validate_gateway_proxy`; it now uses `validate_can_update_experiment`, matching the sibling `INVOKE_ISSUE_DETECTION` / `INVOKE_GENAI_EVALUATE` endpoints (gates on UPDATE for the request's `experiment_id`).

**Part B - bind traces to the authorized experiment** (`mlflow/server/handlers.py`): gating on `experiment_id` alone is insufficient, because a user auto-gets `MANAGE` on an experiment they create, so they could name their own experiment to pass the gate and still supply another user's `trace_ids`. `_invoke_scorer_handler` now resolves the requested traces (`batch_get_trace_infos`, with a per-trace `get_trace_info` fallback for stores that do not implement it) and rejects the request with a fail-closed `PERMISSION_DENIED` (403), using a generic message, if any requested trace resolves to a different experiment than the authorized one. Traces that do not exist are not rejected here; they are left to fail downstream in the scorer job (reported as `Traces not found`), which preserves the existing contract for missing traces. Duplicate `trace_ids` are de-duplicated first so a repeated id is not fetched or scored twice.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`test_invoke_scorer_rejects_cross_experiment_traces` and `test_invoke_scorer_rejects_foreign_trace_fallback_path` verify a caller who owns experiment A cannot score traces from experiment B (batch and fallback paths); `test_invoke_scorer_fallback_drops_missing_trace` locks in that a missing trace is forwarded to the job rather than surfaced as a 404; `test_invoke_scorer_deduplicates_trace_ids` covers de-duplication; `test_invoke_scorer_submits_jobs` covers the legitimate path and asserts the trace-info lookup and the experiment forwarded to the job.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Reported by @Swissguy-ShelbyCore via GitHub Security Advisory GHSA-6c27-cp6h-c66m.
