### PR TITLE
Fail fast in `mlflow server` when `MLFLOW_FLASK_SERVER_SECRET_KEY` is unset for `basic-auth`

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -328,14 +328,16 @@ def _build_uvicorn_command(
 
 
 def _bootstrap_basic_auth() -> None:
-    """Create the basic-auth admin user before spawning workers.
+    """Validate the basic-auth configuration and create the admin user before spawning workers.
 
-    A missing or insecure bootstrap password then fails ``mlflow server`` with one error
-    instead of an endless loop of the uvicorn supervisor restarting crashed workers.
+    A missing secret key or a missing/insecure bootstrap password then fails ``mlflow server``
+    with one error instead of an endless loop of the uvicorn supervisor restarting crashed
+    workers.
     """
     # `mlflow.server.auth` requires the optional `auth` extra, so only import it when needed.
-    from mlflow.server.auth import bootstrap_admin_user
+    from mlflow.server.auth import bootstrap_admin_user, get_flask_server_secret_key
 
+    get_flask_server_secret_key()
     bootstrap_admin_user()
 
 

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -6030,6 +6030,26 @@ _RBAC_ROUTES: list[tuple[Callable[[], Any], str, str, str]] = [
 ]
 
 
+def get_flask_server_secret_key() -> str:
+    """Return the static secret key the basic-auth app needs for CSRF protection.
+
+    Like ``bootstrap_admin_user``, this runs in every worker via ``create_app`` and, before
+    any worker exists, in the ``mlflow server`` process so a missing key fails the command
+    with one clear error instead of an endless worker restart loop.
+    """
+    secret_key = MLFLOW_FLASK_SERVER_SECRET_KEY.get()
+    if not secret_key:
+        raise MlflowException(
+            "A static secret key needs to be set for CSRF protection. Please set the "
+            "`MLFLOW_FLASK_SERVER_SECRET_KEY` environment variable before starting the "
+            "server. For example:\n\n"
+            "export MLFLOW_FLASK_SERVER_SECRET_KEY='my-secret-key'\n\n"
+            "If you are using multiple servers, please ensure this key is consistent between "
+            "them, in order to prevent validation issues."
+        )
+    return secret_key
+
+
 def create_app(app: Flask = app):
     """
     A factory to enable authentication and authorization for the MLflow server.
@@ -6049,17 +6069,7 @@ def create_app(app: Flask = app):
     # a secret key is required for flashing, and also for
     # CSRF protection. it's important that this is a static key,
     # otherwise CSRF validation won't work across workers.
-    secret_key = MLFLOW_FLASK_SERVER_SECRET_KEY.get()
-    if not secret_key:
-        raise MlflowException(
-            "A static secret key needs to be set for CSRF protection. Please set the "
-            "`MLFLOW_FLASK_SERVER_SECRET_KEY` environment variable before starting the "
-            "server. For example:\n\n"
-            "export MLFLOW_FLASK_SERVER_SECRET_KEY='my-secret-key'\n\n"
-            "If you are using multiple servers, please ensure this key is consistent between "
-            "them, in order to prevent validation issues."
-        )
-    app.secret_key = secret_key
+    app.secret_key = get_flask_server_secret_key()
 
     # we only need to protect the CREATE_USER_UI route, since that's
     # the only browser-accessible route. the rest are client / REST

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -12,6 +12,7 @@ from mlflow.environment_variables import (
     _MLFLOW_AUTH_ADMIN_BOOTSTRAPPED,
     _MLFLOW_SERVER_BOOT_ID,
     _MLFLOW_SGI_NAME,
+    MLFLOW_FLASK_SERVER_SECRET_KEY,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.utils import find_free_port
@@ -329,6 +330,7 @@ def test_mlflow_server_shuts_down_on_signal(sig: signal.Signals, tmp_path):
 
 def test_run_server_bootstraps_basic_auth_admin_before_spawning_workers(mock_exec_cmd, monkeypatch):
     monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "false")
+    monkeypatch.setenv(MLFLOW_FLASK_SERVER_SECRET_KEY.name, "my-secret-key")
     with mock.patch("mlflow.server.auth.bootstrap_admin_user") as bootstrap:
         server._run_server(
             file_store_path="",
@@ -353,6 +355,7 @@ def test_run_server_fails_before_spawning_workers_when_admin_bootstrap_fails(
     mock_exec_cmd, monkeypatch
 ):
     monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "false")
+    monkeypatch.setenv(MLFLOW_FLASK_SERVER_SECRET_KEY.name, "my-secret-key")
     with (
         mock.patch(
             "mlflow.server.auth.bootstrap_admin_user",
@@ -371,6 +374,30 @@ def test_run_server_fails_before_spawning_workers_when_admin_bootstrap_fails(
             port="",
             app_name="basic-auth",
         )
+    mock_exec_cmd.assert_not_called()
+
+
+def test_run_server_fails_before_spawning_workers_when_secret_key_missing(
+    mock_exec_cmd, monkeypatch
+):
+    monkeypatch.setenv("MLFLOW_SERVER_ENABLE_JOB_EXECUTION", "false")
+    monkeypatch.delenv(MLFLOW_FLASK_SERVER_SECRET_KEY.name, raising=False)
+    with (
+        mock.patch("mlflow.server.auth.bootstrap_admin_user") as bootstrap,
+        pytest.raises(MlflowException, match="MLFLOW_FLASK_SERVER_SECRET_KEY"),
+    ):
+        server._run_server(
+            file_store_path="",
+            registry_store_uri="",
+            default_artifact_root="",
+            serve_artifacts="",
+            artifacts_only="",
+            artifacts_destination="",
+            host="",
+            port="",
+            app_name="basic-auth",
+        )
+    bootstrap.assert_not_called()
     mock_exec_cmd.assert_not_called()
 
 


### PR DESCRIPTION
### Related Issues/PRs

Stacked on #25751, which notes that a missing `MLFLOW_FLASK_SERVER_SECRET_KEY` still crash-loops the same way the missing admin password did and leaves it for a separate PR. This is that PR.

### What changes are proposed in this pull request?

`mlflow server --app-name basic-auth` without `MLFLOW_FLASK_SERVER_SECRET_KEY` raises `MlflowException` inside `create_app` in every worker. With the default worker count, the uvicorn multiprocess supervisor restarts each crashed worker indefinitely, so the command never exits and the actual error is buried under repeated tracebacks.

- Move the secret-key check out of `create_app` into a `get_flask_server_secret_key` helper in `mlflow/server/auth/__init__.py`, keeping the existing error message.
- Call the helper from the `_bootstrap_basic_auth` pre-flight in `mlflow/server/__init__.py` (added in #25751), so the `mlflow server` parent process fails with one error before any worker is spawned. The secret key is checked before the admin bootstrap, so a misconfigured server fails on the cheaper check first.
- `create_app` still calls the helper, so the factory remains safe when used outside the CLI (waitress, gunicorn, tests, embedding).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New `test_run_server_fails_before_spawning_workers_when_secret_key_missing` in `tests/server/test_init.py` asserts the pre-flight raises, skips the admin bootstrap, and never spawns workers. The two existing pre-flight tests now set the secret key so they still exercise the admin bootstrap path. `tests/server/test_init.py` and `tests/server/auth/test_admin_bootstrap.py` pass (37 tests).

Manual, with a throwaway `MLFLOW_AUTH_CONFIG_PATH` ini, `MLFLOW_AUTH_ADMIN_PASSWORD` set, the secret key unset, and the default worker count: `mlflow server --app-name basic-auth` now exits with code 1 after a single traceback ending in the "A static secret key needs to be set for CSRF protection" error, and uvicorn never starts.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. `mlflow server --app-name basic-auth` now exits immediately with a clear error when `MLFLOW_FLASK_SERVER_SECRET_KEY` is unset, instead of endlessly restarting crashed workers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.

