### PR TITLE
Add a source logged model link to the model version page

### DIFF
--- a/docs/docs/classic-ml/model-registry/workflow.mdx
+++ b/docs/docs/classic-ml/model-registry/workflow.mdx
@@ -67,7 +67,7 @@ To learn more about a specific model version, navigate to the details page for t
 
 ![](/images/oss_registry_5_version.png)
 
-In this page, you can inspect model version details like the model signature, MLflow source run, and creation timestamp. You can also view and configure the version's aliases,
+In this page, you can inspect model version details like the model signature, MLflow source run, source logged model, and creation timestamp. You can also view and configure the version's aliases,
 tags, and description.
 
 ## API Workflow

--- a/mlflow/server/js/scripts/componentId-registry.js
+++ b/mlflow/server/js/scripts/componentId-registry.js
@@ -1786,6 +1786,7 @@ module.exports = {
   "mlflow.model_registry.version_view.breadcrumb_model_link": "",
   "mlflow.model_registry.version_view.breadcrumb_registered_models_link": "",
   "mlflow.model_registry.version_view.copied_from_link": "",
+  "mlflow.model_registry.version_view.source_model_link": "",
   "mlflow.model_registry.version_view.source_run_link": "",
 
   // -- mlflow.model_trace_explorer --

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1287,6 +1287,10 @@
     "defaultMessage": "No traces yet",
     "description": "Title for the traces empty state"
   },
+  "3LhJyC": {
+    "defaultMessage": "Loading source model",
+    "description": "Screen reader label shown while the source logged model of a model version is loading"
+  },
   "3MZ6H+": {
     "defaultMessage": "Submit",
     "description": "Label for the submit button on the playground page that runs the chat completion request"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -5643,6 +5643,10 @@
     "defaultMessage": "To disable or enable this display, call {disableFunction} or {enableFunction} and re-run the cell",
     "description": "Content in an info popover that instructs the user on how to disable the display. The disable and enable functions are code snippets with the real function names"
   },
+  "LEQdst": {
+    "defaultMessage": "Source Model",
+    "description": "Label name for the source logged model metadata in model version page"
+  },
   "LEiN8m": {
     "defaultMessage": "Tags",
     "description": "Experiment page > group by runs control > tags section label"

--- a/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, test } from '@jest/globals';
+import { rest } from 'msw';
+import { setupServer } from '../../common/utils/setup-msw';
+import { renderWithIntl, screen, waitFor } from '../../common/utils/TestUtils.react18';
+import { MemoryRouter } from '../../common/utils/RoutingUtils';
+import { QueryClient, QueryClientProvider } from '../../common/utils/reactQueryHooks';
+import Routes from '../../experiment-tracking/routes';
+import { ModelVersionSourceModelLink } from './ModelVersionSourceModelLink';
+
+const loggedModelId = 'm-1bc96c322a8441c7a5af8de3df2cc4ce';
+
+describe('ModelVersionSourceModelLink', () => {
+  const server = setupServer();
+
+  const renderComponent = () => {
+    const queryClient = new QueryClient();
+    renderWithIntl(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ModelVersionSourceModelLink loggedModelId={loggedModelId} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    return queryClient;
+  };
+
+  test('links to the logged model page using its name', async () => {
+    server.use(
+      rest.get(`/ajax-api/2.0/mlflow/logged-models/${loggedModelId}`, (req, res, ctx) =>
+        res(ctx.json({ model: { info: { model_id: loggedModelId, experiment_id: '123', name: 'iris_model' } } })),
+      ),
+    );
+    renderComponent();
+
+    const link = await screen.findByTestId('source-model-link');
+    expect(link).toHaveTextContent('iris_model');
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringContaining(Routes.getExperimentLoggedModelDetailsPageRoute('123', loggedModelId)),
+    );
+  });
+
+  test('falls back to the plain model ID when the logged model cannot be fetched', async () => {
+    server.use(
+      rest.get(`/ajax-api/2.0/mlflow/logged-models/${loggedModelId}`, (req, res, ctx) =>
+        res(ctx.status(404), ctx.json({ error_code: 'RESOURCE_DOES_NOT_EXIST' })),
+      ),
+    );
+    const queryClient = renderComponent();
+
+    // The plain ID is also shown while loading, so wait for the request to fail before asserting
+    await waitFor(() => expect(queryClient.getQueryCache().getAll()[0]?.state.status).toBe('error'));
+    expect(screen.getByTestId('source-model-id')).toHaveTextContent(loggedModelId);
+    expect(screen.queryByTestId('source-model-link')).not.toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.test.tsx
@@ -1,36 +1,41 @@
 import { describe, expect, test } from '@jest/globals';
 import { rest } from 'msw';
 import { setupServer } from '../../common/utils/setup-msw';
-import { renderWithIntl, screen, waitFor } from '../../common/utils/TestUtils.react18';
+import { renderWithIntl, screen } from '../../common/utils/TestUtils.react18';
 import { MemoryRouter } from '../../common/utils/RoutingUtils';
 import { QueryClient, QueryClientProvider } from '../../common/utils/reactQueryHooks';
 import Routes from '../../experiment-tracking/routes';
 import { ModelVersionSourceModelLink } from './ModelVersionSourceModelLink';
 
 const loggedModelId = 'm-1bc96c322a8441c7a5af8de3df2cc4ce';
+const loggedModelUrl = `/ajax-api/2.0/mlflow/logged-models/${loggedModelId}`;
 
 describe('ModelVersionSourceModelLink', () => {
   const server = setupServer();
 
-  const renderComponent = () => {
-    const queryClient = new QueryClient();
+  const renderComponent = () =>
     renderWithIntl(
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={new QueryClient()}>
         <MemoryRouter>
           <ModelVersionSourceModelLink loggedModelId={loggedModelId} />
         </MemoryRouter>
       </QueryClientProvider>,
     );
-    return queryClient;
-  };
 
-  test('links to the logged model page using its name', async () => {
+  test('shows a skeleton while loading, then links to the logged model page using its name', async () => {
     server.use(
-      rest.get(`/ajax-api/2.0/mlflow/logged-models/${loggedModelId}`, (req, res, ctx) =>
-        res(ctx.json({ model: { info: { model_id: loggedModelId, experiment_id: '123', name: 'iris_model' } } })),
+      rest.get(loggedModelUrl, (req, res, ctx) =>
+        res(
+          ctx.delay(100),
+          ctx.json({ model: { info: { model_id: loggedModelId, experiment_id: '123', name: 'iris_model' } } }),
+        ),
       ),
     );
     renderComponent();
+
+    expect(screen.getByTestId('source-model-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('source-model-id')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('source-model-link')).not.toBeInTheDocument();
 
     const link = await screen.findByTestId('source-model-link');
     expect(link).toHaveTextContent('iris_model');
@@ -38,19 +43,30 @@ describe('ModelVersionSourceModelLink', () => {
       'href',
       expect.stringContaining(Routes.getExperimentLoggedModelDetailsPageRoute('123', loggedModelId)),
     );
+    expect(screen.queryByTestId('source-model-loading')).not.toBeInTheDocument();
   });
 
   test('falls back to the plain model ID when the logged model cannot be fetched', async () => {
     server.use(
-      rest.get(`/ajax-api/2.0/mlflow/logged-models/${loggedModelId}`, (req, res, ctx) =>
+      rest.get(loggedModelUrl, (req, res, ctx) =>
         res(ctx.status(404), ctx.json({ error_code: 'RESOURCE_DOES_NOT_EXIST' })),
       ),
     );
-    const queryClient = renderComponent();
+    renderComponent();
 
-    // The plain ID is also shown while loading, so wait for the request to fail before asserting
-    await waitFor(() => expect(queryClient.getQueryCache().getAll()[0]?.state.status).toBe('error'));
-    expect(screen.getByTestId('source-model-id')).toHaveTextContent(loggedModelId);
+    expect(await screen.findByTestId('source-model-id')).toHaveTextContent(loggedModelId);
+    expect(screen.queryByTestId('source-model-link')).not.toBeInTheDocument();
+  });
+
+  test('falls back to the plain model ID when the logged model has no experiment ID', async () => {
+    server.use(
+      rest.get(loggedModelUrl, (req, res, ctx) =>
+        res(ctx.json({ model: { info: { model_id: loggedModelId, name: 'iris_model' } } })),
+      ),
+    );
+    renderComponent();
+
+    expect(await screen.findByTestId('source-model-id')).toHaveTextContent(loggedModelId);
     expect(screen.queryByTestId('source-model-link')).not.toBeInTheDocument();
   });
 });

--- a/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.test.tsx
@@ -46,6 +46,17 @@ describe('ModelVersionSourceModelLink', () => {
     expect(screen.queryByTestId('source-model-loading')).not.toBeInTheDocument();
   });
 
+  test('uses the model ID as the link text when the logged model has an empty name', async () => {
+    server.use(
+      rest.get(loggedModelUrl, (req, res, ctx) =>
+        res(ctx.json({ model: { info: { model_id: loggedModelId, experiment_id: '123', name: '' } } })),
+      ),
+    );
+    renderComponent();
+
+    expect(await screen.findByTestId('source-model-link')).toHaveTextContent(loggedModelId);
+  });
+
   test('falls back to the plain model ID when the logged model cannot be fetched', async () => {
     server.use(
       rest.get(loggedModelUrl, (req, res, ctx) =>

--- a/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.tsx
@@ -1,0 +1,23 @@
+import { Link } from '../../common/utils/RoutingUtils';
+import { useGetLoggedModelQuery } from '../../experiment-tracking/hooks/logged-models/useGetLoggedModelQuery';
+import Routes from '../../experiment-tracking/routes';
+
+/**
+ * Link to the logged model that a model version was registered from; plain model ID until it resolves.
+ */
+export const ModelVersionSourceModelLink = ({ loggedModelId }: { loggedModelId: string }) => {
+  const { data } = useGetLoggedModelQuery({ loggedModelId });
+  const experimentId = data?.info?.experiment_id;
+  if (!experimentId) {
+    return <span data-testid="source-model-id">{loggedModelId}</span>;
+  }
+  return (
+    <Link
+      componentId="mlflow.model_registry.version_view.source_model_link"
+      data-testid="source-model-link"
+      to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, loggedModelId)}
+    >
+      {data?.info?.name ?? loggedModelId}
+    </Link>
+  );
+};

--- a/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.tsx
@@ -36,7 +36,7 @@ export const ModelVersionSourceModelLink = ({ loggedModelId }: { loggedModelId: 
       data-testid="source-model-link"
       to={Routes.getExperimentLoggedModelDetailsPageRoute(experimentId, loggedModelId)}
     >
-      {data?.info?.name ?? loggedModelId}
+      {data?.info?.name || loggedModelId}
     </Link>
   );
 };

--- a/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionSourceModelLink.tsx
@@ -1,16 +1,35 @@
+import { ParagraphSkeleton, Typography } from '@databricks/design-system';
+import { useIntl } from 'react-intl';
 import { Link } from '../../common/utils/RoutingUtils';
 import { useGetLoggedModelQuery } from '../../experiment-tracking/hooks/logged-models/useGetLoggedModelQuery';
 import Routes from '../../experiment-tracking/routes';
 
 /**
- * Link to the logged model that a model version was registered from; plain model ID until it resolves.
+ * Link to the logged model that a model version was registered from.
+ * Falls back to the plain model ID when the logged model cannot be fetched or has no experiment.
  */
 export const ModelVersionSourceModelLink = ({ loggedModelId }: { loggedModelId: string }) => {
-  const { data } = useGetLoggedModelQuery({ loggedModelId });
-  const experimentId = data?.info?.experiment_id;
-  if (!experimentId) {
-    return <span data-testid="source-model-id">{loggedModelId}</span>;
+  const intl = useIntl();
+  const { data, isLoading, error } = useGetLoggedModelQuery({ loggedModelId });
+
+  if (isLoading) {
+    return (
+      <ParagraphSkeleton
+        css={{ width: 80 }}
+        data-testid="source-model-loading"
+        label={intl.formatMessage({
+          defaultMessage: 'Loading source model',
+          description: 'Screen reader label shown while the source logged model of a model version is loading',
+        })}
+      />
+    );
   }
+
+  const experimentId = data?.info?.experiment_id;
+  if (error || !experimentId) {
+    return <Typography.Text data-testid="source-model-id">{loggedModelId}</Typography.Text>;
+  }
+
   return (
     <Link
       componentId="mlflow.model_registry.version_view.source_model_link"

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.enzyme.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.enzyme.test.tsx
@@ -24,8 +24,15 @@ import { mountWithIntl } from '@mlflow/mlflow/src/common/utils/TestUtils.enzyme'
 import { DesignSystemContainer } from '../../common/components/DesignSystemContainer';
 import { Services } from '../services';
 import { shouldShowModelsNextUI } from '../../common/utils/FeatureUtils';
+import { useGetLoggedModelQuery } from '../../experiment-tracking/hooks/logged-models/useGetLoggedModelQuery';
 
 jest.spyOn(Services, 'searchRegisteredModels').mockResolvedValue({});
+jest.mock('../../experiment-tracking/hooks/logged-models/useGetLoggedModelQuery', () => ({
+  ...jest.requireActual<typeof import('../../experiment-tracking/hooks/logged-models/useGetLoggedModelQuery')>(
+    '../../experiment-tracking/hooks/logged-models/useGetLoggedModelQuery',
+  ),
+  useGetLoggedModelQuery: jest.fn(),
+}));
 jest.mock('../../common/utils/FeatureUtils', () => ({
   ...jest.requireActual<typeof import('../../common/utils/FeatureUtils')>('../../common/utils/FeatureUtils'),
   shouldShowModelsNextUI: jest.fn(),
@@ -244,5 +251,35 @@ describe('ModelVersionView', () => {
     expect(wrapper.find('[data-testid="descriptions-item-label"]').at(6).text()).toBe('Stage (deprecated)');
     const linkedRun = wrapper.find('[data-testid="copied-from-link"]').at(0);
     expect(linkedRun.html()).toContain(ModelRegistryRoutes.getModelVersionPageRoute('Model B', '2'));
+  });
+  test('should render source model description when registered from a logged model', () => {
+    jest.mocked(shouldShowModelsNextUI).mockImplementation(() => true);
+    const loggedModelId = 'm-1bc96c322a8441c7a5af8de3df2cc4ce';
+    const props = {
+      ...minimalProps,
+      modelVersion: mockModelVersionDetailed(
+        'Model A',
+        1,
+        Stages.NONE,
+        ModelVersionStatus.READY,
+        [],
+        undefined,
+        'b99a0fc567ae4d32994392c800c0b6ce',
+        'richard@example.com',
+        `models:/${loggedModelId}`,
+      ),
+    };
+    jest.mocked(useGetLoggedModelQuery).mockReturnValue({
+      data: { info: { model_id: loggedModelId, experiment_id: 'experiment_id', name: 'iris_model' } },
+    } as any);
+    wrapper = createComponentInstance(props);
+    expect(wrapper.find('[data-testid="descriptions-item-label"]').at(3).text()).toBe('Source Run');
+    expect(wrapper.find('[data-testid="descriptions-item-label"]').at(4).text()).toBe('Source Model');
+    expect(wrapper.find('[data-testid="descriptions-item-label"]').at(5).text()).toBe('Aliases');
+    const sourceModelLink = wrapper.find('[data-testid="source-model-link"]').hostNodes();
+    expect(sourceModelLink.text()).toBe('iris_model');
+    expect(sourceModelLink.prop('href')).toContain(
+      TrackingRouters.getExperimentLoggedModelDetailsPageRoute('experiment_id', loggedModelId),
+    );
   });
 });

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.enzyme.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.enzyme.test.tsx
@@ -290,9 +290,7 @@ describe('ModelVersionView', () => {
         (item: any) => item.find('[data-testid="descriptions-item-label"]').hostNodes().text() === 'Source Model',
       );
     expect(sourceModelItem).toHaveLength(1);
-    const sourceModelLink = sourceModelItem.find('[data-testid="source-model-link"]').hostNodes();
-    expect(sourceModelLink.text()).toBe('iris_model');
-    expect(sourceModelLink.prop('href')).toContain(
+    expect(sourceModelItem.find('[data-testid="source-model-link"]').hostNodes().prop('href')).toContain(
       TrackingRouters.getExperimentLoggedModelDetailsPageRoute('experiment_id', loggedModelId),
     );
   });

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.enzyme.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.enzyme.test.tsx
@@ -271,12 +271,26 @@ describe('ModelVersionView', () => {
     };
     jest.mocked(useGetLoggedModelQuery).mockReturnValue({
       data: { info: { model_id: loggedModelId, experiment_id: 'experiment_id', name: 'iris_model' } },
-    } as any);
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: jest.fn(),
+    } as ReturnType<typeof useGetLoggedModelQuery>);
     wrapper = createComponentInstance(props);
-    expect(wrapper.find('[data-testid="descriptions-item-label"]').at(3).text()).toBe('Source Run');
-    expect(wrapper.find('[data-testid="descriptions-item-label"]').at(4).text()).toBe('Source Model');
-    expect(wrapper.find('[data-testid="descriptions-item-label"]').at(5).text()).toBe('Aliases');
-    const sourceModelLink = wrapper.find('[data-testid="source-model-link"]').hostNodes();
+    const descriptionLabels = wrapper
+      .find('[data-testid="descriptions-item-label"]')
+      .hostNodes()
+      .map((label: any) => label.text());
+    expect(descriptionLabels).toContain('Source Run');
+    expect(descriptionLabels).toContain('Source Model');
+    const sourceModelItem = wrapper
+      .find('[data-testid="descriptions-item"]')
+      .hostNodes()
+      .filterWhere(
+        (item: any) => item.find('[data-testid="descriptions-item-label"]').hostNodes().text() === 'Source Model',
+      );
+    expect(sourceModelItem).toHaveLength(1);
+    const sourceModelLink = sourceModelItem.find('[data-testid="source-model-link"]').hostNodes();
     expect(sourceModelLink.text()).toBe('iris_model');
     expect(sourceModelLink.prop('href')).toContain(
       TrackingRouters.getExperimentLoggedModelDetailsPageRoute('experiment_id', loggedModelId),

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.tsx
@@ -14,6 +14,7 @@ import { TagAssignmentModal } from '../../common/components/TagAssignmentModal';
 import { TagList } from '../../common/components/TagList';
 import { PromoteModelButton } from './PromoteModelButton';
 import { SchemaTable } from './SchemaTable';
+import { ModelVersionSourceModelLink } from './ModelVersionSourceModelLink';
 import Utils from '../../common/utils/Utils';
 import { ModelStageTransitionDropdown } from './ModelStageTransitionDropdown';
 import { Descriptions } from '../../common/components/Descriptions';
@@ -38,7 +39,7 @@ import { setModelVersionTagApi, deleteModelVersionTagApi } from '../actions';
 import { connect } from 'react-redux';
 import { OverflowMenu, PageHeader } from '../../shared/building_blocks/PageHeader';
 import { FormattedMessage, type IntlShape, injectIntl } from 'react-intl';
-import { extractArtifactPathFromModelSource } from '../utils/VersionUtils';
+import { extractArtifactPathFromModelSource, extractLoggedModelIdFromModelSource } from '../utils/VersionUtils';
 import { withNextModelsUIContext } from '../hooks/useNextModelsUI';
 import { ModelsNextUIToggleSwitch } from './ModelsNextUIToggleSwitch';
 import { shouldShowModelsNextUI, shouldUseSharedTaggingUI } from '../../common/utils/FeatureUtils';
@@ -387,6 +388,24 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
     );
   }
 
+  renderSourceModelDescription() {
+    const loggedModelId = extractLoggedModelIdFromModelSource(this.props.modelVersion?.source);
+    if (!loggedModelId) {
+      return null;
+    }
+    return (
+      <Descriptions.Item
+        key="description-key-source-model"
+        label={this.props.intl.formatMessage({
+          defaultMessage: 'Source Model',
+          description: 'Label name for the source logged model metadata in model version page',
+        })}
+      >
+        <ModelVersionSourceModelLink loggedModelId={loggedModelId} />
+      </Descriptions.Item>
+    );
+  }
+
   renderCopiedFromLink() {
     const { source } = this.props.modelVersion;
     const modelUriRegex = /^models:\/[^/]+\/[^/]+$/;
@@ -458,6 +477,7 @@ export class ModelVersionViewImpl extends React.Component<ModelVersionViewImplPr
       this.renderCreatorDescription(modelVersion.user_id),
       this.renderLastModifiedDescription(modelVersion.last_updated_timestamp),
       this.renderSourceRunDescription(),
+      this.renderSourceModelDescription(),
       this.renderCopiedFromLink(),
       usingNextModelsUI ? this.renderAliasEditor() : this.renderStageDropdown(modelVersion),
       usingNextModelsUI ? this.renderDisabledStage(modelVersion) : null,

--- a/mlflow/server/js/src/model-registry/utils/VersionUtils.test.ts
+++ b/mlflow/server/js/src/model-registry/utils/VersionUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { extractArtifactPathFromModelSource } from './VersionUtils';
+import { extractArtifactPathFromModelSource, extractLoggedModelIdFromModelSource } from './VersionUtils';
 
 describe('extractArtifactPathFromModelSource', () => {
   it('test extractArtifactPathFromModelSource', () => {
@@ -18,5 +18,17 @@ describe('extractArtifactPathFromModelSource', () => {
     expect(extractArtifactPathFromModelSource('file///path/to/mlruns/0/01bcd/artifacts/xx/yy', '01bce')).toBe(
       undefined,
     );
+  });
+});
+
+describe('extractLoggedModelIdFromModelSource', () => {
+  it('returns the model ID only for `models:/<model_id>` sources', () => {
+    expect(extractLoggedModelIdFromModelSource('models:/m-1bc96c322a8441c7a5af8de3df2cc4ce')).toBe(
+      'm-1bc96c322a8441c7a5af8de3df2cc4ce',
+    );
+    expect(extractLoggedModelIdFromModelSource('models:/Model B/2')).toBe(undefined);
+    expect(extractLoggedModelIdFromModelSource('models:/Model B@champion')).toBe(undefined);
+    expect(extractLoggedModelIdFromModelSource('mlflow-artifacts:/0/01bcd/artifacts/model')).toBe(undefined);
+    expect(extractLoggedModelIdFromModelSource(undefined)).toBe(undefined);
   });
 });

--- a/mlflow/server/js/src/model-registry/utils/VersionUtils.ts
+++ b/mlflow/server/js/src/model-registry/utils/VersionUtils.ts
@@ -4,3 +4,11 @@
 export function extractArtifactPathFromModelSource(modelSource: string, runId: string) {
   return modelSource.match(new RegExp(`/${runId}/artifacts/(.+)`))?.[1];
 }
+
+/**
+ * Extract the logged model ID from a `models:/<model_id>` source URI.
+ * Mirrors `_parse_model_uri` in the Python client: a single path segment without `@` is a model ID.
+ */
+export function extractLoggedModelIdFromModelSource(modelSource?: string) {
+  return modelSource?.match(/^models:\/([^/@]+)$/)?.[1];
+}


### PR DESCRIPTION
### Related Issues/PRs

Relates to #16644
Closes #25728

### What changes are proposed in this pull request?

The model version page in the Model Registry UI links to the source run but not to the logged model the version was registered from, so reaching the model's artifacts means going through the run. Versions registered from a model logged outside a run have no Source Run entry at all, so there is no path.

This PR adds a "Source Model" entry next to "Source Run" when `model_version.source` is `models:/<model_id>`:

- `extractLoggedModelIdFromModelSource` in `VersionUtils.ts` parses the ID (a single path segment without `@`, matching `_parse_model_uri` on the Python side).
- `ModelVersionSourceModelLink` fetches the logged model with the existing `useGetLoggedModelQuery` hook and links to the logged model details page. It shows a skeleton while loading, and falls back to the plain model ID if the logged model cannot be fetched or has no experiment ID.
- `models:/<name>/<version>` sources keep the existing "Copied from" behavior.

The docs sentence listing the model version page fields now mentions the source logged model.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests: `VersionUtils.test.ts` (source parsing), `ModelVersionSourceModelLink.test.tsx` (skeleton while loading, link rendering, and the fallbacks for a failed fetch and a missing experiment ID, with msw), and a case in `ModelVersionView.enzyme.test.tsx` (the new description item and its link, selected by label).

Manual: ran `mlflow server` 3.16.0 in Docker with this build of the UI, registered one version from a model logged in a run and one from a model logged outside a run, and confirmed both pages show the link and it opens the logged model page. Also checked the loading and failure states by holding the logged-model request open and by answering it with 404.

Version 1, registered from a model logged in a run. Before (Source Run only):

<img width="1400" height="900" alt="mv1_before" src="https://github.com/user-attachments/assets/d80e60fa-2a87-47f7-8ce9-056727de2976" />

After (Source Run and Source Model):

<img width="1400" height="900" alt="mv1_after" src="https://github.com/user-attachments/assets/4b0f2d3a-c829-48c9-a577-77680c16948e" />

Version 2, registered from a model logged outside a run. 

Before (no source rows):

<img width="1400" height="900" alt="mv2_before" src="https://github.com/user-attachments/assets/051707ba-d652-4b8c-880f-787504a2dc5b" />

After (Source Model only):

<img width="1400" height="900" alt="mv2_after" src="https://github.com/user-attachments/assets/9b0979ae-e62b-4f31-a37a-df8968703dae" />

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The model version page in the Model Registry UI now links to the source logged model.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release