### PR TITLE
Warn for proxied artifact roots in `mlflow db move-resources`

### DIFF
--- a/docs/docs/self-hosting/workspaces/configuration.mdx
+++ b/docs/docs/self-hosting/workspaces/configuration.mdx
@@ -124,9 +124,21 @@ used as is, otherwise pass `--default-artifact-root` with the value the tracking
 started with and the `workspaces/<name>` suffix is appended.
 
 Only the experiment's `artifact_location` changes, in the same transaction as the move. Artifact
-objects are not copied or deleted, and stored run, logged model and trace URIs stay unchanged, so
-everything already logged keeps resolving at its current location while new runs land under the
-target workspace's artifact root.
+objects are not copied or deleted, and stored run, logged model and trace URIs stay unchanged.
+Historical artifacts keep resolving when those stored URIs are absolute locations, such as `s3://`,
+`gs://`, `file://`, or another direct artifact store URI.
+
+:::warning[Moving experiments with proxied artifacts]
+Experiments created with `--serve-artifacts` can store proxied `mlflow-artifacts:/...` locations.
+Those paths are resolved relative to the active workspace. For example, after moving an experiment
+from `default` to `team-a`, a historical `mlflow-artifacts:/1/<run_id>/artifacts` URI is served from
+`<artifacts-destination>/workspaces/team-a/1/<run_id>/artifacts`, while the existing object may still
+be under `<artifacts-destination>/1/<run_id>/artifacts`.
+
+Run `mlflow db move-resources ... --dry-run` before moving experiments. If it reports proxied
+artifact roots, relocate the listed paths under the server's `--artifacts-destination` so historical
+artifacts remain reachable from the target workspace.
+:::
 
 ## Client Workspace Selection (summary)
 

--- a/mlflow/db.py
+++ b/mlflow/db.py
@@ -111,6 +111,26 @@ def _parse_tag(value: str) -> tuple[str, str]:
     return key, val
 
 
+def _format_proxied_artifact_root_notes(proxied_artifact_roots) -> list[str]:
+    if not proxied_artifact_roots:
+        return []
+
+    notes = [
+        "Note: some moved experiments use proxied mlflow-artifacts: locations. "
+        "These paths are resolved relative to the active workspace, so historical "
+        "artifacts may need to be relocated under the server's --artifacts-destination:",
+    ]
+    notes.extend(
+        f"  {root.name!r} ({root.artifact_location}): "
+        f"{root.current_path or '<artifact root>'} -> {root.target_path or '<artifact root>'}"
+        for root in proxied_artifact_roots
+    )
+    notes.append(
+        "Stored run, logged model, and trace artifact URIs are not rewritten by this command."
+    )
+    return notes
+
+
 @commands.command("move-resources")
 @click.argument("url")
 @click.option(
@@ -235,8 +255,9 @@ def move_resources(
     artifact_location is repointed to the artifact root resolved for the target
     workspace, in the same transaction as the move. Artifact objects are not
     copied or deleted, and stored run, logged model and trace URIs are left
-    unchanged, so everything already logged keeps resolving at its current
-    location while new runs land under the new root.
+    unchanged. Historical artifacts keep resolving when stored artifact URIs
+    are absolute locations; proxied mlflow-artifacts: locations may require
+    relocating objects under the server's --artifacts-destination.
 
     **IMPORTANT**: Always take a backup of your database before running this command.
     """
@@ -300,6 +321,7 @@ def move_resources(
                 f"Note: {result.row_count} rows match {len(result.names)} distinct "
                 f"name(s). All rows with a matching name will be moved."
             )
+        extra_notes.extend(_format_proxied_artifact_root_notes(result.proxied_artifact_roots))
 
         if dry_run:
             click.echo(
@@ -349,6 +371,9 @@ def move_resources(
                 f"Repointed {result.row_count} experiment artifact root(s) "
                 f"under {result.retarget_root}."
             )
+        if yes:
+            for note in _format_proxied_artifact_root_notes(result.proxied_artifact_roots):
+                click.echo(note)
     except (RuntimeError, MlflowException) as e:
         raise click.ClickException(str(e)) from e
     except sqlalchemy.exc.SQLAlchemyError as e:

--- a/mlflow/store/db/workspace_move.py
+++ b/mlflow/store/db/workspace_move.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import posixpath
 from dataclasses import dataclass
 from typing import Literal
 
@@ -25,8 +26,18 @@ from mlflow.store.tracking.dbmodels.models import (
 )
 from mlflow.store.workspace.abstract_store import AbstractStore
 from mlflow.store.workspace.sqlalchemy_store import _WORKSPACE_ROOT_MODELS
-from mlflow.utils.uri import append_to_uri_path
-from mlflow.utils.workspace_utils import WORKSPACES_DIR_NAME
+from mlflow.utils.uri import append_to_uri_path, extract_and_normalize_path, get_uri_scheme
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME, WORKSPACES_DIR_NAME
+
+
+@dataclass(frozen=True)
+class ProxiedArtifactRoot:
+    """A moved experiment whose proxied artifact root may require storage relocation."""
+
+    name: str
+    artifact_location: str
+    current_path: str
+    target_path: str
 
 
 @dataclass(frozen=True)
@@ -38,6 +49,9 @@ class MoveResult:
     # Set when artifact_policy="retarget": the artifact root the moved
     # experiments were repointed under.
     retarget_root: str | None = None
+    # Set when moving experiments whose proxied artifact roots are interpreted
+    # relative to the active workspace.
+    proxied_artifact_roots: tuple[ProxiedArtifactRoot, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -240,6 +254,52 @@ def _resolve_target_artifact_root(
     return root
 
 
+def _normalize_proxied_artifact_path(artifact_location: str) -> str:
+    normalized = extract_and_normalize_path(artifact_location)
+    return "" if normalized == "." else normalized
+
+
+def _get_target_proxied_artifact_path(current_path: str, target_workspace: str) -> str:
+    segments = current_path.split("/", 2)
+    if len(segments) >= 2 and segments[0] == WORKSPACES_DIR_NAME and segments[1]:
+        suffix = segments[2] if len(segments) == 3 else ""
+    else:
+        suffix = current_path
+
+    if target_workspace == DEFAULT_WORKSPACE_NAME:
+        return suffix
+    return posixpath.join(WORKSPACES_DIR_NAME, target_workspace, suffix)
+
+
+def _find_proxied_artifact_roots(
+    conn,
+    table: sa.Table,
+    name_col,
+    source_workspace: str,
+    target_workspace: str,
+    name_filter: list[str] | sa.Select | None,
+) -> tuple[ProxiedArtifactRoot, ...]:
+    stmt = sa.select(name_col, table.c.artifact_location).where(
+        table.c.workspace == source_workspace
+    )
+    if name_filter is not None:
+        stmt = stmt.where(name_col.in_(name_filter))
+
+    roots = []
+    for name, artifact_location in conn.execute(stmt.order_by(name_col)).fetchall():
+        if get_uri_scheme(artifact_location or "") == "mlflow-artifacts":
+            current_path = _normalize_proxied_artifact_path(artifact_location)
+            roots.append(
+                ProxiedArtifactRoot(
+                    name=name,
+                    artifact_location=artifact_location,
+                    current_path=current_path,
+                    target_path=_get_target_proxied_artifact_path(current_path, target_workspace),
+                )
+            )
+    return tuple(roots)
+
+
 def move_resources(
     engine: sa.Engine,
     workspace_store: AbstractStore,
@@ -363,6 +423,14 @@ def move_resources(
             )
         ).scalar()
 
+        proxied_artifact_roots = (
+            _find_proxied_artifact_roots(
+                conn, table, name_col, source_workspace, target_workspace, name_filter
+            )
+            if resource_type == SqlExperiment.__tablename__
+            else ()
+        )
+
         if not dry_run:
             if retarget_root is not None:
                 # Resolved before the flip because the tag-filter subquery in
@@ -423,4 +491,9 @@ def move_resources(
                     )
                 )
 
-    return MoveResult(names=sorted(matched), row_count=row_count, retarget_root=retarget_root)
+    return MoveResult(
+        names=sorted(matched),
+        row_count=row_count,
+        retarget_root=retarget_root,
+        proxied_artifact_roots=proxied_artifact_roots,
+    )

--- a/tests/db/test_workspace_move.py
+++ b/tests/db/test_workspace_move.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 import sqlalchemy as sa
 
+from mlflow.db import _format_proxied_artifact_root_notes
 from mlflow.entities import ExperimentTag, TraceInfo
 from mlflow.entities.model_registry import ModelVersionTag, RegisteredModelTag
 from mlflow.entities.trace_location import TraceLocation
@@ -12,7 +13,12 @@ from mlflow.entities.trace_state import TraceState
 from mlflow.entities.workspace import Workspace
 from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
 from mlflow.exceptions import MlflowException
-from mlflow.store.db.workspace_move import _SPEC_BY_MODEL, MoveResult, move_resources
+from mlflow.store.db.workspace_move import (
+    _SPEC_BY_MODEL,
+    MoveResult,
+    ProxiedArtifactRoot,
+    move_resources,
+)
 from mlflow.store.model_registry.sqlalchemy_workspace_store import (
     WorkspaceAwareSqlAlchemyStore as WorkspaceAwareRegistryStore,
 )
@@ -478,6 +484,17 @@ def _seed_experiment_with_artifacts(tracking_store, name):
     return exp_id, run, model, trace_info
 
 
+def _set_experiment_artifact_location(engine, exp_id, artifact_location):
+    experiments_table = sa.Table("experiments", sa.MetaData(), autoload_with=engine)
+    with engine.begin() as conn:
+        conn.execute(
+            experiments_table
+            .update()
+            .where(experiments_table.c.experiment_id == int(exp_id))
+            .values(artifact_location=artifact_location)
+        )
+
+
 def test_move_experiments_artifact_policy_retarget(tracking_store, workspace_store, engine):
     _create_workspace(workspace_store, "team-a")
     exp_id, run, model, trace_info = _seed_experiment_with_artifacts(tracking_store, "exp-rt")
@@ -540,6 +557,71 @@ def test_move_experiments_artifact_policy_preserve_leaves_uris(
     with WorkspaceContext("team-a"):
         assert tracking_store.get_experiment(exp_id).artifact_location == old_location
         assert tracking_store.get_run(run.info.run_id).info.artifact_uri == run.info.artifact_uri
+
+
+def test_move_experiments_reports_proxied_artifact_roots(tracking_store, workspace_store, engine):
+    _create_workspace(workspace_store, "team-a")
+    exp_id, _, _, _ = _seed_experiment_with_artifacts(tracking_store, "exp-proxy")
+    artifact_location = f"mlflow-artifacts:/{exp_id}"
+    _set_experiment_artifact_location(engine, exp_id, artifact_location)
+
+    result = move_resources(
+        engine,
+        workspace_store,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        names=["exp-proxy"],
+        dry_run=True,
+    )
+
+    assert result.proxied_artifact_roots == (
+        ProxiedArtifactRoot(
+            name="exp-proxy",
+            artifact_location=artifact_location,
+            current_path=exp_id,
+            target_path=f"workspaces/team-a/{exp_id}",
+        ),
+    )
+
+
+def test_move_experiments_does_not_report_absolute_artifact_roots(
+    tracking_store, workspace_store, engine
+):
+    _create_workspace(workspace_store, "team-a")
+    exp_id, _, _, _ = _seed_experiment_with_artifacts(tracking_store, "exp-absolute")
+    _set_experiment_artifact_location(engine, exp_id, f"s3://bucket/{exp_id}")
+
+    result = move_resources(
+        engine,
+        workspace_store,
+        source_workspace=DEFAULT_WORKSPACE_NAME,
+        target_workspace="team-a",
+        resource_type="experiments",
+        names=["exp-absolute"],
+        dry_run=True,
+    )
+
+    assert result.proxied_artifact_roots == ()
+
+
+def test_cli_formats_proxied_artifact_root_notes():
+    notes = _format_proxied_artifact_root_notes((
+        ProxiedArtifactRoot(
+            name="exp-proxy",
+            artifact_location="mlflow-artifacts:/1",
+            current_path="1",
+            target_path="workspaces/team-a/1",
+        ),
+    ))
+
+    assert notes == [
+        "Note: some moved experiments use proxied mlflow-artifacts: locations. "
+        "These paths are resolved relative to the active workspace, so historical "
+        "artifacts may need to be relocated under the server's --artifacts-destination:",
+        "  'exp-proxy' (mlflow-artifacts:/1): 1 -> workspaces/team-a/1",
+        "Stored run, logged model, and trace artifact URIs are not rewritten by this command.",
+    ]
 
 
 def test_move_retarget_dry_run_makes_no_changes(tracking_store, workspace_store, engine):


### PR DESCRIPTION
### Related Issues/PRs

Closes #25698

### What changes are proposed in this pull request?

This PR makes `mlflow db move-resources` surface moved experiments whose stored artifact root uses the proxied `mlflow-artifacts:` scheme.

For those experiments, the command now reports the current proxied artifact path and the target-workspace path that administrators may need to relocate under the tracking server's `--artifacts-destination`. The warning is shown during dry runs, interactive confirmation, and confirmed `-y` moves.

The workspace migration docs and CLI help text are also updated to clarify that absolute stored artifact URIs keep resolving, while proxied workspace-relative artifact paths may require object relocation after a move.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Manual checks run locally:

```bash
python -m py_compile mlflow/db.py mlflow/store/db/workspace_move.py tests/db/test_workspace_move.py
UV_CACHE_DIR=/private/tmp/mlflow-uv-cache UV_PYTHON_INSTALL_DIR=/private/tmp/mlflow-uv-python uv run ruff check mlflow/db.py mlflow/store/db/workspace_move.py tests/db/test_workspace_move.py
UV_CACHE_DIR=/private/tmp/mlflow-uv-cache UV_PYTHON_INSTALL_DIR=/private/tmp/mlflow-uv-python uv run ruff format --check mlflow/db.py mlflow/store/db/workspace_move.py tests/db/test_workspace_move.py
```

I also attempted to run `tests/db/test_workspace_move.py`; collection/import did not complete in this local environment because the plain system environment was missing optional dependencies and the uv-backed run stalled while importing generated protobuf modules.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow db move-resources` now warns when moved experiments use proxied `mlflow-artifacts:` roots whose underlying artifact objects may need to be relocated for the target workspace.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
