### PR TITLE
Enforce password policy on the basic-auth password-update path (GHSA-v67f-7g57-fjhv)

### DIFF
--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -215,6 +215,7 @@ class SqlAlchemyStore:
         with self.ManagedSessionMaker(read_only=False) as session:
             user = self._get_user(session, username)
             if password is not None:
+                _validate_password(password)
                 pwhash = generate_password_hash(password)
                 user.password_hash = pwhash
             if is_admin is not None:

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -840,9 +840,7 @@ def _validate_username(username):
 
 def _validate_password(password) -> None:
     if password is None or len(password) < 12:
-        raise MlflowException.invalid_parameter_value(
-            "Password must be a string longer than 12 characters."
-        )
+        raise MlflowException.invalid_parameter_value("Password must be at least 12 characters.")
 
 
 def _validate_trace_tag(key, value):

--- a/tests/server/auth/test_sqlalchemy_store.py
+++ b/tests/server/auth/test_sqlalchemy_store.py
@@ -138,20 +138,21 @@ def test_update_user(store):
 
 def test_update_user_password_validation(store):
     username = random_str()
-    password = random_str()
+    password = random_str(size=20)
     _user_maker(store, username, password)
 
     with pytest.raises(
-        MlflowException, match=r"Password must be a string longer than 12 characters"
+        MlflowException, match=r"Password must be at least 12 characters"
     ) as exception_context:
         store.update_user(username, password="short")
     assert exception_context.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
     # The rejected update must leave the stored password unchanged (validation runs before hashing).
     assert store.authenticate_user(username, password)
 
-    new_password = random_str()
+    new_password = "new-" + random_str(size=20)
     store.update_user(username, password=new_password)
     assert store.authenticate_user(username, new_password)
+    assert not store.authenticate_user(username, password)
 
 
 def test_delete_user(store):

--- a/tests/server/auth/test_sqlalchemy_store.py
+++ b/tests/server/auth/test_sqlalchemy_store.py
@@ -141,14 +141,14 @@ def test_update_user_password_validation(store):
     password = random_str()
     _user_maker(store, username, password)
 
-    # Short password should be rejected
     with pytest.raises(
         MlflowException, match=r"Password must be a string longer than 12 characters"
     ) as exception_context:
         store.update_user(username, password="short")
     assert exception_context.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+    # The rejected update must leave the stored password unchanged (validation runs before hashing).
+    assert store.authenticate_user(username, password)
 
-    # Valid password should succeed
     new_password = random_str()
     store.update_user(username, password=new_password)
     assert store.authenticate_user(username, new_password)

--- a/tests/server/auth/test_sqlalchemy_store.py
+++ b/tests/server/auth/test_sqlalchemy_store.py
@@ -136,6 +136,24 @@ def test_update_user(store):
     assert not store.get_user(username1).is_admin
 
 
+def test_update_user_password_validation(store):
+    username = random_str()
+    password = random_str()
+    _user_maker(store, username, password)
+
+    # Short password should be rejected
+    with pytest.raises(
+        MlflowException, match=r"Password must be a string longer than 12 characters"
+    ) as exception_context:
+        store.update_user(username, password="short")
+    assert exception_context.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+    # Valid password should succeed
+    new_password = random_str()
+    store.update_user(username, password=new_password)
+    assert store.authenticate_user(username, new_password)
+
+
 def test_delete_user(store):
     username1 = random_str()
     password1 = random_str()


### PR DESCRIPTION
### Related Issues/PRs

Relates to GHSA-v67f-7g57-fjhv (private security advisory).

### What changes are proposed in this pull request?

The basic-auth password-strength policy (`_validate_password`, minimum length 12) is enforced when a user is created (`SqlAlchemyStore.create_user`) but was **not** enforced on the password-update path, so a user (or admin) could set a password shorter than the policy allows via `update_user` / `update_user_password`.

This adds `_validate_password(password)` inside `SqlAlchemyStore.update_user`'s `if password is not None:` block, before hashing, mirroring `create_user`. `update_user` is the single store-level choke point for password changes (all REST, signup, bootstrap, and admin paths route through it), so the policy now applies uniformly. `is_admin`-only updates (no password) are unaffected.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`test_update_user_password_validation` asserts a sub-policy password is rejected with `INVALID_PARAMETER_VALUE`, that the rejected update leaves the stored password unchanged (validation runs before hashing), and that a valid update still succeeds.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

Reported by @Het-Kalariya via GitHub Security Advisory GHSA-v67f-7g57-fjhv.
