### PR TITLE
Remove the default basic-auth admin password shipped in `basic_auth.ini` (GHSA-gq3w-7jj3-x7gr)

### DIFF
--- a/dev/benchmarks/gateway/README.md
+++ b/dev/benchmarks/gateway/README.md
@@ -93,26 +93,26 @@ DB schema before the others join. All instances share one PostgreSQL database.
 
 ## Options
 
-| Flag                          | Default        | Description                                                             |
-| ----------------------------- | -------------- | ----------------------------------------------------------------------- |
-| `--url URL`                   | —              | Benchmark this URL directly, skip all setup                             |
-| `--instances N`               | 4              | MLflow instances. Use 1 for single-instance (no nginx, optional SQLite) |
-| `--workers N`                 | 4              | MLflow worker processes per instance                                    |
-| `--database sqlite\|postgres` | `sqlite`       | Database to use — only applies when `--instances 1`                     |
-| `--no-usage-tracking`         | —              | Disable usage tracking (tracing) on the endpoint                        |
-| `--port N`                    | 5731           | Port to benchmark (MLflow port for single, nginx LB port for multi)     |
-| `--base-port N`               | 5800           | First MLflow instance port in multi mode (rest are +1, +2, …)           |
-| `--fake-server-port N`        | 9137           | Fake OpenAI server port                                                 |
-| `--requests N`                | 2000           | Requests per run                                                        |
-| `--max-concurrent N`          | 50             | Max concurrent requests                                                 |
-| `--runs N`                    | 3              | Number of benchmark runs                                                |
-| `--fake-delay-ms N`           | 50             | Simulated provider latency in ms                                        |
-| `--min-rps N`                 | —              | Fail (exit 1) if average throughput falls below N req/s                 |
-| `--max-p50-ms N`              | —              | Fail (exit 1) if average P50 latency exceeds N ms (CI threshold)        |
-| `--max-p99-ms N`              | —              | Fail (exit 1) if average P99 latency exceeds N ms (CI threshold)        |
-| `--auth`                      | off            | Start MLflow with `--app-name=basic-auth`; send Basic auth on requests  |
-| `--auth-username USER`        | `admin`        | Basic-auth username (matches `mlflow/server/auth/basic_auth.ini`)       |
-| `--auth-password PASS`        | `password1234` | Basic-auth password (matches `mlflow/server/auth/basic_auth.ini`)       |
+| Flag                          | Default  | Description                                                             |
+| ----------------------------- | -------- | ----------------------------------------------------------------------- |
+| `--url URL`                   | —        | Benchmark this URL directly, skip all setup                             |
+| `--instances N`               | 4        | MLflow instances. Use 1 for single-instance (no nginx, optional SQLite) |
+| `--workers N`                 | 4        | MLflow worker processes per instance                                    |
+| `--database sqlite\|postgres` | `sqlite` | Database to use — only applies when `--instances 1`                     |
+| `--no-usage-tracking`         | —        | Disable usage tracking (tracing) on the endpoint                        |
+| `--port N`                    | 5731     | Port to benchmark (MLflow port for single, nginx LB port for multi)     |
+| `--base-port N`               | 5800     | First MLflow instance port in multi mode (rest are +1, +2, …)           |
+| `--fake-server-port N`        | 9137     | Fake OpenAI server port                                                 |
+| `--requests N`                | 2000     | Requests per run                                                        |
+| `--max-concurrent N`          | 50       | Max concurrent requests                                                 |
+| `--runs N`                    | 3        | Number of benchmark runs                                                |
+| `--fake-delay-ms N`           | 50       | Simulated provider latency in ms                                        |
+| `--min-rps N`                 | —        | Fail (exit 1) if average throughput falls below N req/s                 |
+| `--max-p50-ms N`              | —        | Fail (exit 1) if average P50 latency exceeds N ms (CI threshold)        |
+| `--max-p99-ms N`              | —        | Fail (exit 1) if average P99 latency exceeds N ms (CI threshold)        |
+| `--auth`                      | off      | Start MLflow with `--app-name=basic-auth`; send Basic auth on requests  |
+| `--auth-username USER`        | `admin`  | Basic-auth admin username bootstrapped on the benchmarked server        |
+| `--auth-password PASS`        | random   | Basic-auth admin password bootstrapped on the benchmarked server        |
 
 All flags can also be set via environment variables (same name, uppercased):
 `INSTANCES`, `WORKERS_PER_INSTANCE`, `REQUESTS`, `MAX_CONCURRENT`, `RUNS`,

--- a/dev/benchmarks/gateway/run.py
+++ b/dev/benchmarks/gateway/run.py
@@ -511,6 +511,20 @@ def cmd_bench(args: argparse.Namespace) -> None:
         _check_docker()
 
     with tempfile.TemporaryDirectory(prefix="mlflow-bench-") as work_dir:
+        if creds:
+            # Keep the auth DB inside the per-run work dir. The packaged basic_auth.ini uses a
+            # relative sqlite path that would persist next to this script, so a later run with
+            # a freshly generated random password would fail to authenticate against the admin
+            # bootstrapped by an earlier run.
+            auth_ini = Path(work_dir) / "basic_auth.ini"
+            auth_ini.write_text(
+                "[mlflow]\n"
+                "default_permission = READ\n"
+                f"database_uri = sqlite:///{Path(work_dir) / 'basic_auth.db'}\n"
+                f"admin_username = {args.auth_username}\n"
+                "authorization_function = mlflow.server.auth:authenticate_request_basic_auth\n"
+            )
+            os.environ["MLFLOW_AUTH_CONFIG_PATH"] = str(auth_ini)
         port = args.port
         fake_port = args.fake_server_port
         instance_ports = [args.base_port + i for i in range(instances)]

--- a/dev/benchmarks/gateway/run.py
+++ b/dev/benchmarks/gateway/run.py
@@ -20,6 +20,7 @@ import base64
 import contextlib
 import json
 import os
+import secrets
 import shutil
 import subprocess
 import sys
@@ -475,6 +476,10 @@ def cmd_bench(args: argparse.Namespace) -> None:
     instances = args.instances
     mode = "1 instance" if instances == 1 else f"{instances} instances, nginx LB"
     creds = (args.auth_username, args.auth_password) if args.auth else None
+    if creds:
+        # Bootstraps the admin user of the spawned MLflow servers (MLflow ships no default).
+        os.environ["MLFLOW_AUTH_ADMIN_USERNAME"] = args.auth_username
+        os.environ["MLFLOW_AUTH_ADMIN_PASSWORD"] = args.auth_password
 
     if args.url:
         console.print(
@@ -780,8 +785,11 @@ def main() -> None:
     )
     parser.add_argument(
         "--auth-password",
-        default=os.environ.get("AUTH_PASSWORD", "password1234"),
-        help="Basic auth password (default: password1234, from basic_auth.ini)",
+        default=os.environ.get("AUTH_PASSWORD") or secrets.token_urlsafe(16),
+        help=(
+            "Basic auth password used to bootstrap the admin user of the benchmarked "
+            "server (default: a random value; MLflow ships no default admin password)"
+        ),
     )
 
     args = parser.parse_args()

--- a/docs/docs/self-hosting/security/basic-http-auth.mdx
+++ b/docs/docs/self-hosting/security/basic-http-auth.mdx
@@ -1148,15 +1148,19 @@ configuration file or the `MLFLOW_AUTH_ADMIN_USERNAME` environment variable.
 
 There is no default admin password. Set one with the `MLFLOW_AUTH_ADMIN_PASSWORD` environment variable or with
 `admin_password` in the configuration file before the first start; the server refuses to start otherwise. Both
-settings are only used to create the admin user and are ignored once it exists. After the first successful start, unset
-`MLFLOW_AUTH_ADMIN_PASSWORD` (or remove `admin_password` from the file) so the secret does not linger in the server's
-environment or configuration, and rotate the password with the `2.0/mlflow/users/update-password` endpoint.
+settings are only used to create the admin user (and to replace its password if it is still the legacy default
+described below) and are ignored otherwise. After the first successful start, unset `MLFLOW_AUTH_ADMIN_PASSWORD` (or
+remove `admin_password` from the file) so the secret does not linger in the server's environment or configuration, and
+rotate the password with the `2.0/mlflow/users/update-password` endpoint.
 
 :::warning
 Earlier MLflow versions shipped the admin password `password1234` in `basic_auth.ini`
-([GHSA-gq3w-7jj3-x7gr](https://github.com/advisories/GHSA-gq3w-7jj3-x7gr)). If you upgraded an existing deployment,
-rotate the admin password immediately. The server logs a warning at startup while the admin user still has that
-password, and never accepts it for creating a new admin user.
+([GHSA-gq3w-7jj3-x7gr](https://github.com/advisories/GHSA-gq3w-7jj3-x7gr)). That password is no longer accepted: the
+server rejects logins by admin users that present it, never uses it to create an admin user, and logs a warning at
+startup while an admin user still has it. If you upgraded an existing deployment whose admin user still has that
+password, set `MLFLOW_AUTH_ADMIN_PASSWORD` (or `admin_password`) to a new password and restart the server once; the
+stored password is replaced and the setting can be unset again. Alternatively, another admin can update or delete the
+user.
 :::
 
 Multiple admin users can exist by promoting other users to admin, using the `2.0/mlflow/users/update-admin` endpoint.
@@ -1374,8 +1378,9 @@ Authentication configuration is located at `mlflow/server/auth/basic_auth.ini`:
     <tr>
       <td>`admin_password`</td>
       <td>
-        Password of the admin user created on first start. Overridden by `MLFLOW_AUTH_ADMIN_PASSWORD`. There is no
-        default; one of the two must be set until the admin user exists.
+        Password of the admin user created on first start; also replaces that user's password on upgrade while it
+        is still the legacy default. Overridden by `MLFLOW_AUTH_ADMIN_PASSWORD`. There is no default; one of the two
+        must be set until the admin user exists.
       </td>
     </tr>
     <tr>

--- a/docs/docs/self-hosting/security/basic-http-auth.mdx
+++ b/docs/docs/self-hosting/security/basic-http-auth.mdx
@@ -34,6 +34,19 @@ If your setup uses multiple servers, please make sure that this key is consisten
 run into unexpected validation errors.
 :::
 
+:::note
+MLflow ships no default admin password. The first time the server starts with authentication enabled, it creates the
+admin user with the password from the `MLFLOW_AUTH_ADMIN_PASSWORD` environment variable (or `admin_password` in a
+custom [configuration file](#configuration)) and refuses to start if neither is set. Passwords must be at least
+12 characters.
+
+```
+export MLFLOW_AUTH_ADMIN_PASSWORD="<strong-password>"
+```
+
+See [Admin Users](#admin-users) for details.
+:::
+
 To enable MLflow authentication, launch the MLflow UI with the following command:
 
 ```bash
@@ -1129,28 +1142,22 @@ Admin users have unrestricted access to all MLflow resources,
 granting or revoking permissions from other users, and managing permissions for all
 MLflow resources,** even if `NO_PERMISSIONS` is explicitly set to that admin account.
 
-MLflow has a built-in admin user that will be created the first time that the MLflow authentication feature is enabled.
+MLflow has a built-in admin user that is created the first time the server starts with authentication enabled
+against an empty user store. Its username defaults to `admin` and can be changed with `admin_username` in the
+configuration file or the `MLFLOW_AUTH_ADMIN_USERNAME` environment variable.
 
-:::note
-It is recommended that you update the default admin password as soon as possible after creation.
+There is no default admin password. Set one with the `MLFLOW_AUTH_ADMIN_PASSWORD` environment variable or with
+`admin_password` in the configuration file before the first start; the server refuses to start otherwise. Both
+settings are only used to create the admin user and are ignored once it exists. After the first successful start, unset
+`MLFLOW_AUTH_ADMIN_PASSWORD` (or remove `admin_password` from the file) so the secret does not linger in the server's
+environment or configuration, and rotate the password with the `2.0/mlflow/users/update-password` endpoint.
+
+:::warning
+Earlier MLflow versions shipped the admin password `password1234` in `basic_auth.ini`
+([GHSA-gq3w-7jj3-x7gr](https://github.com/advisories/GHSA-gq3w-7jj3-x7gr)). If you upgraded an existing deployment,
+rotate the admin password immediately. The server logs a warning at startup while the admin user still has that
+password, and never accepts it for creating a new admin user.
 :::
-
-The default admin user credentials are as follows:
-
-<table>
-  <thead>
-    <tr>
-      <th>Username</th>
-      <th>Password</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>`admin`</td>
-      <td>`password1234`</td>
-    </tr>
-  </tbody>
-</table>
 
 Multiple admin users can exist by promoting other users to admin, using the `2.0/mlflow/users/update-admin` endpoint.
 
@@ -1362,11 +1369,14 @@ Authentication configuration is located at `mlflow/server/auth/basic_auth.ini`:
     </tr>
     <tr>
       <td>`admin_username`</td>
-      <td>Default admin username if the admin is not already created</td>
+      <td>Username of the admin user created on first start. Overridden by `MLFLOW_AUTH_ADMIN_USERNAME`.</td>
     </tr>
     <tr>
       <td>`admin_password`</td>
-      <td>Default admin password if the admin is not already created</td>
+      <td>
+        Password of the admin user created on first start. Overridden by `MLFLOW_AUTH_ADMIN_PASSWORD`. There is no
+        default; one of the two must be set until the admin user exists.
+      </td>
     </tr>
     <tr>
       <td>`authorization_function`</td>

--- a/docs/docs/self-hosting/workspaces/configuration.mdx
+++ b/docs/docs/self-hosting/workspaces/configuration.mdx
@@ -204,7 +204,8 @@ Example configuration:
 default_permission = READ
 database_uri = sqlite:///basic_auth.db
 admin_username = admin
-admin_password = password1234
+# Required on first start (or set MLFLOW_AUTH_ADMIN_PASSWORD); MLflow ships no default.
+admin_password = <strong-password>
 authorization_function = mlflow.server.auth:authenticate_request_basic_auth
 # Default secure setting for new deployments; for existing instances upgrading to workspaces,
 # set this to true for backwards compatibility (see note above).

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -541,6 +541,19 @@ MLFLOW_EXPERIMENT_NAME = _EnvironmentVariable("MLFLOW_EXPERIMENT_NAME", str, Non
 #: (default: ``None``)
 MLFLOW_AUTH_CONFIG_PATH = _EnvironmentVariable("MLFLOW_AUTH_CONFIG_PATH", str, None)
 
+#: Specifies the username of the admin user that MLflow Authentication creates the first time
+#: it starts against an empty user store. Takes precedence over ``admin_username`` in the
+#: authentication configuration file.
+#: (default: ``None``)
+MLFLOW_AUTH_ADMIN_USERNAME = _EnvironmentVariable("MLFLOW_AUTH_ADMIN_USERNAME", str, None)
+
+#: Specifies the password of the admin user that MLflow Authentication creates the first time
+#: it starts against an empty user store. Takes precedence over ``admin_password`` in the
+#: authentication configuration file. MLflow ships no default admin password, so this variable
+#: (or ``admin_password`` in the configuration file) must be set before the admin user exists.
+#: (default: ``None``)
+MLFLOW_AUTH_ADMIN_PASSWORD = _EnvironmentVariable("MLFLOW_AUTH_ADMIN_PASSWORD", str, None)
+
 #: Specifies and takes precedence for setting the UC OSS basic/bearer auth on http requests.
 #: (default: ``None``)
 MLFLOW_UC_OSS_TOKEN = _EnvironmentVariable("MLFLOW_UC_OSS_TOKEN", str, None)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -171,6 +171,14 @@ MLFLOW_ASSISTANT_SANDBOX_CLI_IMAGE = _EnvironmentVariable(
 #: current generation just launched. Not intended to be set by users.
 _MLFLOW_SERVER_BOOT_ID = _EnvironmentVariable("_MLFLOW_SERVER_BOOT_ID", str, None)
 
+#: Internal. Set by ``mlflow server --app-name basic-auth`` for its worker processes once the
+#: admin user has been bootstrapped in the CLI process, so each worker skips the redundant
+#: bootstrap and legacy-password checks (each one a PBKDF2 hash comparison against the primary
+#: database). Not intended to be set by users.
+_MLFLOW_AUTH_ADMIN_BOOTSTRAPPED = _BooleanEnvironmentVariable(
+    "_MLFLOW_AUTH_ADMIN_BOOTSTRAPPED", False
+)
+
 #: **Experimental** — subject to change or removal in a future release.
 #: URL of an outbound proxy for sandbox container egress (e.g. ``http://proxy.internal:3128``).
 #: When set, it is injected as ``HTTP_PROXY``/``HTTPS_PROXY`` into every sandbox container, with

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -559,6 +559,9 @@ MLFLOW_AUTH_ADMIN_USERNAME = _EnvironmentVariable("MLFLOW_AUTH_ADMIN_USERNAME", 
 #: it starts against an empty user store. Takes precedence over ``admin_password`` in the
 #: authentication configuration file. MLflow ships no default admin password, so this variable
 #: (or ``admin_password`` in the configuration file) must be set before the admin user exists.
+#: On upgraded deployments whose admin user still has the legacy default password
+#: ``password1234`` (https://github.com/advisories/GHSA-gq3w-7jj3-x7gr), which the server no
+#: longer accepts, it is also used once at startup to replace that password.
 #: (default: ``None``)
 MLFLOW_AUTH_ADMIN_PASSWORD = _EnvironmentVariable("MLFLOW_AUTH_ADMIN_PASSWORD", str, None)
 

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -326,6 +326,18 @@ def _build_uvicorn_command(
     return cmd
 
 
+def _bootstrap_basic_auth() -> None:
+    """Create the basic-auth admin user before spawning workers.
+
+    A missing or insecure bootstrap password then fails ``mlflow server`` with one error
+    instead of an endless loop of the uvicorn supervisor restarting crashed workers.
+    """
+    # `mlflow.server.auth` requires the optional `auth` extra, so only import it when needed.
+    from mlflow.server.auth import bootstrap_admin_user
+
+    bootstrap_admin_user()
+
+
 def _run_server(
     *,
     file_store_path,
@@ -416,6 +428,8 @@ def _run_server(
         # Don't use () syntax if we're using uvicorn
         use_factory_syntax = not is_windows() and is_factory and not using_uvicorn
         app = f"{app}()" if use_factory_syntax else app
+        if app_name == "basic-auth":
+            _bootstrap_basic_auth()
 
     # Determine which server to use
     if using_uvicorn:

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -18,6 +18,7 @@ from flask import Flask, Response, send_from_directory
 from packaging.version import Version
 
 from mlflow.environment_variables import (
+    _MLFLOW_AUTH_ADMIN_BOOTSTRAPPED,
     _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN,
     _MLFLOW_SERVER_BOOT_ID,
     _MLFLOW_SGI_NAME,
@@ -430,6 +431,7 @@ def _run_server(
         app = f"{app}()" if use_factory_syntax else app
         if app_name == "basic-auth":
             _bootstrap_basic_auth()
+            env_map[_MLFLOW_AUTH_ADMIN_BOOTSTRAPPED.name] = "true"
 
     # Determine which server to use
     if using_uvicorn:

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -51,6 +51,7 @@ from mlflow.entities import Experiment
 from mlflow.entities.logged_model import LoggedModel
 from mlflow.entities.model_registry import RegisteredModel
 from mlflow.environment_variables import (
+    _MLFLOW_AUTH_ADMIN_BOOTSTRAPPED,
     _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN,
     _MLFLOW_SGI_NAME,
     MLFLOW_AUTH_ADMIN_PASSWORD,
@@ -4419,6 +4420,15 @@ def _warn_if_legacy_default_password_in_use(username: str) -> None:
             )
 
 
+def _init_store_for_app() -> None:
+    if _MLFLOW_AUTH_ADMIN_BOOTSTRAPPED.get():
+        # The `mlflow server` CLI already bootstrapped the admin user and ran the legacy-password
+        # check before spawning this worker, so only the store engine needs initializing here.
+        store.init_db(auth_config.database_uri, read_db_uri=auth_config.read_database_uri)
+    else:
+        bootstrap_admin_user()
+
+
 def create_admin_user(username: str, password: str | None) -> None:
     # Read from the primary database: with a read replica configured, replication lag during a
     # restart could make an existing admin look absent and fail bootstrap for a missing password.
@@ -5962,7 +5972,7 @@ def create_app(app: Flask = app):
     csrf = CSRFProtect()
     csrf.init_app(app)
 
-    bootstrap_admin_user()
+    _init_store_for_app()
 
     _auth_initialized = True
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -489,9 +489,10 @@ def _authenticate_cached(username: str, password: str) -> User | None:
         if not store.authenticate_user(username, password):
             return None
         try:
-            return store.get_user(username)
+            user = store.get_user(username)
         except MlflowException:
             return None
+        return None if _is_disabled_legacy_admin_login(username, password, user) else user
 
     key = _auth_cache_key(username, password)
     with _USER_AUTH_CACHE_LOCK:
@@ -508,6 +509,9 @@ def _authenticate_cached(username: str, password: str) -> User | None:
     except MlflowException:
         # User was deleted between authenticate_user and get_user — treat as auth
         # failure and don't cache anything.
+        return None
+    if _is_disabled_legacy_admin_login(username, password, user):
+        # A rejected credential must not be cached as valid either.
         return None
     with _USER_AUTH_CACHE_LOCK:
         _USER_AUTH_CACHE[key] = user
@@ -3344,7 +3348,9 @@ def authenticate_request_basic_auth() -> Authorization | Response:
     # _authenticate_cached does for the sake of cache-population — the Flask
     # path only cares about the yes/no auth decision.
     if _USER_AUTH_CACHE is None:
-        if store.authenticate_user(username, password):
+        if store.authenticate_user(username, password) and not _is_disabled_legacy_admin_login(
+            username, password
+        ):
             return request.authorization
     elif _authenticate_cached(username, password):
         return request.authorization
@@ -4369,9 +4375,37 @@ def _after_request(resp: Response):
 
 # The admin credentials that earlier MLflow versions shipped in basic_auth.ini
 # (https://github.com/advisories/GHSA-gq3w-7jj3-x7gr). The password is never accepted for
-# bootstrapping a new admin user, and deployments where it is still in use are warned at startup.
+# bootstrapping a new admin user or for logging in as an admin, and deployments where an admin
+# still has it are warned at startup.
 _LEGACY_DEFAULT_ADMIN_USERNAME = "admin"
 _LEGACY_DEFAULT_ADMIN_PASSWORD = "password1234"
+
+
+def _is_disabled_legacy_admin_login(username: str, password: str, user: User | None = None) -> bool:
+    """Whether a credential that passed ``store.authenticate_user`` is the legacy default password
+    on an admin account, which the server no longer accepts.
+
+    Upgraded deployments keep starting so nobody is locked out of the server, but the publicly
+    known admin credential must not stay usable. Rotation needs no working admin login: set
+    ``MLFLOW_AUTH_ADMIN_PASSWORD`` (or ``admin_password``) and restart, see ``create_admin_user``.
+    """
+    if password != _LEGACY_DEFAULT_ADMIN_PASSWORD:
+        return False
+    if user is None:
+        try:
+            user = store.get_user(username)
+        except MlflowException:
+            return False
+    if not user.is_admin:
+        return False
+    _logger.warning(
+        f"Rejected a login by admin user '{username}' with the insecure default password that "
+        "older MLflow versions shipped in basic_auth.ini "
+        "(https://github.com/advisories/GHSA-gq3w-7jj3-x7gr). To rotate it, set "
+        f"{MLFLOW_AUTH_ADMIN_PASSWORD.name} (or `admin_password` in the configuration file "
+        f"referenced by {MLFLOW_AUTH_CONFIG_PATH.name}) to a new password and restart the server."
+    )
+    return True
 
 
 def _validate_bootstrap_admin_username(username: str | None) -> None:
@@ -4396,8 +4430,8 @@ def _validate_bootstrap_admin_password(username: str, password: str | None) -> N
         )
     if password == _LEGACY_DEFAULT_ADMIN_PASSWORD:
         raise MlflowException(
-            f"Refusing to create the admin user '{username}' with the insecure default "
-            "password that older MLflow versions shipped in basic_auth.ini "
+            "Refusing to use the insecure default password that older MLflow versions shipped "
+            f"in basic_auth.ini for the admin user '{username}' "
             "(https://github.com/advisories/GHSA-gq3w-7jj3-x7gr). Set "
             f"{MLFLOW_AUTH_ADMIN_PASSWORD.name} or `admin_password` in the configuration file "
             f"referenced by {MLFLOW_AUTH_CONFIG_PATH.name} to a different password."
@@ -4436,9 +4470,11 @@ def _warn_if_legacy_default_password_in_use(username: str) -> None:
             _logger.warning(
                 f"The MLflow basic auth user '{candidate}' still uses the insecure default "
                 "password that older MLflow versions shipped in basic_auth.ini "
-                "(https://github.com/advisories/GHSA-gq3w-7jj3-x7gr). Rotate it via "
-                f"{UPDATE_USER_PASSWORD} or delete the user before exposing this server beyond "
-                "localhost."
+                "(https://github.com/advisories/GHSA-gq3w-7jj3-x7gr); admin logins with it are "
+                f"rejected. Rotate it by setting {MLFLOW_AUTH_ADMIN_PASSWORD.name} (or "
+                "`admin_password` in the configuration file) to a new password and restarting "
+                f"the server, or have another admin update it via {UPDATE_USER_PASSWORD} or "
+                "delete the user."
             )
 
 
@@ -4469,6 +4505,19 @@ def create_admin_user(username: str | None, password: str | None) -> None:
             # will succeed while the others will fail with an IntegrityError.
             if not isinstance(e.__cause__, sqlalchemy.exc.IntegrityError):
                 raise
+    elif password is not None and store.authenticate_user(
+        username, _LEGACY_DEFAULT_ADMIN_PASSWORD, use_primary=True
+    ):
+        # Upgrade path for deployments bootstrapped with the shipped default: logins with it are
+        # rejected, so the configured bootstrap password doubles as the rotation mechanism that
+        # needs no working admin credential.
+        _validate_bootstrap_admin_password(username, password)
+        store.update_user(username, password=password)
+        _logger.warning(
+            f"Replaced the insecure default password of admin user '{username}' with the "
+            f"configured one. Unset {MLFLOW_AUTH_ADMIN_PASSWORD.name} (or remove "
+            "`admin_password` from the configuration file) now that the rotation is done."
+        )
     _warn_if_legacy_default_password_in_use(username)
 
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -55,6 +55,7 @@ from mlflow.environment_variables import (
     _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN,
     _MLFLOW_SGI_NAME,
     MLFLOW_AUTH_ADMIN_PASSWORD,
+    MLFLOW_AUTH_ADMIN_USERNAME,
     MLFLOW_AUTH_CONFIG_PATH,
     MLFLOW_BASIC_AUTH_FAIL_CLOSED,
     MLFLOW_ENABLE_WORKSPACES,
@@ -418,6 +419,7 @@ from mlflow.utils import workspace_context
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.rest_utils import _REST_API_PATH_PREFIX
 from mlflow.utils.search_utils import SearchUtils
+from mlflow.utils.validation import _validate_password
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 try:
@@ -4372,6 +4374,16 @@ _LEGACY_DEFAULT_ADMIN_USERNAME = "admin"
 _LEGACY_DEFAULT_ADMIN_PASSWORD = "password1234"
 
 
+def _validate_bootstrap_admin_username(username: str | None) -> None:
+    if not username:
+        raise MlflowException(
+            "MLflow Authentication needs a username for the admin user, but none is configured "
+            f"(or it is empty). Set the {MLFLOW_AUTH_ADMIN_USERNAME.name} environment variable, "
+            "or set `admin_username` in the configuration file referenced by "
+            f"{MLFLOW_AUTH_CONFIG_PATH.name}, and restart the server."
+        )
+
+
 def _validate_bootstrap_admin_password(username: str, password: str | None) -> None:
     if not password:
         raise MlflowException(
@@ -4390,6 +4402,16 @@ def _validate_bootstrap_admin_password(username: str, password: str | None) -> N
             f"{MLFLOW_AUTH_ADMIN_PASSWORD.name} or `admin_password` in the configuration file "
             f"referenced by {MLFLOW_AUTH_CONFIG_PATH.name} to a different password."
         )
+    # Apply the store's password policy here so a too-short bootstrap password names the
+    # setting to fix, like the other misconfigurations, instead of failing inside create_user.
+    try:
+        _validate_password(password)
+    except MlflowException as e:
+        raise MlflowException(
+            f"The configured password for the admin user '{username}' is invalid: {e.message} "
+            f"Set {MLFLOW_AUTH_ADMIN_PASSWORD.name} or `admin_password` in the configuration "
+            f"file referenced by {MLFLOW_AUTH_CONFIG_PATH.name} to a valid password."
+        ) from e
 
 
 def bootstrap_admin_user() -> None:
@@ -4424,12 +4446,16 @@ def _init_store_for_app() -> None:
     if _MLFLOW_AUTH_ADMIN_BOOTSTRAPPED.get():
         # The `mlflow server` CLI already bootstrapped the admin user and ran the legacy-password
         # check before spawning this worker, so only the store engine needs initializing here.
+        # This trusts that the CLI resolved the same `database_uri` as this worker. The variable
+        # is private and only the CLI sets it; importing `create_app` directly with it set skips
+        # both checks.
         store.init_db(auth_config.database_uri, read_db_uri=auth_config.read_database_uri)
     else:
         bootstrap_admin_user()
 
 
-def create_admin_user(username: str, password: str | None) -> None:
+def create_admin_user(username: str | None, password: str | None) -> None:
+    _validate_bootstrap_admin_username(username)
     # Read from the primary database: with a read replica configured, replication lag during a
     # restart could make an existing admin look absent and fail bootstrap for a missing password.
     if not store.has_user(username, use_primary=True):

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -4,7 +4,6 @@ Usage
 
 .. code-block:: bash
 
-    export MLFLOW_FLASK_SERVER_SECRET_KEY="<random-secret>"
     export MLFLOW_AUTH_ADMIN_PASSWORD="<strong-password>"  # required on first start
     mlflow server --app-name basic-auth
 """
@@ -4365,9 +4364,10 @@ def _after_request(resp: Response):
     return resp
 
 
-# The admin password that earlier MLflow versions shipped in basic_auth.ini
-# (https://github.com/advisories/GHSA-gq3w-7jj3-x7gr). It is never accepted for bootstrapping
-# a new admin user, and deployments whose existing admin still uses it are warned at startup.
+# The admin credentials that earlier MLflow versions shipped in basic_auth.ini
+# (https://github.com/advisories/GHSA-gq3w-7jj3-x7gr). The password is never accepted for
+# bootstrapping a new admin user, and deployments where it is still in use are warned at startup.
+_LEGACY_DEFAULT_ADMIN_USERNAME = "admin"
 _LEGACY_DEFAULT_ADMIN_PASSWORD = "password1234"
 
 
@@ -4375,7 +4375,8 @@ def _validate_bootstrap_admin_password(username: str, password: str | None) -> N
     if not password:
         raise MlflowException(
             f"MLflow Authentication needs a password to create the admin user '{username}', "
-            "and none is configured. MLflow ships no default admin password. Set the "
+            "but none is configured (or it is empty). MLflow ships no default admin password. "
+            "Set the "
             f"{MLFLOW_AUTH_ADMIN_PASSWORD.name} environment variable, or set `admin_password` "
             f"in the configuration file referenced by {MLFLOW_AUTH_CONFIG_PATH.name}, and "
             "restart the server."
@@ -4402,31 +4403,37 @@ def bootstrap_admin_user() -> None:
     create_admin_user(auth_config.admin_username, auth_config.admin_password)
 
 
-def create_admin_user(username: str, password: str | None) -> None:
-    if store.has_user(username):
-        # The configured password only matters for bootstrapping. For existing deployments,
-        # check the stored credential instead so operators who upgraded from a release that
-        # shipped a default password are told to rotate it.
-        if store.authenticate_user(username, _LEGACY_DEFAULT_ADMIN_PASSWORD):
+def _warn_if_legacy_default_password_in_use(username: str) -> None:
+    # The configured password only matters for bootstrapping, so inspect the stored credentials
+    # instead. Besides the configured admin, always check the historical `admin` account: an
+    # operator who overrides the bootstrap username on an upgraded deployment must still hear
+    # that the publicly known credential is usable.
+    for candidate in dict.fromkeys((username, _LEGACY_DEFAULT_ADMIN_USERNAME)):
+        if store.authenticate_user(candidate, _LEGACY_DEFAULT_ADMIN_PASSWORD, use_primary=True):
             _logger.warning(
-                f"The MLflow basic auth admin user '{username}' still uses the insecure default "
+                f"The MLflow basic auth user '{candidate}' still uses the insecure default "
                 "password that older MLflow versions shipped in basic_auth.ini "
                 "(https://github.com/advisories/GHSA-gq3w-7jj3-x7gr). Rotate it via "
-                f"{UPDATE_USER_PASSWORD} before exposing this server beyond localhost."
+                f"{UPDATE_USER_PASSWORD} or delete the user before exposing this server beyond "
+                "localhost."
             )
-        return
 
-    _validate_bootstrap_admin_password(username, password)
-    try:
-        store.create_user(username, password, is_admin=True)
-        _logger.info(f"Created admin user '{username}'.")
-    except MlflowException as e:
-        if isinstance(e.__cause__, sqlalchemy.exc.IntegrityError):
+
+def create_admin_user(username: str, password: str | None) -> None:
+    # Read from the primary database: with a read replica configured, replication lag during a
+    # restart could make an existing admin look absent and fail bootstrap for a missing password.
+    if not store.has_user(username, use_primary=True):
+        _validate_bootstrap_admin_password(username, password)
+        try:
+            store.create_user(username, password, is_admin=True)
+            _logger.info(f"Created admin user '{username}'.")
+        except MlflowException as e:
             # When multiple workers are starting up at the same time, it's possible
             # that they try to create the admin user at the same time and one of them
             # will succeed while the others will fail with an IntegrityError.
-            return
-        raise
+            if not isinstance(e.__cause__, sqlalchemy.exc.IntegrityError):
+                raise
+    _warn_if_legacy_default_password_in_use(username)
 
 
 def alert(href: str):

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -4505,12 +4505,16 @@ def create_admin_user(username: str | None, password: str | None) -> None:
             # will succeed while the others will fail with an IntegrityError.
             if not isinstance(e.__cause__, sqlalchemy.exc.IntegrityError):
                 raise
-    elif password is not None and store.authenticate_user(
-        username, _LEGACY_DEFAULT_ADMIN_PASSWORD, use_primary=True
+    elif (
+        password is not None
+        and password != _LEGACY_DEFAULT_ADMIN_PASSWORD
+        and store.authenticate_user(username, _LEGACY_DEFAULT_ADMIN_PASSWORD, use_primary=True)
     ):
         # Upgrade path for deployments bootstrapped with the shipped default: logins with it are
         # rejected, so the configured bootstrap password doubles as the rotation mechanism that
-        # needs no working admin credential.
+        # needs no working admin credential. A configured legacy value is a stale copy of the old
+        # ini rather than a rotation request, so it must not fail startup: the deployment keeps
+        # running with the login block and the warning below.
         _validate_bootstrap_admin_password(username, password)
         store.update_user(username, password=password)
         _logger.warning(

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -4,6 +4,8 @@ Usage
 
 .. code-block:: bash
 
+    export MLFLOW_FLASK_SERVER_SECRET_KEY="<random-secret>"
+    export MLFLOW_AUTH_ADMIN_PASSWORD="<strong-password>"  # required on first start
     mlflow server --app-name basic-auth
 """
 
@@ -52,6 +54,8 @@ from mlflow.entities.model_registry import RegisteredModel
 from mlflow.environment_variables import (
     _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN,
     _MLFLOW_SGI_NAME,
+    MLFLOW_AUTH_ADMIN_PASSWORD,
+    MLFLOW_AUTH_CONFIG_PATH,
     MLFLOW_BASIC_AUTH_FAIL_CLOSED,
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_FLASK_SERVER_SECRET_KEY,
@@ -4361,37 +4365,68 @@ def _after_request(resp: Response):
     return resp
 
 
-def create_admin_user(username, password):
-    if not store.has_user(username):
-        try:
-            store.create_user(username, password, is_admin=True)
-            _logger.info(
-                f"Created admin user '{username}'. "
-                "It is recommended that you set a new password as soon as possible "
-                f"on {UPDATE_USER_PASSWORD}."
-            )
-        except MlflowException as e:
-            if isinstance(e.__cause__, sqlalchemy.exc.IntegrityError):
-                # When multiple workers are starting up at the same time, it's possible
-                # that they try to create the admin user at the same time and one of them
-                # will succeed while the others will fail with an IntegrityError.
-                return
-            raise
+# The admin password that earlier MLflow versions shipped in basic_auth.ini
+# (https://github.com/advisories/GHSA-gq3w-7jj3-x7gr). It is never accepted for bootstrapping
+# a new admin user, and deployments whose existing admin still uses it are warned at startup.
+_LEGACY_DEFAULT_ADMIN_PASSWORD = "password1234"
 
 
-# Must match the admin_password shipped in mlflow/server/auth/basic_auth.ini.
-_DEFAULT_ADMIN_PASSWORD = "password1234"
-
-
-def _warn_if_default_admin_password(password):
-    if password == _DEFAULT_ADMIN_PASSWORD:
-        _logger.warning(
-            "The MLflow basic auth admin account is using the default password shipped "
-            "in basic_auth.ini. Change it before exposing this server beyond localhost. "
-            "To override, set the MLFLOW_AUTH_CONFIG_PATH environment variable to point "
-            "to a custom basic_auth.ini with a non-default admin_password, or update the "
-            f"password via {UPDATE_USER_PASSWORD} after startup."
+def _validate_bootstrap_admin_password(username: str, password: str | None) -> None:
+    if not password:
+        raise MlflowException(
+            f"MLflow Authentication needs a password to create the admin user '{username}', "
+            "and none is configured. MLflow ships no default admin password. Set the "
+            f"{MLFLOW_AUTH_ADMIN_PASSWORD.name} environment variable, or set `admin_password` "
+            f"in the configuration file referenced by {MLFLOW_AUTH_CONFIG_PATH.name}, and "
+            "restart the server."
         )
+    if password == _LEGACY_DEFAULT_ADMIN_PASSWORD:
+        raise MlflowException(
+            f"Refusing to create the admin user '{username}' with the insecure default "
+            "password that older MLflow versions shipped in basic_auth.ini "
+            "(https://github.com/advisories/GHSA-gq3w-7jj3-x7gr). Set "
+            f"{MLFLOW_AUTH_ADMIN_PASSWORD.name} or `admin_password` in the configuration file "
+            f"referenced by {MLFLOW_AUTH_CONFIG_PATH.name} to a different password."
+        )
+
+
+def bootstrap_admin_user() -> None:
+    """Initialize the auth store and create the admin user if it does not exist yet.
+
+    Runs in every worker via ``create_app`` and, before any worker exists, in the
+    ``mlflow server`` process. The uvicorn supervisor restarts workers that die while loading
+    the app, so a bootstrap failure inside a worker would otherwise turn into an endless
+    restart loop instead of one clear error that exits the command.
+    """
+    store.init_db(auth_config.database_uri, read_db_uri=auth_config.read_database_uri)
+    create_admin_user(auth_config.admin_username, auth_config.admin_password)
+
+
+def create_admin_user(username: str, password: str | None) -> None:
+    if store.has_user(username):
+        # The configured password only matters for bootstrapping. For existing deployments,
+        # check the stored credential instead so operators who upgraded from a release that
+        # shipped a default password are told to rotate it.
+        if store.authenticate_user(username, _LEGACY_DEFAULT_ADMIN_PASSWORD):
+            _logger.warning(
+                f"The MLflow basic auth admin user '{username}' still uses the insecure default "
+                "password that older MLflow versions shipped in basic_auth.ini "
+                "(https://github.com/advisories/GHSA-gq3w-7jj3-x7gr). Rotate it via "
+                f"{UPDATE_USER_PASSWORD} before exposing this server beyond localhost."
+            )
+        return
+
+    _validate_bootstrap_admin_password(username, password)
+    try:
+        store.create_user(username, password, is_admin=True)
+        _logger.info(f"Created admin user '{username}'.")
+    except MlflowException as e:
+        if isinstance(e.__cause__, sqlalchemy.exc.IntegrityError):
+            # When multiple workers are starting up at the same time, it's possible
+            # that they try to create the admin user at the same time and one of them
+            # will succeed while the others will fail with an IntegrityError.
+            return
+        raise
 
 
 def alert(href: str):
@@ -5920,12 +5955,7 @@ def create_app(app: Flask = app):
     csrf = CSRFProtect()
     csrf.init_app(app)
 
-    store.init_db(
-        auth_config.database_uri,
-        read_db_uri=auth_config.read_database_uri,
-    )
-    create_admin_user(auth_config.admin_username, auth_config.admin_password)
-    _warn_if_default_admin_password(auth_config.admin_password)
+    bootstrap_admin_user()
 
     _auth_initialized = True
 

--- a/mlflow/server/auth/basic_auth.ini
+++ b/mlflow/server/auth/basic_auth.ini
@@ -2,7 +2,11 @@
 default_permission = READ
 database_uri = sqlite:///basic_auth.db
 admin_username = admin
-admin_password = password1234
+# MLflow ships no default admin password. The first time the auth app starts against an empty
+# user store it creates `admin_username` with the password from `admin_password` below or from
+# the MLFLOW_AUTH_ADMIN_PASSWORD environment variable, and refuses to start if neither is set.
+# Both settings are ignored once the admin user exists; rotate it via the update-password API.
+# admin_password =
 authorization_function = mlflow.server.auth:authenticate_request_basic_auth
 # When true, users inherit default_permission for the reserved 'default' workspace.
 grant_default_workspace_access = false

--- a/mlflow/server/auth/config.py
+++ b/mlflow/server/auth/config.py
@@ -38,13 +38,24 @@ def read_auth_config() -> AuthConfig:
     config_path = _get_auth_config_path()
     config = configparser.ConfigParser()
     config.read(config_path)
+    # An environment variable that is set takes precedence even when it is empty, so an empty
+    # injected secret surfaces as a bootstrap error instead of silently falling back to a
+    # possibly stale value in the file. An empty password normalizes to None.
+    admin_username = (
+        MLFLOW_AUTH_ADMIN_USERNAME.get()
+        if MLFLOW_AUTH_ADMIN_USERNAME.is_set()
+        else config["mlflow"]["admin_username"]
+    )
+    admin_password = (
+        MLFLOW_AUTH_ADMIN_PASSWORD.get()
+        if MLFLOW_AUTH_ADMIN_PASSWORD.is_set()
+        else config["mlflow"].get("admin_password")
+    ) or None
     return AuthConfig(
         default_permission=config["mlflow"]["default_permission"],
         database_uri=config["mlflow"]["database_uri"],
-        admin_username=MLFLOW_AUTH_ADMIN_USERNAME.get() or config["mlflow"]["admin_username"],
-        admin_password=MLFLOW_AUTH_ADMIN_PASSWORD.get()
-        or config["mlflow"].get("admin_password")
-        or None,
+        admin_username=admin_username,
+        admin_password=admin_password,
         authorization_function=config["mlflow"].get(
             "authorization_function", DEFAULT_AUTHORIZATION_FUNCTION
         ),

--- a/mlflow/server/auth/config.py
+++ b/mlflow/server/auth/config.py
@@ -14,10 +14,10 @@ DEFAULT_AUTHORIZATION_FUNCTION = "mlflow.server.auth:authenticate_request_basic_
 class AuthConfig(NamedTuple):
     default_permission: str
     database_uri: str
-    admin_username: str
-    # None when neither the config file nor MLFLOW_AUTH_ADMIN_PASSWORD provides one. MLflow
-    # ships no default admin password; the auth app refuses to bootstrap the admin user
-    # without an explicit value.
+    # Both are None when neither the config file nor the MLFLOW_AUTH_ADMIN_* environment
+    # variable provides a non-empty value. MLflow ships no default admin password; the auth app
+    # refuses to bootstrap the admin user without explicit values.
+    admin_username: str | None
     admin_password: str | None
     authorization_function: str
     grant_default_workspace_access: bool
@@ -40,12 +40,12 @@ def read_auth_config() -> AuthConfig:
     config.read(config_path)
     # An environment variable that is set takes precedence even when it is empty, so an empty
     # injected secret surfaces as a bootstrap error instead of silently falling back to a
-    # possibly stale value in the file. An empty password normalizes to None.
+    # possibly stale value in the file. Empty values normalize to None.
     admin_username = (
         MLFLOW_AUTH_ADMIN_USERNAME.get()
         if MLFLOW_AUTH_ADMIN_USERNAME.is_set()
-        else config["mlflow"]["admin_username"]
-    )
+        else config["mlflow"].get("admin_username")
+    ) or None
     admin_password = (
         MLFLOW_AUTH_ADMIN_PASSWORD.get()
         if MLFLOW_AUTH_ADMIN_PASSWORD.is_set()

--- a/mlflow/server/auth/config.py
+++ b/mlflow/server/auth/config.py
@@ -2,7 +2,11 @@ import configparser
 from pathlib import Path
 from typing import NamedTuple
 
-from mlflow.environment_variables import MLFLOW_AUTH_CONFIG_PATH
+from mlflow.environment_variables import (
+    MLFLOW_AUTH_ADMIN_PASSWORD,
+    MLFLOW_AUTH_ADMIN_USERNAME,
+    MLFLOW_AUTH_CONFIG_PATH,
+)
 
 DEFAULT_AUTHORIZATION_FUNCTION = "mlflow.server.auth:authenticate_request_basic_auth"
 
@@ -11,7 +15,10 @@ class AuthConfig(NamedTuple):
     default_permission: str
     database_uri: str
     admin_username: str
-    admin_password: str
+    # None when neither the config file nor MLFLOW_AUTH_ADMIN_PASSWORD provides one. MLflow
+    # ships no default admin password; the auth app refuses to bootstrap the admin user
+    # without an explicit value.
+    admin_password: str | None
     authorization_function: str
     grant_default_workspace_access: bool
     workspace_cache_max_size: int
@@ -34,8 +41,10 @@ def read_auth_config() -> AuthConfig:
     return AuthConfig(
         default_permission=config["mlflow"]["default_permission"],
         database_uri=config["mlflow"]["database_uri"],
-        admin_username=config["mlflow"]["admin_username"],
-        admin_password=config["mlflow"]["admin_password"],
+        admin_username=MLFLOW_AUTH_ADMIN_USERNAME.get() or config["mlflow"]["admin_username"],
+        admin_password=MLFLOW_AUTH_ADMIN_PASSWORD.get()
+        or config["mlflow"].get("admin_password")
+        or None,
         authorization_function=config["mlflow"].get(
             "authorization_function", DEFAULT_AUTHORIZATION_FUNCTION
         ),

--- a/mlflow/server/auth/sqlalchemy_store.py
+++ b/mlflow/server/auth/sqlalchemy_store.py
@@ -135,8 +135,8 @@ class SqlAlchemyStore:
             SessionMaker = sessionmaker(bind=self.engine)
             self.ManagedSessionMaker = _get_managed_session_maker(SessionMaker, self.db_type)
 
-    def authenticate_user(self, username: str, password: str) -> bool:
-        with self.ManagedSessionMaker() as session:
+    def authenticate_user(self, username: str, password: str, *, use_primary: bool = False) -> bool:
+        with self.ManagedSessionMaker(read_only=not use_primary) as session:
             try:
                 user = self._get_user(session, username)
                 return check_password_hash(user.password_hash, password)
@@ -174,8 +174,8 @@ class SqlAlchemyStore:
                 INVALID_STATE,
             )
 
-    def has_user(self, username: str) -> bool:
-        with self.ManagedSessionMaker() as session:
+    def has_user(self, username: str, *, use_primary: bool = False) -> bool:
+        with self.ManagedSessionMaker(read_only=not use_primary) as session:
             return session.query(SqlUser).filter(SqlUser.username == username).first() is not None
 
     def get_user(self, username: str) -> User:

--- a/tests/server/auth/auth_test_utils.py
+++ b/tests/server/auth/auth_test_utils.py
@@ -10,7 +10,9 @@ from tests.tracking.integration_test_utils import _send_rest_tracking_post_reque
 PERMISSION = "READ"
 NEW_PERMISSION = "EDIT"
 ADMIN_USERNAME = auth_config.admin_username
-ADMIN_PASSWORD = auth_config.admin_password
+# MLflow ships no default admin password, so tests bootstrap the admin user with this one
+# (either written into an isolated .ini or passed via MLFLOW_AUTH_ADMIN_PASSWORD).
+ADMIN_PASSWORD = "test-admin-password"
 
 
 def write_isolated_auth_config(tmp_path: Path) -> Path:

--- a/tests/server/auth/fixtures/jwt_auth.ini
+++ b/tests/server/auth/fixtures/jwt_auth.ini
@@ -2,5 +2,4 @@
 default_permission = READ
 database_uri = sqlite:///basic_auth.db
 admin_username = admin
-admin_password = password1234
 authorization_function = jwt_auth:authenticate_request

--- a/tests/server/auth/fixtures/no_permission_auth.ini
+++ b/tests/server/auth/fixtures/no_permission_auth.ini
@@ -2,5 +2,4 @@
 default_permission = NO_PERMISSIONS
 database_uri = sqlite:///basic_auth.db
 admin_username = admin
-admin_password = password1234
 authorization_function = mlflow.server.auth:authenticate_request_basic_auth

--- a/tests/server/auth/test_admin_bootstrap.py
+++ b/tests/server/auth/test_admin_bootstrap.py
@@ -169,19 +169,27 @@ def test_create_admin_user_rotates_legacy_default_password_when_password_configu
     assert "Replaced the insecure default password of admin user 'admin'" in messages[0]
 
 
-@pytest.mark.parametrize(
-    ("password", "match"),
-    [
-        (_LEGACY_DEFAULT_PASSWORD, "insecure default password"),
-        ("short", "at least 12 characters"),
-    ],
-)
-def test_create_admin_user_refuses_to_rotate_to_an_invalid_password(store, password, match):
+def test_create_admin_user_refuses_to_rotate_to_a_short_password(store):
     store.has_user.return_value = True
     store.authenticate_user.return_value = True
-    with pytest.raises(MlflowException, match=match):
-        auth_module.create_admin_user("admin", password)
+    with pytest.raises(MlflowException, match="at least 12 characters"):
+        auth_module.create_admin_user("admin", "short")
     store.update_user.assert_not_called()
+
+
+def test_create_admin_user_keeps_starting_with_a_stale_legacy_ini_password(store, caplog):
+    # An upgraded deployment that copied the old ini still has `admin_password = password1234`
+    # next to an admin row on that password. That is not a rotation request and must not fail
+    # startup; the login block and the warning cover it.
+    store.has_user.return_value = True
+    store.authenticate_user.return_value = True
+    with caplog.at_level(logging.WARNING, logger=auth_module.__name__):
+        auth_module.create_admin_user("admin", _LEGACY_DEFAULT_PASSWORD)
+    store.update_user.assert_not_called()
+    store.create_user.assert_not_called()
+    messages = [r.message for r in caplog.records]
+    assert len(messages) == 1
+    assert "user 'admin' still uses the insecure default password" in messages[0]
 
 
 def test_create_admin_user_leaves_a_rotated_password_alone(store):

--- a/tests/server/auth/test_admin_bootstrap.py
+++ b/tests/server/auth/test_admin_bootstrap.py
@@ -150,9 +150,46 @@ def test_create_admin_user_warns_when_existing_admin_uses_legacy_default(store, 
         "admin", _LEGACY_DEFAULT_PASSWORD, use_primary=True
     )
     store.create_user.assert_not_called()
+    store.update_user.assert_not_called()
     assert any(
         "user 'admin' still uses the insecure default password" in r.message for r in caplog.records
     )
+
+
+def test_create_admin_user_rotates_legacy_default_password_when_password_configured(store, caplog):
+    store.has_user.return_value = True
+    # The stored credential is the legacy default until update_user replaces it.
+    store.authenticate_user.side_effect = lambda *_, **__: not store.update_user.called
+    with caplog.at_level(logging.WARNING, logger=auth_module.__name__):
+        auth_module.create_admin_user("admin", "a-strong-admin-password")
+    store.update_user.assert_called_once_with("admin", password="a-strong-admin-password")
+    store.create_user.assert_not_called()
+    messages = [r.message for r in caplog.records]
+    assert len(messages) == 1
+    assert "Replaced the insecure default password of admin user 'admin'" in messages[0]
+
+
+@pytest.mark.parametrize(
+    ("password", "match"),
+    [
+        (_LEGACY_DEFAULT_PASSWORD, "insecure default password"),
+        ("short", "at least 12 characters"),
+    ],
+)
+def test_create_admin_user_refuses_to_rotate_to_an_invalid_password(store, password, match):
+    store.has_user.return_value = True
+    store.authenticate_user.return_value = True
+    with pytest.raises(MlflowException, match=match):
+        auth_module.create_admin_user("admin", password)
+    store.update_user.assert_not_called()
+
+
+def test_create_admin_user_leaves_a_rotated_password_alone(store):
+    store.has_user.return_value = True
+    store.authenticate_user.return_value = False
+    auth_module.create_admin_user("admin", "a-strong-admin-password")
+    store.update_user.assert_not_called()
+    store.create_user.assert_not_called()
 
 
 @pytest.mark.parametrize("root_exists", [True, False])
@@ -166,6 +203,8 @@ def test_create_admin_user_warns_about_legacy_admin_when_username_overridden(
     with caplog.at_level(logging.WARNING, logger=auth_module.__name__):
         auth_module.create_admin_user("root", "a-strong-admin-password")
     assert store.create_user.call_count == (0 if root_exists else 1)
+    # The configured password only rotates the configured bootstrap admin, never another user.
+    store.update_user.assert_not_called()
     messages = [r.message for r in caplog.records]
     assert len(messages) == 1
     assert "user 'admin' still uses the insecure default password" in messages[0]

--- a/tests/server/auth/test_admin_bootstrap.py
+++ b/tests/server/auth/test_admin_bootstrap.py
@@ -69,10 +69,17 @@ def test_admin_password_resolution(tmp_path, monkeypatch, ini_password, env_pass
     assert config.admin_password == expected
 
 
-@pytest.mark.parametrize("env_username", ["root", ""])
-def test_admin_username_env_overrides_ini(tmp_path, monkeypatch, env_username):
+@pytest.mark.parametrize(
+    ("env_username", "expected"),
+    [
+        ("root", "root"),
+        # A set-but-empty variable wins over the file and normalizes to None, like the password.
+        ("", None),
+    ],
+)
+def test_admin_username_env_overrides_ini(tmp_path, monkeypatch, env_username, expected):
     monkeypatch.setenv(MLFLOW_AUTH_ADMIN_USERNAME.name, env_username)
-    assert _read_config(_write_ini(tmp_path)).admin_username == env_username
+    assert _read_config(_write_ini(tmp_path)).admin_username == expected
 
 
 @pytest.fixture
@@ -81,11 +88,29 @@ def store():
         yield store
 
 
-@pytest.mark.parametrize("password", [None, ""])
-def test_create_admin_user_requires_password(store, password):
+@pytest.mark.parametrize("username", [None, ""])
+def test_create_admin_user_requires_username(store, username):
+    with pytest.raises(MlflowException, match="needs a username for the admin user") as exc_info:
+        auth_module.create_admin_user(username, "a-strong-admin-password")
+    assert MLFLOW_AUTH_ADMIN_USERNAME.name in str(exc_info.value)
+    store.has_user.assert_not_called()
+    store.create_user.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("password", "match"),
+    [
+        (None, "needs a password to create the admin user"),
+        ("", "needs a password to create the admin user"),
+        ("short", "at least 12 characters"),
+    ],
+)
+def test_create_admin_user_rejects_missing_or_short_password(store, password, match):
     store.has_user.return_value = False
-    with pytest.raises(MlflowException, match="needs a password to create the admin user"):
+    with pytest.raises(MlflowException, match=match) as exc_info:
         auth_module.create_admin_user("admin", password)
+    # Every misconfiguration names the setting to fix.
+    assert MLFLOW_AUTH_ADMIN_PASSWORD.name in str(exc_info.value)
     store.create_user.assert_not_called()
 
 

--- a/tests/server/auth/test_admin_bootstrap.py
+++ b/tests/server/auth/test_admin_bootstrap.py
@@ -53,6 +53,8 @@ def test_packaged_config_ships_no_admin_password():
         ("ini-admin-password", None, "ini-admin-password"),
         (None, "env-admin-password", "env-admin-password"),
         ("ini-admin-password", "env-admin-password", "env-admin-password"),
+        # A set-but-empty variable wins over the file so the misconfiguration is not masked.
+        ("ini-admin-password", "", None),
     ],
 )
 def test_admin_password_resolution(tmp_path, monkeypatch, ini_password, env_password, expected):
@@ -62,9 +64,10 @@ def test_admin_password_resolution(tmp_path, monkeypatch, ini_password, env_pass
     assert config.admin_password == expected
 
 
-def test_admin_username_env_overrides_ini(tmp_path, monkeypatch):
-    monkeypatch.setenv(MLFLOW_AUTH_ADMIN_USERNAME.name, "root")
-    assert _read_config(_write_ini(tmp_path)).admin_username == "root"
+@pytest.mark.parametrize("env_username", ["root", ""])
+def test_admin_username_env_overrides_ini(tmp_path, monkeypatch, env_username):
+    monkeypatch.setenv(MLFLOW_AUTH_ADMIN_USERNAME.name, env_username)
+    assert _read_config(_write_ini(tmp_path)).admin_username == env_username
 
 
 @pytest.fixture
@@ -90,7 +93,9 @@ def test_create_admin_user_rejects_legacy_default_password(store):
 
 def test_create_admin_user_creates_admin_with_configured_password(store):
     store.has_user.return_value = False
+    store.authenticate_user.return_value = False
     auth_module.create_admin_user("admin", "a-strong-admin-password")
+    store.has_user.assert_called_once_with("admin", use_primary=True)
     store.create_user.assert_called_once_with("admin", "a-strong-admin-password", is_admin=True)
 
 
@@ -110,9 +115,30 @@ def test_create_admin_user_warns_when_existing_admin_uses_legacy_default(store, 
     store.authenticate_user.return_value = True
     with caplog.at_level(logging.WARNING, logger=auth_module.__name__):
         auth_module.create_admin_user("admin", None)
-    store.authenticate_user.assert_called_once_with("admin", _LEGACY_DEFAULT_PASSWORD)
+    # Reads go to the primary so replica lag cannot hide an existing admin during a restart.
+    store.authenticate_user.assert_called_once_with(
+        "admin", _LEGACY_DEFAULT_PASSWORD, use_primary=True
+    )
     store.create_user.assert_not_called()
-    assert any("still uses the insecure default password" in r.message for r in caplog.records)
+    assert any(
+        "user 'admin' still uses the insecure default password" in r.message for r in caplog.records
+    )
+
+
+@pytest.mark.parametrize("root_exists", [True, False])
+def test_create_admin_user_warns_about_legacy_admin_when_username_overridden(
+    store, caplog, root_exists
+):
+    # Overriding the bootstrap username on an upgraded deployment must not hide the historical
+    # `admin` account that still carries the publicly known password.
+    store.has_user.return_value = root_exists
+    store.authenticate_user.side_effect = lambda username, password, **_: username == "admin"
+    with caplog.at_level(logging.WARNING, logger=auth_module.__name__):
+        auth_module.create_admin_user("root", "a-strong-admin-password")
+    assert store.create_user.call_count == (0 if root_exists else 1)
+    messages = [r.message for r in caplog.records]
+    assert len(messages) == 1
+    assert "user 'admin' still uses the insecure default password" in messages[0]
 
 
 def test_bootstrap_admin_user_initializes_store_then_creates_admin(store, monkeypatch):

--- a/tests/server/auth/test_admin_bootstrap.py
+++ b/tests/server/auth/test_admin_bootstrap.py
@@ -1,0 +1,133 @@
+import logging
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from mlflow.environment_variables import MLFLOW_AUTH_ADMIN_PASSWORD, MLFLOW_AUTH_ADMIN_USERNAME
+from mlflow.exceptions import MlflowException
+from mlflow.server import auth as auth_module
+from mlflow.server.auth.config import read_auth_config
+
+_PACKAGED_BASIC_AUTH_INI = Path(auth_module.__file__).parent / "basic_auth.ini"
+_LEGACY_DEFAULT_PASSWORD = "password1234"
+
+
+@pytest.fixture(autouse=True)
+def _clear_admin_env(monkeypatch):
+    monkeypatch.delenv(MLFLOW_AUTH_ADMIN_USERNAME.name, raising=False)
+    monkeypatch.delenv(MLFLOW_AUTH_ADMIN_PASSWORD.name, raising=False)
+
+
+def _write_ini(tmp_path: Path, *, admin_password: str | None = None) -> Path:
+    lines = [
+        "[mlflow]",
+        "default_permission = READ",
+        f"database_uri = sqlite:///{tmp_path / 'auth.db'}",
+        "admin_username = admin",
+    ]
+    if admin_password is not None:
+        lines.append(f"admin_password = {admin_password}")
+    path = tmp_path / "auth.ini"
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def _read_config(path: Path):
+    with mock.patch("mlflow.server.auth.config._get_auth_config_path", return_value=str(path)):
+        return read_auth_config()
+
+
+def test_packaged_config_ships_no_admin_password():
+    config = _read_config(_PACKAGED_BASIC_AUTH_INI)
+    assert config.admin_username == "admin"
+    assert config.admin_password is None
+    assert _LEGACY_DEFAULT_PASSWORD not in _PACKAGED_BASIC_AUTH_INI.read_text()
+
+
+@pytest.mark.parametrize(
+    ("ini_password", "env_password", "expected"),
+    [
+        (None, None, None),
+        ("", None, None),
+        ("ini-admin-password", None, "ini-admin-password"),
+        (None, "env-admin-password", "env-admin-password"),
+        ("ini-admin-password", "env-admin-password", "env-admin-password"),
+    ],
+)
+def test_admin_password_resolution(tmp_path, monkeypatch, ini_password, env_password, expected):
+    if env_password is not None:
+        monkeypatch.setenv(MLFLOW_AUTH_ADMIN_PASSWORD.name, env_password)
+    config = _read_config(_write_ini(tmp_path, admin_password=ini_password))
+    assert config.admin_password == expected
+
+
+def test_admin_username_env_overrides_ini(tmp_path, monkeypatch):
+    monkeypatch.setenv(MLFLOW_AUTH_ADMIN_USERNAME.name, "root")
+    assert _read_config(_write_ini(tmp_path)).admin_username == "root"
+
+
+@pytest.fixture
+def store():
+    with mock.patch.object(auth_module, "store") as store:
+        yield store
+
+
+@pytest.mark.parametrize("password", [None, ""])
+def test_create_admin_user_requires_password(store, password):
+    store.has_user.return_value = False
+    with pytest.raises(MlflowException, match="needs a password to create the admin user"):
+        auth_module.create_admin_user("admin", password)
+    store.create_user.assert_not_called()
+
+
+def test_create_admin_user_rejects_legacy_default_password(store):
+    store.has_user.return_value = False
+    with pytest.raises(MlflowException, match="insecure default password"):
+        auth_module.create_admin_user("admin", _LEGACY_DEFAULT_PASSWORD)
+    store.create_user.assert_not_called()
+
+
+def test_create_admin_user_creates_admin_with_configured_password(store):
+    store.has_user.return_value = False
+    auth_module.create_admin_user("admin", "a-strong-admin-password")
+    store.create_user.assert_called_once_with("admin", "a-strong-admin-password", is_admin=True)
+
+
+def test_create_admin_user_skips_bootstrap_when_admin_exists(store, caplog):
+    store.has_user.return_value = True
+    store.authenticate_user.return_value = False
+    with caplog.at_level(logging.WARNING, logger=auth_module.__name__):
+        # Missing / legacy configured passwords are irrelevant once the admin exists.
+        auth_module.create_admin_user("admin", None)
+        auth_module.create_admin_user("admin", _LEGACY_DEFAULT_PASSWORD)
+    store.create_user.assert_not_called()
+    assert not caplog.records
+
+
+def test_create_admin_user_warns_when_existing_admin_uses_legacy_default(store, caplog):
+    store.has_user.return_value = True
+    store.authenticate_user.return_value = True
+    with caplog.at_level(logging.WARNING, logger=auth_module.__name__):
+        auth_module.create_admin_user("admin", None)
+    store.authenticate_user.assert_called_once_with("admin", _LEGACY_DEFAULT_PASSWORD)
+    store.create_user.assert_not_called()
+    assert any("still uses the insecure default password" in r.message for r in caplog.records)
+
+
+def test_bootstrap_admin_user_initializes_store_then_creates_admin(store, monkeypatch):
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(
+            database_uri="sqlite:///auth.db",
+            read_database_uri=None,
+            admin_username="admin",
+            admin_password=None,
+        ),
+    )
+    store.has_user.return_value = False
+    with pytest.raises(MlflowException, match="needs a password"):
+        auth_module.bootstrap_admin_user()
+    store.init_db.assert_called_once_with("sqlite:///auth.db", read_db_uri=None)
+    store.create_user.assert_not_called()

--- a/tests/server/auth/test_admin_bootstrap.py
+++ b/tests/server/auth/test_admin_bootstrap.py
@@ -4,7 +4,11 @@ from unittest import mock
 
 import pytest
 
-from mlflow.environment_variables import MLFLOW_AUTH_ADMIN_PASSWORD, MLFLOW_AUTH_ADMIN_USERNAME
+from mlflow.environment_variables import (
+    _MLFLOW_AUTH_ADMIN_BOOTSTRAPPED,
+    MLFLOW_AUTH_ADMIN_PASSWORD,
+    MLFLOW_AUTH_ADMIN_USERNAME,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.server import auth as auth_module
 from mlflow.server.auth.config import read_auth_config
@@ -17,6 +21,7 @@ _LEGACY_DEFAULT_PASSWORD = "password1234"
 def _clear_admin_env(monkeypatch):
     monkeypatch.delenv(MLFLOW_AUTH_ADMIN_USERNAME.name, raising=False)
     monkeypatch.delenv(MLFLOW_AUTH_ADMIN_PASSWORD.name, raising=False)
+    monkeypatch.delenv(_MLFLOW_AUTH_ADMIN_BOOTSTRAPPED.name, raising=False)
 
 
 def _write_ini(tmp_path: Path, *, admin_password: str | None = None) -> Path:
@@ -157,3 +162,31 @@ def test_bootstrap_admin_user_initializes_store_then_creates_admin(store, monkey
         auth_module.bootstrap_admin_user()
     store.init_db.assert_called_once_with("sqlite:///auth.db", read_db_uri=None)
     store.create_user.assert_not_called()
+
+
+@pytest.mark.parametrize("already_bootstrapped", [True, False])
+def test_init_store_for_app_skips_bootstrap_when_cli_already_did_it(
+    store, monkeypatch, already_bootstrapped
+):
+    if already_bootstrapped:
+        monkeypatch.setenv(_MLFLOW_AUTH_ADMIN_BOOTSTRAPPED.name, "true")
+    monkeypatch.setattr(
+        auth_module,
+        "auth_config",
+        auth_module.auth_config._replace(
+            database_uri="sqlite:///auth.db",
+            read_database_uri=None,
+            admin_username="admin",
+            admin_password="a-strong-admin-password",
+        ),
+    )
+    store.has_user.return_value = False
+    store.authenticate_user.return_value = False
+    auth_module._init_store_for_app()
+    store.init_db.assert_called_once_with("sqlite:///auth.db", read_db_uri=None)
+    if already_bootstrapped:
+        store.has_user.assert_not_called()
+        store.authenticate_user.assert_not_called()
+        store.create_user.assert_not_called()
+    else:
+        store.create_user.assert_called_once_with("admin", "a-strong-admin-password", is_admin=True)

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -21,6 +21,7 @@ from mlflow.entities import Dataset, DatasetInput, InputTag, LoggedModelOutput
 from mlflow.entities.logged_model_status import LoggedModelStatus
 from mlflow.environment_variables import (
     _MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN,
+    MLFLOW_AUTH_ADMIN_PASSWORD,
     MLFLOW_ENABLE_WORKSPACES,
     MLFLOW_FLASK_SERVER_SECRET_KEY,
     MLFLOW_TRACKING_PASSWORD,
@@ -94,6 +95,10 @@ def _isolate_auth_config(extra_env: dict[str, str], tmp_path: Path) -> dict[str,
 
     Relative ``MLFLOW_AUTH_CONFIG_PATH`` values are anchored to this test
     file's directory so the helper works regardless of pytest's CWD.
+
+    Neither the packaged config nor the fixtures carry an admin password (MLflow
+    ships none), so the bootstrap password is supplied through
+    ``MLFLOW_AUTH_ADMIN_PASSWORD`` unless ``extra_env`` already sets it.
     """
     if raw := extra_env.get("MLFLOW_AUTH_CONFIG_PATH"):
         src_path = Path(raw)
@@ -110,7 +115,11 @@ def _isolate_auth_config(extra_env: dict[str, str], tmp_path: Path) -> dict[str,
     )
     dst_path = tmp_path / src_path.name
     dst_path.write_text(isolated_text)
-    return {**extra_env, "MLFLOW_AUTH_CONFIG_PATH": str(dst_path)}
+    return {
+        MLFLOW_AUTH_ADMIN_PASSWORD.name: ADMIN_PASSWORD,
+        **extra_env,
+        "MLFLOW_AUTH_CONFIG_PATH": str(dst_path),
+    }
 
 
 @pytest.fixture

--- a/tests/server/auth/test_auth.py
+++ b/tests/server/auth/test_auth.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+import logging
 import re
 import subprocess
 import sys
@@ -4959,6 +4960,62 @@ def test_flask_basic_auth_skips_get_user_when_cache_disabled(
     mock_auth_store.authenticate_user.assert_called_once_with("alice", "password123")
     # Cache disabled + Flask path only needs the yes/no answer → no user fetch.
     mock_auth_store.get_user.assert_not_called()
+
+
+@pytest.mark.parametrize("is_admin", [True, False])
+def test_flask_basic_auth_rejects_legacy_default_password_for_admins(
+    mock_auth_store, mock_auth_config, monkeypatch, caplog, is_admin
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    mock_auth_store.get_user.side_effect = lambda username: mock.Mock(
+        username=username, is_admin=is_admin
+    )
+    fake_flask_request = mock.Mock()
+    fake_flask_request.authorization.username = "admin"
+    fake_flask_request.authorization.password = "password1234"
+    challenge = object()
+
+    with (
+        mock.patch("mlflow.server.auth._USER_AUTH_CACHE", None),
+        mock.patch("mlflow.server.auth.request", fake_flask_request),
+        mock.patch("mlflow.server.auth.make_basic_auth_response", return_value=challenge),
+        caplog.at_level(logging.WARNING, logger=auth_module.__name__),
+    ):
+        result = auth_module.authenticate_request_basic_auth()
+
+    mock_auth_store.authenticate_user.assert_called_once_with("admin", "password1234")
+    mock_auth_store.get_user.assert_called_once_with("admin")
+    rejected = [r for r in caplog.records if "Rejected a login by admin user 'admin'" in r.message]
+    if is_admin:
+        assert result is challenge
+        assert len(rejected) == 1
+    else:
+        assert result is fake_flask_request.authorization
+        assert not rejected
+
+
+@pytest.mark.parametrize("cache_enabled", [True, False])
+def test_fastapi_basic_auth_rejects_legacy_default_password_for_admins(
+    mock_auth_store, mock_auth_config, monkeypatch, caplog, cache_enabled
+):
+    monkeypatch.delenv(_MLFLOW_INTERNAL_GATEWAY_AUTH_TOKEN.name, raising=False)
+    mock_auth_store.get_user.side_effect = lambda username: mock.Mock(
+        username=username, is_admin=True
+    )
+    credentials = base64.b64encode(b"admin:password1234").decode("ascii")
+    cache = TTLCache(maxsize=10, ttl=60) if cache_enabled else None
+
+    with (
+        mock.patch("mlflow.server.auth._USER_AUTH_CACHE", cache),
+        caplog.at_level(logging.WARNING, logger=auth_module.__name__),
+    ):
+        assert _authenticate_fastapi_request(_make_request("/x", f"Basic {credentials}")) is None
+
+    mock_auth_store.authenticate_user.assert_called_once_with("admin", "password1234")
+    assert any("Rejected a login by admin user 'admin'" in r.message for r in caplog.records)
+    if cache_enabled:
+        # The rejected credential must not be cached as valid.
+        assert auth_module._auth_cache_key("admin", "password1234") not in cache
 
 
 def test_flask_basic_auth_shares_cache_with_fastapi_path(

--- a/tests/server/auth/test_read_write_routing.py
+++ b/tests/server/auth/test_read_write_routing.py
@@ -61,6 +61,22 @@ def test_none_read_uri_skips_replica(store_no_replica):
 # --- TestReadWriteRouting ---
 
 
+def test_bootstrap_reads_can_bypass_stale_replica(store_with_replica):
+    # The admin bootstrap must see users that exist on the primary even when the replica lags.
+    store_with_replica.create_user("primary_only_admin", "primary-only-password", is_admin=True)
+    assert store_with_replica.has_user("primary_only_admin") is False
+    assert store_with_replica.has_user("primary_only_admin", use_primary=True) is True
+    assert (
+        store_with_replica.authenticate_user("primary_only_admin", "primary-only-password") is False
+    )
+    assert (
+        store_with_replica.authenticate_user(
+            "primary_only_admin", "primary-only-password", use_primary=True
+        )
+        is True
+    )
+
+
 def test_write_goes_to_primary(store_with_replica):
     user = store_with_replica.create_user("test_user", "password12345678")
     assert user.username == "test_user"

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -8,7 +8,11 @@ from unittest import mock
 import pytest
 
 from mlflow import server
-from mlflow.environment_variables import _MLFLOW_SERVER_BOOT_ID, _MLFLOW_SGI_NAME
+from mlflow.environment_variables import (
+    _MLFLOW_AUTH_ADMIN_BOOTSTRAPPED,
+    _MLFLOW_SERVER_BOOT_ID,
+    _MLFLOW_SGI_NAME,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.utils import find_free_port
 from mlflow.utils.os import is_windows
@@ -339,6 +343,10 @@ def test_run_server_bootstraps_basic_auth_admin_before_spawning_workers(mock_exe
         )
     bootstrap.assert_called_once_with()
     mock_exec_cmd.assert_called_once()
+    # Workers are told the bootstrap already happened so they skip the PBKDF2 checks.
+    assert mock_exec_cmd.call_args.kwargs["extra_env"][_MLFLOW_AUTH_ADMIN_BOOTSTRAPPED.name] == (
+        "true"
+    )
 
 
 def test_run_server_fails_before_spawning_workers_when_admin_bootstrap_fails(
@@ -380,3 +388,4 @@ def test_run_server_skips_admin_bootstrap_for_default_app(mock_exec_cmd, monkeyp
             port="",
         )
     bootstrap.assert_not_called()
+    assert _MLFLOW_AUTH_ADMIN_BOOTSTRAPPED.name not in mock_exec_cmd.call_args.kwargs["extra_env"]

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -321,3 +321,62 @@ def test_mlflow_server_shuts_down_on_signal(sig: signal.Signals, tmp_path):
                 proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 proc.kill()
+
+
+def test_run_server_bootstraps_basic_auth_admin_before_spawning_workers(mock_exec_cmd, monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "false")
+    with mock.patch("mlflow.server.auth.bootstrap_admin_user") as bootstrap:
+        server._run_server(
+            file_store_path="",
+            registry_store_uri="",
+            default_artifact_root="",
+            serve_artifacts="",
+            artifacts_only="",
+            artifacts_destination="",
+            host="",
+            port="",
+            app_name="basic-auth",
+        )
+    bootstrap.assert_called_once_with()
+    mock_exec_cmd.assert_called_once()
+
+
+def test_run_server_fails_before_spawning_workers_when_admin_bootstrap_fails(
+    mock_exec_cmd, monkeypatch
+):
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "false")
+    with (
+        mock.patch(
+            "mlflow.server.auth.bootstrap_admin_user",
+            side_effect=MlflowException("no admin password"),
+        ),
+        pytest.raises(MlflowException, match="no admin password"),
+    ):
+        server._run_server(
+            file_store_path="",
+            registry_store_uri="",
+            default_artifact_root="",
+            serve_artifacts="",
+            artifacts_only="",
+            artifacts_destination="",
+            host="",
+            port="",
+            app_name="basic-auth",
+        )
+    mock_exec_cmd.assert_not_called()
+
+
+def test_run_server_skips_admin_bootstrap_for_default_app(mock_exec_cmd, monkeypatch):
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "false")
+    with mock.patch("mlflow.server.auth.bootstrap_admin_user") as bootstrap:
+        server._run_server(
+            file_store_path="",
+            registry_store_uri="",
+            default_artifact_root="",
+            serve_artifacts="",
+            artifacts_only="",
+            artifacts_destination="",
+            host="",
+            port="",
+        )
+    bootstrap.assert_not_called()


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/advisories/GHSA-gq3w-7jj3-x7gr (CVE-2026-2635). Note that the advisory's metadata is misattributed: it references #19260 (an artifact path-traversal fix) and claims 3.8.0rc0 is patched, but the default credential was still shipped on master. The only prior mitigation was the startup warning from #23182.

### What changes are proposed in this pull request?

`mlflow/server/auth/basic_auth.ini` shipped `admin_password = password1234`, so any `mlflow server --app-name basic-auth` deployment that did not supply a custom config file exposed a network-reachable admin account with a publicly documented password (CWE-1393).

- Drop `admin_password` from the shipped `basic_auth.ini`. MLflow no longer ships any default admin password.
- Add `MLFLOW_AUTH_ADMIN_USERNAME` / `MLFLOW_AUTH_ADMIN_PASSWORD` environment variables that override the ini values, so the bootstrap credential can be injected (Docker `-e`, Kubernetes `secretKeyRef`, `--env-file`) without writing a custom config file. The value is consumed once at bootstrap and ignored afterwards; the docs tell operators to unset it after the first start.
- Refuse to bootstrap the admin user when no password is configured, when it is shorter than the 12-character policy, or when it equals the legacy default, with an error naming both ways to fix it. An empty or missing admin username fails the same way.
- Stop accepting the legacy default on upgraded deployments. A basic-auth login by an admin user that presents `password1234` is rejected (401, warning logged, credential never cached); non-admin users are unaffected. The server itself keeps starting, so nobody is locked out of it.
- Give upgraders a rotation path that needs no working admin login: while the bootstrap admin still has the legacy password, a configured `MLFLOW_AUTH_ADMIN_PASSWORD` / `admin_password` replaces it once at startup (same validation as on first start) and the log says so. A startup warning is logged as long as any admin still has the legacy password.
- Bootstrap the admin user in the `mlflow server` CLI process before workers are spawned. Without this, a bootstrap failure inside `create_app` becomes an endless loop of the uvicorn multiprocess supervisor restarting crashed workers instead of the command exiting with one error. This also removes the multi-worker race on creating the admin.
- Update both auth docs pages (drop the published credential table, describe the requirement and the upgrade warning), the test fixtures and shared test helper that read the password from the shipped ini, and the gateway benchmark default.

**Intended posture.** Fresh installs cannot obtain the default credential at all. Upgraded deployments are not refused startup (force-rotating the only admin at boot risks locking operators out of the whole server), but the publicly known admin credential stops working on the first request after upgrade, which is what closes the advisory rather than warning about it. Rotation is one env var and one restart, or another admin updating or deleting the user.

A missing `MLFLOW_FLASK_SERVER_SECRET_KEY` still crash-loops in the same way; that is pre-existing and left for a separate PR.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `tests/server/auth/test_admin_bootstrap.py` (config precedence, shipped ini has no password, every branch of the bootstrap and rotation logic), `tests/server/auth/test_auth.py` (legacy admin login rejected on the Flask and FastAPI paths with and without the credential cache, non-admins unaffected) and `tests/server/test_init.py` (pre-flight runs before spawning workers, blocks the spawn on failure, skipped for the default app). The full `tests/server/auth` suite and `tests/agent/test_setup_sh_e2e.py` pass.

Manual, with an isolated `MLFLOW_AUTH_CONFIG_PATH` ini and the default worker count:

- No password configured: `mlflow server --app-name basic-auth` exits with code 1 and a single "needs a password to create the admin user" error; uvicorn never starts.
- `MLFLOW_AUTH_ADMIN_PASSWORD=password1234`: exits with the "Refusing to create the admin user with the insecure default password" error.
- `MLFLOW_AUTH_ADMIN_PASSWORD=<strong>`: admin created once; unauthenticated and `admin:password1234` requests get 401, the configured password gets 200.
- Restart with the variable unset: server starts normally because the admin row exists.
- Pre-seeded admin with `password1234` in the auth DB (simulated upgrade), no password configured: server starts and logs the rotation warning once; `admin:password1234` gets 401 with a "Rejected a login" warning; a non-admin user with the same password still gets 200.
- Same DB, restart with `MLFLOW_AUTH_ADMIN_PASSWORD=<new>`: log shows the password was replaced, the new password gets 200, the legacy one 401. Restart with the variable unset: new password still works, no warnings.

The matrix above was run with `--workers 4` and `read_database_uri` set (to a symlink of the primary SQLite file, so replica routing is enabled), which exercises the `use_primary=True` reads together with the per-worker `_MLFLOW_AUTH_ADMIN_BOOTSTRAPPED` skip: the admin is created once by the CLI and every warning is logged exactly once.

### Does this PR require documentation update?

- [ ] No.
- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow no longer ships a default admin password for the basic-auth app (GHSA-gq3w-7jj3-x7gr). New deployments must set `MLFLOW_AUTH_ADMIN_PASSWORD` (or `admin_password` in a custom auth config) before the first start, and the server refuses to start otherwise. Existing deployments keep starting, but the old default `password1234` is no longer accepted for admin logins: if your admin user still has it, set `MLFLOW_AUTH_ADMIN_PASSWORD` to a new password and restart once to rotate it.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release

This pull request and its description were written by Isaac.
