### PR TITLE
Validate gateway secret `api_base` to prevent SSRF (GHSA-h7x2-h6g9-p789)

### DIFF
--- a/docs/docs/genai/governance/ai-gateway/api-keys/create-and-manage.mdx
+++ b/docs/docs/genai/governance/ai-gateway/api-keys/create-and-manage.mdx
@@ -28,6 +28,20 @@ Navigate to `http://localhost:5000/#/settings` and click on the **LLM Connection
 
 ![Create LLM Connection](/images/genai/settings/create-api-key.png)
 
+### Custom Base URL Validation
+
+Some providers accept a custom **API Base URL** (`api_base`), for example Azure OpenAI, Databricks, or Portkey. Because the gateway forwards requests, including caller-controlled raw proxy paths, to this URL, MLflow validates it to prevent Server-Side Request Forgery (SSRF). By default:
+
+- Only **HTTPS** URLs are allowed
+- URLs with embedded credentials are rejected
+- URLs that resolve to **private**, **loopback**, **link-local**, or **reserved** IP addresses are rejected
+
+This prevents a connection from being pointed at internal services, cloud metadata endpoints (e.g., `169.254.169.254`), or localhost services. Leaving the field blank is always allowed and uses the provider's default base URL.
+
+:::note
+For local development against a self-hosted model server, set `MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS=true` and, if the server does not use TLS, `MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES=http,https`. Do not enable these in production.
+:::
+
 ## Working with Existing Connections
 
 The LLM Connections page displays all your configured connections along with important metadata:

--- a/docs/docs/genai/governance/ai-gateway/api-keys/create-and-manage.mdx
+++ b/docs/docs/genai/governance/ai-gateway/api-keys/create-and-manage.mdx
@@ -38,7 +38,7 @@ Some providers accept a custom **API Base URL** (`api_base`), for example Azure 
 
 This prevents a connection from being pointed at internal services, cloud metadata endpoints (e.g., `169.254.169.254`), or localhost services. Leaving the field blank is always allowed and uses the provider's default base URL.
 
-The private-IP policy is also enforced when the gateway actually connects to an upstream: every address the gateway dials is checked at connection time and redirects from the upstream are never followed. This means connections created before this validation existed, and hostnames that change what they resolve to after creation, are still blocked from reaching internal addresses.
+The private-IP policy is also enforced when the gateway actually connects to an upstream: every address the gateway dials is checked at connection time and redirects from the upstream are never followed. This means connections created before this validation existed, and hostnames that change what they resolve to after creation, are still blocked from reaching internal addresses. Providers routed through LiteLLM use LiteLLM's own HTTP client, so for them the base URL is resolved and checked immediately before each request instead.
 
 :::note
 Deployments that legitimately use a private upstream, such as a self-hosted Ollama or vLLM server, must set `MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS=true`. If that server does not use TLS, also set `MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES=http,https` so its URL can be saved. Only enable these when every user who can create LLM connections is trusted with access to your private network.

--- a/docs/docs/genai/governance/ai-gateway/api-keys/create-and-manage.mdx
+++ b/docs/docs/genai/governance/ai-gateway/api-keys/create-and-manage.mdx
@@ -38,10 +38,10 @@ Some providers accept a custom **API Base URL** (`api_base`), for example Azure 
 
 This prevents a connection from being pointed at internal services, cloud metadata endpoints (e.g., `169.254.169.254`), or localhost services. Leaving the field blank is always allowed and uses the provider's default base URL.
 
-The private-IP policy is also enforced when the gateway actually connects to an upstream: every address the gateway dials is checked at connection time and redirects from the upstream are never followed. This means connections created before this validation existed, and hostnames that change what they resolve to after creation, are still blocked from reaching internal addresses. Providers routed through LiteLLM use LiteLLM's own HTTP client, so for them the base URL is resolved and checked immediately before each request instead.
+The private-IP policy is also enforced when the gateway actually connects to a custom base URL: every address it dials is checked at connection time and redirects from the upstream are never followed. This means connections created before this validation existed, and hostnames that change what they resolve to after creation, are still blocked from reaching internal addresses. Providers routed through LiteLLM use LiteLLM's own HTTP client, so for them the base URL is resolved and checked immediately before each request instead. A provider's built-in base URL, such as Ollama's `localhost:11434`, is not subject to this check on the chat, embeddings and passthrough routes; it is checked on the raw proxy route, where the caller also controls the request path.
 
 :::note
-Deployments that legitimately use a private upstream, such as a self-hosted Ollama or vLLM server, must set `MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS=true`. If that server does not use TLS, also set `MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES=http,https` so its URL can be saved. Only enable these when every user who can create LLM connections is trusted with access to your private network.
+Deployments whose custom base URL points at a private address, such as an in-cluster vLLM server or an Azure OpenAI Private Link endpoint, must set `MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS=true`. If that server does not use TLS, also set `MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES=http,https` so its URL can be saved. Only enable these when every user who can create LLM connections is trusted with access to your private network.
 :::
 
 ## Working with Existing Connections

--- a/docs/docs/genai/governance/ai-gateway/api-keys/create-and-manage.mdx
+++ b/docs/docs/genai/governance/ai-gateway/api-keys/create-and-manage.mdx
@@ -38,8 +38,10 @@ Some providers accept a custom **API Base URL** (`api_base`), for example Azure 
 
 This prevents a connection from being pointed at internal services, cloud metadata endpoints (e.g., `169.254.169.254`), or localhost services. Leaving the field blank is always allowed and uses the provider's default base URL.
 
+The private-IP policy is also enforced when the gateway actually connects to an upstream: every address the gateway dials is checked at connection time and redirects from the upstream are never followed. This means connections created before this validation existed, and hostnames that change what they resolve to after creation, are still blocked from reaching internal addresses.
+
 :::note
-For local development against a self-hosted model server, set `MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS=true` and, if the server does not use TLS, `MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES=http,https`. Do not enable these in production.
+Deployments that legitimately use a private upstream, such as a self-hosted Ollama or vLLM server, must set `MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS=true`. If that server does not use TLS, also set `MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES=http,https` so its URL can be saved. Only enable these when every user who can create LLM connections is trusted with access to your private network.
 :::
 
 ## Working with Existing Connections

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1520,6 +1520,22 @@ MLFLOW_ICON_URL_ALLOWED_DOMAINS = _EnvironmentVariable(
     "MLFLOW_ICON_URL_ALLOWED_DOMAINS", _split_strip, None
 )
 
+#: Allowed URL schemes for the ``api_base`` override stored in an AI Gateway secret's
+#: ``auth_config``. Defaults to ``https``. Set to ``http,https`` to allow plaintext
+#: upstreams, e.g. a self-hosted OpenAI-compatible server during local development.
+MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES = _EnvironmentVariable(
+    "MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES", _split_strip, ["https"]
+)
+
+#: Whether to allow an AI Gateway secret's ``api_base`` to target private, loopback,
+#: link-local or otherwise non-public IP addresses (e.g. ``localhost`` or cloud metadata
+#: endpoints such as ``169.254.169.254``). The gateway proxies caller-controlled requests
+#: to ``api_base``, so rejecting these targets prevents Server-Side Request Forgery.
+#: Intended for local development and testing only. (default: ``False``)
+MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS = _BooleanEnvironmentVariable(
+    "MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS", False
+)
+
 #: Specifies the secret key used to encrypt webhook secrets in MLflow.
 MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY = _EnvironmentVariable(
     "MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY", str, None

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1544,22 +1544,16 @@ MLFLOW_ICON_URL_ALLOWED_DOMAINS = _EnvironmentVariable(
     "MLFLOW_ICON_URL_ALLOWED_DOMAINS", _split_strip, None
 )
 
-#: Allowed URL schemes for the ``api_base`` override stored in an AI Gateway secret's
-#: ``auth_config``. Defaults to ``https``. Set to ``http,https`` to allow plaintext
-#: upstreams, e.g. a self-hosted OpenAI-compatible server during local development.
+#: Allowed URL schemes for an AI Gateway secret's ``api_base``. Set to ``http,https`` to
+#: allow plaintext upstreams. (default: ``https``)
 MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES = _EnvironmentVariable(
     "MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES", _split_strip, ["https"]
 )
 
-#: Whether the AI Gateway may talk to upstreams at private, loopback, link-local or
-#: otherwise non-public IP addresses (e.g. ``localhost`` or cloud metadata endpoints such
-#: as ``169.254.169.254``). When false, a secret's ``api_base`` is rejected on write if it
-#: resolves to such an address, and connections to a user-supplied ``api_base`` (or any
-#: connection made by the raw proxy route) are checked again at connect time with redirects
-#: never followed, so DNS rebinding and rows written before validation existed cannot reach
-#: internal services. Providers' built-in base URLs on the typed routes are not affected.
-#: Set to true for deployments whose configured ``api_base`` is private, such as in-cluster
-#: vLLM or Private Link endpoints.
+#: Whether an AI Gateway secret's ``api_base`` may target private, loopback or link-local
+#: addresses (e.g. cloud metadata at ``169.254.169.254``). When false, such values are
+#: rejected on write and again at connect time, on the raw proxy route as well. Set to true
+#: for private upstreams such as in-cluster vLLM or Private Link endpoints.
 #: (default: ``False``)
 MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS = _BooleanEnvironmentVariable(
     "MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS", False

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1554,10 +1554,12 @@ MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES = _EnvironmentVariable(
 #: Whether the AI Gateway may talk to upstreams at private, loopback, link-local or
 #: otherwise non-public IP addresses (e.g. ``localhost`` or cloud metadata endpoints such
 #: as ``169.254.169.254``). When false, a secret's ``api_base`` is rejected on write if it
-#: resolves to such an address, and every upstream connection the gateway opens is checked
-#: again at connect time (with redirects never followed), so DNS rebinding and rows written
-#: before validation existed cannot reach internal services. Set to true for deployments
-#: that legitimately use private upstreams such as self-hosted Ollama or vLLM.
+#: resolves to such an address, and connections to a user-supplied ``api_base`` (or any
+#: connection made by the raw proxy route) are checked again at connect time with redirects
+#: never followed, so DNS rebinding and rows written before validation existed cannot reach
+#: internal services. Providers' built-in base URLs on the typed routes are not affected.
+#: Set to true for deployments whose configured ``api_base`` is private, such as in-cluster
+#: vLLM or Private Link endpoints.
 #: (default: ``False``)
 MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS = _BooleanEnvironmentVariable(
     "MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS", False

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1527,11 +1527,14 @@ MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES = _EnvironmentVariable(
     "MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES", _split_strip, ["https"]
 )
 
-#: Whether to allow an AI Gateway secret's ``api_base`` to target private, loopback,
-#: link-local or otherwise non-public IP addresses (e.g. ``localhost`` or cloud metadata
-#: endpoints such as ``169.254.169.254``). The gateway proxies caller-controlled requests
-#: to ``api_base``, so rejecting these targets prevents Server-Side Request Forgery.
-#: Intended for local development and testing only. (default: ``False``)
+#: Whether the AI Gateway may talk to upstreams at private, loopback, link-local or
+#: otherwise non-public IP addresses (e.g. ``localhost`` or cloud metadata endpoints such
+#: as ``169.254.169.254``). When false, a secret's ``api_base`` is rejected on write if it
+#: resolves to such an address, and every upstream connection the gateway opens is checked
+#: again at connect time (with redirects never followed), so DNS rebinding and rows written
+#: before validation existed cannot reach internal services. Set to true for deployments
+#: that legitimately use private upstreams such as self-hosted Ollama or vLLM.
+#: (default: ``False``)
 MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS = _BooleanEnvironmentVariable(
     "MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS", False
 )

--- a/mlflow/gateway/guardrails.py
+++ b/mlflow/gateway/guardrails.py
@@ -271,8 +271,11 @@ class JudgeGuardrail(Guardrail):
                 san_span.set_inputs({"payload": payload, "rationale": rationale})
 
             try:
+                # This calls back into this server's own gateway route, which is commonly
+                # bound to localhost, so the upstream SSRF guard (meant for user-supplied
+                # provider hosts) must not apply here.
                 resp_json = await send_request(
-                    headers=headers, base_url=url, path=path, payload=body
+                    headers=headers, base_url=url, path=path, payload=body, ssrf_protect=False
                 )
             except HTTPException as e:
                 raise GuardrailViolation(

--- a/mlflow/gateway/providers/litellm.py
+++ b/mlflow/gateway/providers/litellm.py
@@ -118,6 +118,25 @@ class LiteLLMProvider(BaseProvider):
 
         return kwargs
 
+    async def _prepare_litellm_kwargs(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Build LiteLLM kwargs and refuse a private ``api_base`` first.
+
+        LiteLLM sends requests through its own HTTP client rather than ``_aiohttp_post``, so
+        the connect-time guard in ``mlflow.gateway.providers.utils`` never sees them. The
+        upstream host is therefore checked here, before the URL is handed to LiteLLM.
+        """
+        from fastapi import HTTPException
+
+        from mlflow.gateway.ssrf import GatewaySSRFProtectionError, assert_public_upstream_host
+
+        kwargs = self._build_litellm_kwargs(payload)
+        if api_base := kwargs.get("api_base"):
+            try:
+                await assert_public_upstream_host(api_base)
+            except GatewaySSRFProtectionError as e:
+                raise HTTPException(status_code=502, detail=str(e)) from e
+        return kwargs
+
     async def _chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         import litellm
         from fastapi.encoders import jsonable_encoder
@@ -125,7 +144,7 @@ class LiteLLMProvider(BaseProvider):
         payload_dict = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload_dict)
 
-        kwargs = self._build_litellm_kwargs(
+        kwargs = await self._prepare_litellm_kwargs(
             self.adapter_class.chat_to_model(payload_dict, self.config)
         )
 
@@ -177,7 +196,7 @@ class LiteLLMProvider(BaseProvider):
         payload_dict = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload_dict)
 
-        kwargs = self._build_litellm_kwargs(
+        kwargs = await self._prepare_litellm_kwargs(
             self.adapter_class.chat_to_model(payload_dict, self.config)
         )
         kwargs["stream"] = True
@@ -243,7 +262,7 @@ class LiteLLMProvider(BaseProvider):
         payload_dict = jsonable_encoder(payload, exclude_none=True)
         self.check_for_model_field(payload_dict)
 
-        kwargs = self._build_litellm_kwargs(
+        kwargs = await self._prepare_litellm_kwargs(
             self.adapter_class.embeddings_to_model(payload_dict, self.config)
         )
 
@@ -453,7 +472,7 @@ class LiteLLMProvider(BaseProvider):
         self._validate_passthrough_action(action)
 
         model_name = self.adapter_class._get_litellm_model_name(self.config)
-        kwargs = self._build_litellm_kwargs(payload)
+        kwargs = await self._prepare_litellm_kwargs(payload)
         kwargs["model"] = model_name
 
         match action:

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -41,8 +41,22 @@ SUPPORTED_ACCEPT_ENCODING = "gzip, deflate, identity"
 
 
 @asynccontextmanager
-async def _aiohttp_post(headers: dict[str, str], base_url: str, path: str, payload: dict[str, Any]):
+async def _aiohttp_post(
+    headers: dict[str, str],
+    base_url: str,
+    path: str,
+    payload: dict[str, Any],
+    *,
+    ssrf_protect: bool = True,
+):
     import aiohttp
+    from fastapi import HTTPException
+
+    from mlflow.gateway.ssrf import (
+        GatewaySSRFProtectionError,
+        assert_public_upstream_url,
+        build_ssrf_guarded_connector,
+    )
 
     # Drop any client Accept-Encoding (any casing) so we send only one value; otherwise
     # aiohttp may send both and upstream can respond with Brotli, which is not supported.
@@ -50,19 +64,49 @@ async def _aiohttp_post(headers: dict[str, str], base_url: str, path: str, paylo
     # re-serialized below (e.g. a zstd-encoded request body is decompressed before it gets
     # here). And drop X-MLflow-Authorization (MLflow's own RBAC credential on gateway routes)
     # so it is never forwarded to the upstream provider. This is the single egress choke
-    # point all proxy/passthrough paths funnel through.
+    # point all proxy/passthrough paths funnel through, so SSRF protection lives here too:
+    # the upstream host may come from a user-supplied secret `api_base`, so the connection
+    # target is checked at connect time (see mlflow.gateway.ssrf) and redirects are never
+    # followed, as a redirect could otherwise steer the request to an internal address.
     request_headers = {k: v for k, v in headers.items() if k.lower() not in _STRIPPED_HEADERS}
     request_headers["Accept-Encoding"] = SUPPORTED_ACCEPT_ENCODING
     url = append_to_uri_path(base_url, path)
-    # Raise the aiohttp stream read buffer to tolerate large SSE `data:` lines
-    # emitted by some providers during streaming responses.
-    async with aiohttp.ClientSession(headers=request_headers, read_bufsize=2**20) as session:
-        timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get())
-        async with session.post(url, json=payload, timeout=timeout) as response:
-            yield response
+    connector = None
+    if ssrf_protect:
+        try:
+            assert_public_upstream_url(url)
+        except GatewaySSRFProtectionError as e:
+            raise HTTPException(status_code=502, detail=str(e)) from e
+        connector = build_ssrf_guarded_connector()
+    try:
+        # Raise the aiohttp stream read buffer to tolerate large SSE `data:` lines
+        # emitted by some providers during streaming responses.
+        async with aiohttp.ClientSession(
+            connector=connector, headers=request_headers, read_bufsize=2**20
+        ) as session:
+            timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get())
+            try:
+                async with session.post(
+                    url, json=payload, timeout=timeout, allow_redirects=False
+                ) as response:
+                    yield response
+            except GatewaySSRFProtectionError as e:
+                raise HTTPException(status_code=502, detail=str(e)) from e
+    finally:
+        # The session owns and closes the connector on exit; this only matters when the
+        # session was replaced by a test double that does not.
+        if connector is not None and not connector.closed:
+            await connector.close()
 
 
-async def send_request(headers: dict[str, str], base_url: str, path: str, payload: dict[str, Any]):
+async def send_request(
+    headers: dict[str, str],
+    base_url: str,
+    path: str,
+    payload: dict[str, Any],
+    *,
+    ssrf_protect: bool = True,
+):
     """
     Send an HTTP request to a specific URL path with given headers and payload.
 
@@ -71,6 +115,9 @@ async def send_request(headers: dict[str, str], base_url: str, path: str, payloa
         base_url: The base URL where the request will be sent.
         path: The specific path of the URL to which the request will be sent.
         payload: The payload (or data) to be included in the request.
+        ssrf_protect: Whether to apply the gateway's upstream SSRF protection (see
+            ``mlflow.gateway.ssrf``). Pass ``False`` only for calls whose target is not
+            user-controlled, such as the server calling itself.
 
     Returns:
         The server's response as a JSON object.
@@ -83,7 +130,9 @@ async def send_request(headers: dict[str, str], base_url: str, path: str, payloa
 
     start = time.perf_counter()
     try:
-        async with _aiohttp_post(headers, base_url, path, payload) as response:
+        async with _aiohttp_post(
+            headers, base_url, path, payload, ssrf_protect=ssrf_protect
+        ) as response:
             content_type = response.headers.get("Content-Type")
             if content_type and "application/json" in content_type:
                 js = await response.json()

--- a/mlflow/gateway/providers/utils.py
+++ b/mlflow/gateway/providers/utils.py
@@ -85,6 +85,8 @@ async def _aiohttp_post(
             connector=connector, headers=request_headers, read_bufsize=2**20
         ) as session:
             timeout = aiohttp.ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get())
+            # ClientSession.__aenter__ opens no connection; the resolver runs while
+            # session.post(...).__aenter__ acquires one, which this try encloses.
             try:
                 async with session.post(
                     url, json=payload, timeout=timeout, allow_redirects=False

--- a/mlflow/gateway/ssrf.py
+++ b/mlflow/gateway/ssrf.py
@@ -1,42 +1,15 @@
-"""Connection-time SSRF protection for AI Gateway upstream calls.
+"""Connect-time SSRF protection for AI Gateway upstream calls.
 
-Gateway secrets can carry a user-supplied ``api_base`` that the gateway sends requests to,
-and the raw proxy route additionally appends a caller-supplied path. Write-time validation
-of ``api_base`` (``mlflow.utils.validation._validate_gateway_api_base``) resolves the
-hostname once and discards the result, so on its own it cannot stop:
+Write-time validation of a secret's ``api_base`` cannot stop DNS rebinding, redirects to
+internal hosts, or rows stored before it existed. This module enforces the same policy at
+the egress point: ``SSRFGuardedResolver`` rejects non-public addresses before aiohttp dials
+them, ``assert_public_upstream_url`` covers IP literals (which aiohttp never resolves), and
+``assert_public_upstream_host`` is the pre-call check for LiteLLM's own HTTP client.
+``_aiohttp_post`` never follows redirects.
 
-- a DNS-rebinding attacker who returns a public IP during validation and a private or
-  link-local IP (e.g. ``169.254.169.254``) at request time;
-- an upstream that answers with a redirect to an internal address;
-- rows that were written before write-time validation existed.
-
-This module closes those gaps at the egress point instead:
-
-- ``SSRFGuardedResolver`` wraps aiohttp's default resolver and rejects any resolved address
-  that is not public. aiohttp connects to exactly the addresses the resolver returns, so
-  there is no second lookup between the check and the connection.
-- ``assert_public_upstream_url`` covers IP-literal hosts, which aiohttp dials without
-  consulting the resolver, and rejects non-canonical numeric spellings (``2130706433``,
-  ``127.1``, ``0177.0.0.1``) that aiohttp also treats as literals but ``ipaddress`` cannot
-  parse, so they would otherwise slip past both checks.
-- ``_aiohttp_post`` disables redirect following, so a redirect can never introduce a host
-  that bypasses the checks above.
-- ``assert_public_upstream_host`` resolves and checks a host for providers that use their
-  own HTTP client instead of ``_aiohttp_post`` (LiteLLM). That lookup is separate from the
-  client's own, so it cannot pin the connection the way the resolver above does; it still
-  blocks plain private hosts, non-canonical literals and rows stored before write-time
-  validation existed.
-
-Enforcement is scoped per request through ``upstream_ssrf_protection``, which the
-tracking server's gateway routes set when the endpoint's secret carries a user-supplied
-``api_base`` or when the request is the raw proxy route (see
-``mlflow.server.gateway_api._enable_upstream_ssrf_protection``). A provider's built-in base
-URL on a typed route is operator code rather than attacker input, so it is left alone and
-the common local Ollama setup keeps working. The standalone ``mlflow gateway`` server reads
-its provider configuration from an operator-owned file and is not affected. Every check is
-also skipped when ``MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS`` is true, which is required
-for deployments whose configured ``api_base`` is private (in-cluster vLLM, Private Link
-endpoints, and similar).
+Enforcement is per request via ``upstream_ssrf_protection`` (set in
+``mlflow.server.gateway_api._enable_upstream_ssrf_protection``) and is skipped entirely
+when ``MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS`` is true.
 """
 
 import asyncio
@@ -55,17 +28,14 @@ from mlflow.utils.validation import _is_ip_literal_like, _is_public_ip
 
 
 class GatewaySSRFProtectionError(Exception):
-    """Raised when an upstream gateway connection would target a non-public IP address.
+    """Raised when an upstream connection would target a non-public IP address.
 
-    Deliberately not an ``OSError`` subclass: aiohttp only wraps ``OSError`` from the
-    resolver, so this propagates unchanged and the request fails closed.
+    Not an ``OSError`` subclass, so aiohttp propagates it unchanged instead of wrapping it.
     """
 
 
-# True while handling a request whose upstream target may be attacker-controlled. Set on the
-# request's context by mlflow.server.gateway_api once the endpoint config is known, so every
-# provider call made while serving the request, including streamed response bodies, observes
-# it, and it never leaks into other requests.
+# Request-scoped: set by mlflow.server.gateway_api once the endpoint config is known, so
+# every provider call for that request, including streamed bodies, observes it.
 upstream_ssrf_protection: ContextVar[bool] = ContextVar(
     "gateway_upstream_ssrf_protection", default=False
 )
@@ -103,11 +73,9 @@ def _parse_upstream_hostname(url: str) -> str:
 def assert_public_upstream_url(url: str) -> None:
     """Reject an upstream URL whose host is a non-public or non-canonical IP literal.
 
-    Hostnames are intentionally not resolved here; they are checked by
-    ``SSRFGuardedResolver`` at connection time so there is no window between the check and
-    the connection. Anything aiohttp would dial as a literal must parse as a canonical
-    address, since aiohttp skips the resolver for such hosts and ``socket`` would map a
-    legacy numeric spelling onto an address unseen. No-op when private upstreams are allowed.
+    Hostnames are left to ``SSRFGuardedResolver`` at connect time. Anything aiohttp would
+    dial as a literal must parse canonically, since aiohttp skips the resolver for it and
+    ``socket`` would silently map a legacy spelling such as ``127.1`` onto an address.
     """
     if not _is_protection_enabled():
         return
@@ -130,11 +98,8 @@ async def _getaddrinfo(hostname: str) -> list[Any]:
 async def assert_public_upstream_host(url: str) -> None:
     """Resolve an upstream URL's host and reject it unless every address is public.
 
-    For provider clients that do not go through ``_aiohttp_post`` (LiteLLM uses its own HTTP
-    client), so ``SSRFGuardedResolver`` cannot sit on the connection. The lookup here is
-    separate from the client's own, which leaves a DNS-rebinding attacker a narrow window
-    between the two; it still blocks plain private hosts, non-canonical literals and rows
-    stored before write-time validation existed. No-op when private upstreams are allowed.
+    For clients that bypass ``_aiohttp_post`` (LiteLLM). The lookup is separate from the
+    client's own, so a DNS-rebinding window remains between the two.
     """
     if not _is_protection_enabled():
         return
@@ -155,8 +120,7 @@ async def assert_public_upstream_host(url: str) -> None:
 class SSRFGuardedResolver(AbstractResolver):
     """aiohttp resolver that only returns public addresses.
 
-    aiohttp dials the addresses this resolver returns, so validating them here is a check on
-    the actual connection target rather than on an earlier, separate lookup.
+    aiohttp dials exactly what the resolver returns, so this checks the real connection target.
     """
 
     def __init__(self, resolver: AbstractResolver | None = None) -> None:
@@ -175,9 +139,7 @@ class SSRFGuardedResolver(AbstractResolver):
 
 
 def build_ssrf_guarded_connector() -> aiohttp.TCPConnector | None:
-    """Return a connector whose DNS results are checked, or ``None`` to use aiohttp's default
-    when private upstreams are allowed.
-    """
+    """Return a guarded connector, or ``None`` for aiohttp's default when protection is off."""
     if not _is_protection_enabled():
         return None
     return aiohttp.TCPConnector(resolver=SSRFGuardedResolver())

--- a/mlflow/gateway/ssrf.py
+++ b/mlflow/gateway/ssrf.py
@@ -16,9 +16,16 @@ This module closes those gaps at the egress point instead:
   that is not public. aiohttp connects to exactly the addresses the resolver returns, so
   there is no second lookup between the check and the connection.
 - ``assert_public_upstream_url`` covers IP-literal hosts, which aiohttp dials without
-  consulting the resolver.
+  consulting the resolver, and rejects non-canonical numeric spellings (``2130706433``,
+  ``127.1``, ``0177.0.0.1``) that aiohttp also treats as literals but ``ipaddress`` cannot
+  parse, so they would otherwise slip past both checks.
 - ``_aiohttp_post`` disables redirect following, so a redirect can never introduce a host
   that bypasses the checks above.
+- ``assert_public_upstream_host`` resolves and checks a host for providers that use their
+  own HTTP client instead of ``_aiohttp_post`` (LiteLLM). That lookup is separate from the
+  client's own, so it cannot pin the connection the way the resolver above does; it still
+  blocks plain private hosts, non-canonical literals and rows stored before write-time
+  validation existed.
 
 Enforcement is scoped to requests served by the tracking server: its middleware sets
 ``upstream_ssrf_protection`` for every request it handles, because there the upstream host
@@ -29,6 +36,7 @@ deployments that legitimately talk to private upstreams (self-hosted Ollama, vLL
 similar).
 """
 
+import asyncio
 import ipaddress
 import socket
 from contextvars import ContextVar
@@ -40,7 +48,7 @@ from aiohttp.abc import AbstractResolver
 from aiohttp.resolver import DefaultResolver
 
 from mlflow.environment_variables import MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS
-from mlflow.utils.validation import _is_public_ip
+from mlflow.utils.validation import _is_ip_literal_like, _is_public_ip
 
 
 class GatewaySSRFProtectionError(Exception):
@@ -79,26 +87,66 @@ def _assert_public_ip(ip_str: str, host: str) -> None:
         )
 
 
-def assert_public_upstream_url(url: str) -> None:
-    """Reject an upstream URL whose host is a non-public IP literal.
-
-    Hostnames are intentionally not resolved here; they are checked by
-    ``SSRFGuardedResolver`` at connection time so there is no window between the check and
-    the connection. No-op when private upstreams are allowed.
-    """
-    if not _is_protection_enabled():
-        return
+def _parse_upstream_hostname(url: str) -> str:
     try:
         hostname = urlparse(url).hostname
     except ValueError as e:
         raise GatewaySSRFProtectionError(f"Invalid gateway upstream URL {url!r}: {e}") from e
     if not hostname:
         raise GatewaySSRFProtectionError(f"Gateway upstream URL must include a hostname: {url!r}")
+    return hostname
+
+
+def assert_public_upstream_url(url: str) -> None:
+    """Reject an upstream URL whose host is a non-public or non-canonical IP literal.
+
+    Hostnames are intentionally not resolved here; they are checked by
+    ``SSRFGuardedResolver`` at connection time so there is no window between the check and
+    the connection. Anything aiohttp would dial as a literal must parse as a canonical
+    address, since aiohttp skips the resolver for such hosts and ``socket`` would map a
+    legacy numeric spelling onto an address unseen. No-op when private upstreams are allowed.
+    """
+    if not _is_protection_enabled():
+        return
+    hostname = _parse_upstream_hostname(url)
+    if not _is_ip_literal_like(hostname):
+        return
     try:
         ipaddress.ip_address(hostname)
-    except ValueError:
-        return
+    except ValueError as e:
+        raise GatewaySSRFProtectionError(
+            f"Gateway upstream host {hostname!r} is not a canonical IP address literal."
+        ) from e
     _assert_public_ip(hostname, hostname)
+
+
+async def _getaddrinfo(hostname: str) -> list[Any]:
+    return await asyncio.get_running_loop().getaddrinfo(hostname, None)
+
+
+async def assert_public_upstream_host(url: str) -> None:
+    """Resolve an upstream URL's host and reject it unless every address is public.
+
+    For provider clients that do not go through ``_aiohttp_post`` (LiteLLM uses its own HTTP
+    client), so ``SSRFGuardedResolver`` cannot sit on the connection. The lookup here is
+    separate from the client's own, which leaves a DNS-rebinding attacker a narrow window
+    between the two; it still blocks plain private hosts, non-canonical literals and rows
+    stored before write-time validation existed. No-op when private upstreams are allowed.
+    """
+    if not _is_protection_enabled():
+        return
+    assert_public_upstream_url(url)
+    hostname = _parse_upstream_hostname(url)
+    if _is_ip_literal_like(hostname):
+        return
+    try:
+        addr_infos = await _getaddrinfo(hostname)
+    except (OSError, UnicodeError, ValueError) as e:
+        raise GatewaySSRFProtectionError(
+            f"Cannot resolve gateway upstream host {hostname!r}: {e}"
+        ) from e
+    for addr_info in addr_infos:
+        _assert_public_ip(addr_info[4][0], hostname)
 
 
 class SSRFGuardedResolver(AbstractResolver):

--- a/mlflow/gateway/ssrf.py
+++ b/mlflow/gateway/ssrf.py
@@ -27,13 +27,16 @@ This module closes those gaps at the egress point instead:
   blocks plain private hosts, non-canonical literals and rows stored before write-time
   validation existed.
 
-Enforcement is scoped to requests served by the tracking server: its middleware sets
-``upstream_ssrf_protection`` for every request it handles, because there the upstream host
-comes from user-created gateway secrets. The standalone ``mlflow gateway`` server reads its
-provider configuration from an operator-owned file and is not affected. Every check is also
-skipped when ``MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS`` is true, which is required for
-deployments that legitimately talk to private upstreams (self-hosted Ollama, vLLM, and
-similar).
+Enforcement is scoped per request through ``upstream_ssrf_protection``, which the
+tracking server's gateway routes set when the endpoint's secret carries a user-supplied
+``api_base`` or when the request is the raw proxy route (see
+``mlflow.server.gateway_api._enable_upstream_ssrf_protection``). A provider's built-in base
+URL on a typed route is operator code rather than attacker input, so it is left alone and
+the common local Ollama setup keeps working. The standalone ``mlflow gateway`` server reads
+its provider configuration from an operator-owned file and is not affected. Every check is
+also skipped when ``MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS`` is true, which is required
+for deployments whose configured ``api_base`` is private (in-cluster vLLM, Private Link
+endpoints, and similar).
 """
 
 import asyncio
@@ -59,10 +62,10 @@ class GatewaySSRFProtectionError(Exception):
     """
 
 
-# True while handling a request whose upstream targets may be user-controlled. Set by the
-# tracking server's FastAPI middleware (see mlflow.server.fastapi_app); the handler task
-# inherits a copy of the middleware's context, so provider calls made while serving the
-# request, including streamed response bodies, observe it.
+# True while handling a request whose upstream target may be attacker-controlled. Set on the
+# request's context by mlflow.server.gateway_api once the endpoint config is known, so every
+# provider call made while serving the request, including streamed response bodies, observes
+# it, and it never leaks into other requests.
 upstream_ssrf_protection: ContextVar[bool] = ContextVar(
     "gateway_upstream_ssrf_protection", default=False
 )

--- a/mlflow/gateway/ssrf.py
+++ b/mlflow/gateway/ssrf.py
@@ -1,0 +1,132 @@
+"""Connection-time SSRF protection for AI Gateway upstream calls.
+
+Gateway secrets can carry a user-supplied ``api_base`` that the gateway sends requests to,
+and the raw proxy route additionally appends a caller-supplied path. Write-time validation
+of ``api_base`` (``mlflow.utils.validation._validate_gateway_api_base``) resolves the
+hostname once and discards the result, so on its own it cannot stop:
+
+- a DNS-rebinding attacker who returns a public IP during validation and a private or
+  link-local IP (e.g. ``169.254.169.254``) at request time;
+- an upstream that answers with a redirect to an internal address;
+- rows that were written before write-time validation existed.
+
+This module closes those gaps at the egress point instead:
+
+- ``SSRFGuardedResolver`` wraps aiohttp's default resolver and rejects any resolved address
+  that is not public. aiohttp connects to exactly the addresses the resolver returns, so
+  there is no second lookup between the check and the connection.
+- ``assert_public_upstream_url`` covers IP-literal hosts, which aiohttp dials without
+  consulting the resolver.
+- ``_aiohttp_post`` disables redirect following, so a redirect can never introduce a host
+  that bypasses the checks above.
+
+Enforcement is scoped to requests served by the tracking server: its middleware sets
+``upstream_ssrf_protection`` for every request it handles, because there the upstream host
+comes from user-created gateway secrets. The standalone ``mlflow gateway`` server reads its
+provider configuration from an operator-owned file and is not affected. Every check is also
+skipped when ``MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS`` is true, which is required for
+deployments that legitimately talk to private upstreams (self-hosted Ollama, vLLM, and
+similar).
+"""
+
+import ipaddress
+import socket
+from contextvars import ContextVar
+from typing import Any
+from urllib.parse import urlparse
+
+import aiohttp
+from aiohttp.abc import AbstractResolver
+from aiohttp.resolver import DefaultResolver
+
+from mlflow.environment_variables import MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS
+from mlflow.utils.validation import _is_public_ip
+
+
+class GatewaySSRFProtectionError(Exception):
+    """Raised when an upstream gateway connection would target a non-public IP address.
+
+    Deliberately not an ``OSError`` subclass: aiohttp only wraps ``OSError`` from the
+    resolver, so this propagates unchanged and the request fails closed.
+    """
+
+
+# True while handling a request whose upstream targets may be user-controlled. Set by the
+# tracking server's FastAPI middleware (see mlflow.server.fastapi_app); the handler task
+# inherits a copy of the middleware's context, so provider calls made while serving the
+# request, including streamed response bodies, observe it.
+upstream_ssrf_protection: ContextVar[bool] = ContextVar(
+    "gateway_upstream_ssrf_protection", default=False
+)
+
+
+def _is_protection_enabled() -> bool:
+    return upstream_ssrf_protection.get() and not MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS.get()
+
+
+def _assert_public_ip(ip_str: str, host: str) -> None:
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError as e:
+        raise GatewaySSRFProtectionError(
+            f"Gateway upstream {host!r} resolved to an invalid IP address: {ip_str!r}"
+        ) from e
+    if not _is_public_ip(ip):
+        raise GatewaySSRFProtectionError(
+            f"Gateway upstream connection blocked: {host!r} resolves to {ip}, which is not a "
+            "public IP address. Set MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS=true to allow "
+            "private upstreams."
+        )
+
+
+def assert_public_upstream_url(url: str) -> None:
+    """Reject an upstream URL whose host is a non-public IP literal.
+
+    Hostnames are intentionally not resolved here; they are checked by
+    ``SSRFGuardedResolver`` at connection time so there is no window between the check and
+    the connection. No-op when private upstreams are allowed.
+    """
+    if not _is_protection_enabled():
+        return
+    try:
+        hostname = urlparse(url).hostname
+    except ValueError as e:
+        raise GatewaySSRFProtectionError(f"Invalid gateway upstream URL {url!r}: {e}") from e
+    if not hostname:
+        raise GatewaySSRFProtectionError(f"Gateway upstream URL must include a hostname: {url!r}")
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        return
+    _assert_public_ip(hostname, hostname)
+
+
+class SSRFGuardedResolver(AbstractResolver):
+    """aiohttp resolver that only returns public addresses.
+
+    aiohttp dials the addresses this resolver returns, so validating them here is a check on
+    the actual connection target rather than on an earlier, separate lookup.
+    """
+
+    def __init__(self, resolver: AbstractResolver | None = None) -> None:
+        self._resolver = resolver or DefaultResolver()
+
+    async def resolve(
+        self, host: str, port: int = 0, family: socket.AddressFamily = socket.AF_INET
+    ) -> list[Any]:
+        results = await self._resolver.resolve(host, port, family=family)
+        for result in results:
+            _assert_public_ip(result["host"], host)
+        return results
+
+    async def close(self) -> None:
+        await self._resolver.close()
+
+
+def build_ssrf_guarded_connector() -> aiohttp.TCPConnector | None:
+    """Return a connector whose DNS results are checked, or ``None`` to use aiohttp's default
+    when private upstreams are allowed.
+    """
+    if not _is_protection_enabled():
+        return None
+    return aiohttp.TCPConnector(resolver=SSRFGuardedResolver())

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -28,7 +28,6 @@ from mlflow.environment_variables import MLFLOW_ENABLE_REMOTE_ASSISTANT
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.constants import MLFLOW_GATEWAY_DURATION_HEADER, MLFLOW_GATEWAY_OVERHEAD_HEADER
 from mlflow.gateway.providers.utils import provider_call_duration_ms
-from mlflow.gateway.ssrf import upstream_ssrf_protection
 from mlflow.server import app as flask_app
 from mlflow.server.artifact_router import artifact_router
 from mlflow.server.asgi_utils import get_routed_asgi_path
@@ -136,29 +135,6 @@ def add_fastapi_workspace_middleware(fastapi_app: FastAPI) -> None:
         return response
 
     fastapi_app.state.workspace_middleware_added = True
-
-
-def add_gateway_upstream_protection_middleware(fastapi_app: FastAPI) -> None:
-    """Enable connect-time SSRF protection for provider calls made while serving a request.
-
-    Gateway secrets created through this server carry user-supplied upstream hosts, so every
-    outbound provider connection opened on behalf of a request must be checked against the
-    private-IP policy (see ``mlflow.gateway.ssrf``). The handler task inherits a copy of this
-    context, so the flag is visible to ``_aiohttp_post`` for the whole request, including
-    streamed bodies.
-    """
-    if getattr(fastapi_app.state, "gateway_upstream_protection_middleware_added", False):
-        return
-
-    @fastapi_app.middleware("http")
-    async def gateway_upstream_protection_middleware(request: Request, call_next):
-        token = upstream_ssrf_protection.set(True)
-        try:
-            return await call_next(request)
-        finally:
-            upstream_ssrf_protection.reset(token)
-
-    fastapi_app.state.gateway_upstream_protection_middleware_added = True
 
 
 def add_gateway_timing_middleware(fastapi_app: FastAPI) -> None:
@@ -297,7 +273,6 @@ def create_fastapi_app(flask_app: Flask = flask_app):
 
     add_fastapi_workspace_middleware(fastapi_app)
     add_gateway_timing_middleware(fastapi_app)
-    add_gateway_upstream_protection_middleware(fastapi_app)
 
     # Include OpenTelemetry API router BEFORE mounting Flask app
     # This ensures FastAPI routes take precedence over the catch-all Flask mount

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -28,6 +28,7 @@ from mlflow.environment_variables import MLFLOW_ENABLE_REMOTE_ASSISTANT
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.constants import MLFLOW_GATEWAY_DURATION_HEADER, MLFLOW_GATEWAY_OVERHEAD_HEADER
 from mlflow.gateway.providers.utils import provider_call_duration_ms
+from mlflow.gateway.ssrf import upstream_ssrf_protection
 from mlflow.server import app as flask_app
 from mlflow.server.artifact_router import artifact_router
 from mlflow.server.asgi_utils import get_routed_asgi_path
@@ -135,6 +136,29 @@ def add_fastapi_workspace_middleware(fastapi_app: FastAPI) -> None:
         return response
 
     fastapi_app.state.workspace_middleware_added = True
+
+
+def add_gateway_upstream_protection_middleware(fastapi_app: FastAPI) -> None:
+    """Enable connect-time SSRF protection for provider calls made while serving a request.
+
+    Gateway secrets created through this server carry user-supplied upstream hosts, so every
+    outbound provider connection opened on behalf of a request must be checked against the
+    private-IP policy (see ``mlflow.gateway.ssrf``). The handler task inherits a copy of this
+    context, so the flag is visible to ``_aiohttp_post`` for the whole request, including
+    streamed bodies.
+    """
+    if getattr(fastapi_app.state, "gateway_upstream_protection_middleware_added", False):
+        return
+
+    @fastapi_app.middleware("http")
+    async def gateway_upstream_protection_middleware(request: Request, call_next):
+        token = upstream_ssrf_protection.set(True)
+        try:
+            return await call_next(request)
+        finally:
+            upstream_ssrf_protection.reset(token)
+
+    fastapi_app.state.gateway_upstream_protection_middleware_added = True
 
 
 def add_gateway_timing_middleware(fastapi_app: FastAPI) -> None:
@@ -273,6 +297,7 @@ def create_fastapi_app(flask_app: Flask = flask_app):
 
     add_fastapi_workspace_middleware(fastapi_app)
     add_gateway_timing_middleware(fastapi_app)
+    add_gateway_upstream_protection_middleware(fastapi_app)
 
     # Include OpenTelemetry API router BEFORE mounting Flask app
     # This ensures FastAPI routes take precedence over the catch-all Flask mount

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -499,10 +499,15 @@ def _build_endpoint_config(
         # Store the original provider name for LiteLLM's provider/model format
         original_provider = model_config.provider
         auth_config = model_config.auth_config or {}
-        # Merge auth_config with secret_value (secret_value contains api_key and other secrets)
+        # Merge auth_config with secret_value (secret_value contains api_key and other secrets).
+        # api_base is validated on auth_config at write time, so the encrypted, unvalidated
+        # secret map must never be allowed to override it.
+        secret_value = {
+            k: v for k, v in model_config.secret_value.items() if k != _AuthConfigKey.API_BASE
+        }
         litellm_config = {
             "litellm_provider": original_provider,
-            "litellm_auth_config": auth_config | model_config.secret_value,
+            "litellm_auth_config": auth_config | secret_value,
         }
         provider_config = LiteLLMConfig(**litellm_config)
         model_config.provider = Provider.LITELLM

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -638,18 +638,11 @@ def _create_provider(
 def _enable_upstream_ssrf_protection(
     endpoint_config: GatewayEndpointConfig, *, raw_proxy: bool = False
 ) -> None:
-    """Turn on connect-time SSRF protection for the rest of this request when it is needed.
+    """Enable connect-time SSRF protection for the rest of this request when needed.
 
-    A provider's built-in base URL (e.g. Ollama's ``localhost:11434``) is operator code, not
-    attacker input, and the typed routes only ever hit fixed inference paths on it, so
-    guarding those calls buys nothing and would break the common local setup. Protection
-    is required when a model's secret carries a user-supplied ``api_base``, which is the
-    SSRF vector, and on the raw proxy route, where the caller also controls the path and
-    could otherwise reach a provider default's full API surface.
-
-    The flag is set on the request's context (the gateway timing middleware runs each
-    handler in a copy), so it covers every provider call made while serving the request,
-    including streamed bodies, and never leaks into other requests.
+    Needed when a secret carries a user-supplied ``api_base`` (the SSRF vector) and on the
+    raw proxy, where the caller also controls the path. Providers' built-in base URLs such
+    as Ollama's ``localhost:11434`` are operator code, so typed routes leave them alone.
     """
     if raw_proxy or any(
         model.auth_config and model.auth_config.get(_AuthConfigKey.API_BASE)

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -69,6 +69,7 @@ from mlflow.gateway.providers.base import (
 )
 from mlflow.gateway.providers.utils import provider_call_duration_ms
 from mlflow.gateway.schemas import chat, embeddings
+from mlflow.gateway.ssrf import upstream_ssrf_protection
 from mlflow.gateway.tracing_utils import (
     aggregate_anthropic_messages_stream_chunks,
     aggregate_chat_stream_chunks,
@@ -634,6 +635,29 @@ def _create_provider(
     return primary_provider
 
 
+def _enable_upstream_ssrf_protection(
+    endpoint_config: GatewayEndpointConfig, *, raw_proxy: bool = False
+) -> None:
+    """Turn on connect-time SSRF protection for the rest of this request when it is needed.
+
+    A provider's built-in base URL (e.g. Ollama's ``localhost:11434``) is operator code, not
+    attacker input, and the typed routes only ever hit fixed inference paths on it, so
+    guarding those calls buys nothing and would break the common local setup. Protection
+    is required when a model's secret carries a user-supplied ``api_base``, which is the
+    SSRF vector, and on the raw proxy route, where the caller also controls the path and
+    could otherwise reach a provider default's full API surface.
+
+    The flag is set on the request's context (the gateway timing middleware runs each
+    handler in a copy), so it covers every provider call made while serving the request,
+    including streamed bodies, and never leaks into other requests.
+    """
+    if raw_proxy or any(
+        model.auth_config and model.auth_config.get(_AuthConfigKey.API_BASE)
+        for model in endpoint_config.models
+    ):
+        upstream_ssrf_protection.set(True)
+
+
 def _create_provider_from_endpoint_name(
     store: SqlAlchemyStore,
     endpoint_name: str,
@@ -653,6 +677,7 @@ def _create_provider_from_endpoint_name(
         Tuple of (provider instance, endpoint config)
     """
     endpoint_config = get_endpoint_config(endpoint_name=endpoint_name, store=store)
+    _enable_upstream_ssrf_protection(endpoint_config)
     return _create_provider(
         endpoint_config, endpoint_type, enable_tracing=enable_tracing
     ), endpoint_config
@@ -1637,6 +1662,8 @@ async def raw_proxy(endpoint_name: str, path: str, request: Request):
     provider, endpoint_config = _create_provider_from_endpoint_name(
         store, endpoint_name, EndpointType.LLM_V1_CHAT
     )
+    # The caller controls the upstream path here, so guard even provider-default base URLs.
+    _enable_upstream_ssrf_protection(endpoint_config, raw_proxy=True)
     _set_gateway_telemetry_state(request, endpoint_config)
     check_budget_limit(
         store, endpoint_config, workspace=workspace, username=_get_request_username(request)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -407,6 +407,7 @@ from mlflow.utils.validation import (
     _validate_batch_log_api_req,
     _validate_experiment_artifact_location,
     _validate_experiment_artifact_location_length,
+    _validate_gateway_secret_auth_config,
     _validate_trace_archival_location,
     _validate_trace_archival_retention_string,
     invalid_value,
@@ -5985,6 +5986,7 @@ def _create_gateway_secret():
     )
     # Empty map means no auth_config was provided
     auth_config = dict(request_message.auth_config) or None
+    _validate_gateway_secret_auth_config(auth_config)
 
     secret = _get_tracking_store().create_gateway_secret(
         secret_name=request_message.secret_name,
@@ -6027,6 +6029,7 @@ def _update_gateway_secret():
     )
     # Empty map means no auth_config was provided
     auth_config = dict(request_message.auth_config) or None
+    _validate_gateway_secret_auth_config(auth_config)
 
     # Empty map means no update to secret_value
     secret_value = dict(request_message.secret_value) or None

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5985,7 +5985,9 @@ def _create_gateway_secret():
             "created_by": [_assert_string],
         },
     )
-    # Empty map means no auth_config was provided
+    # Empty map means no auth_config was provided. Unlike update, the store's create path
+    # persists {} and None identically (NULL), so a map that normalizes to empty is folded
+    # into None here.
     auth_config = _validate_gateway_secret_auth_config(dict(request_message.auth_config)) or None
     secret_value = dict(request_message.secret_value)
     _validate_gateway_secret_value(secret_value)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -408,6 +408,7 @@ from mlflow.utils.validation import (
     _validate_experiment_artifact_location,
     _validate_experiment_artifact_location_length,
     _validate_gateway_secret_auth_config,
+    _validate_gateway_secret_value,
     _validate_trace_archival_location,
     _validate_trace_archival_retention_string,
     invalid_value,
@@ -5985,12 +5986,13 @@ def _create_gateway_secret():
         },
     )
     # Empty map means no auth_config was provided
-    auth_config = dict(request_message.auth_config) or None
-    _validate_gateway_secret_auth_config(auth_config)
+    auth_config = _validate_gateway_secret_auth_config(dict(request_message.auth_config)) or None
+    secret_value = dict(request_message.secret_value)
+    _validate_gateway_secret_value(secret_value)
 
     secret = _get_tracking_store().create_gateway_secret(
         secret_name=request_message.secret_name,
-        secret_value=dict(request_message.secret_value),
+        secret_value=secret_value,
         provider=request_message.provider or None,
         auth_config=auth_config,
         created_by=request_message.created_by or None,
@@ -6027,12 +6029,14 @@ def _update_gateway_secret():
             "updated_by": [_assert_string],
         },
     )
-    # Empty map means no auth_config was provided
-    auth_config = dict(request_message.auth_config) or None
-    _validate_gateway_secret_auth_config(auth_config)
+    # Empty map means no auth_config was provided. A map that normalizes to empty (e.g. only
+    # a blank api_base) is an explicit clear and is passed through as {}.
+    raw_auth_config = dict(request_message.auth_config)
+    auth_config = _validate_gateway_secret_auth_config(raw_auth_config) if raw_auth_config else None
 
     # Empty map means no update to secret_value
     secret_value = dict(request_message.secret_value) or None
+    _validate_gateway_secret_value(secret_value)
 
     secret = _get_tracking_store().update_gateway_secret(
         secret_id=request_message.secret_id,

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -924,6 +924,30 @@ def _is_public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     return _embedded_ipv4(ip).is_global
 
 
+def _is_ip_literal_like(hostname: str) -> bool:
+    """Mirror aiohttp's heuristic for hosts it dials as IP literals without a DNS lookup."""
+    return ":" in hostname or hostname.replace(".", "").isdigit()
+
+
+def _validate_canonical_ip_literal(hostname: str, field_name: str) -> None:
+    """Reject numeric hosts that are not canonical IP address literals.
+
+    ``socket`` accepts legacy spellings such as ``2130706433``, ``127.1`` or ``0177.0.0.1``
+    and maps them onto an address at connect time, but resolvers and validators can parse
+    them differently: ``0177.0.0.1`` is octal loopback to ``inet_aton`` and decimal
+    ``177.0.0.1`` to ``getaddrinfo``. Requiring the canonical form removes that parser
+    differential before any address check runs.
+    """
+    if not _is_ip_literal_like(hostname):
+        return
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError as e:
+        raise MlflowException.invalid_parameter_value(
+            f"{field_name} host {hostname!r} is not a canonical IP address literal."
+        ) from e
+
+
 def _resolve_hostname_with_timeout(hostname: str, field_name: str):
     acquired = _HOSTNAME_RESOLUTION_SEMAPHORE.acquire(timeout=_HOSTNAME_RESOLUTION_TIMEOUT_SECONDS)
     if not acquired:
@@ -1017,6 +1041,8 @@ def _validate_public_https_url(
             f"{field_name} must include a hostname: {url!r}"
         )
 
+    _validate_canonical_ip_literal(hostname, field_name)
+
     if not allow_private_ips:
         _validate_hostname_resolves_to_public_ips(hostname, field_name)
 
@@ -1042,19 +1068,50 @@ def _validate_gateway_api_base(url: str) -> None:
     )
 
 
-def _validate_gateway_secret_auth_config(auth_config: dict[str, Any] | None) -> None:
+# Keys that configure where the gateway sends requests. They must live in ``auth_config``,
+# where they are validated, never in the encrypted ``secret_value`` map, which is stored as-is.
+_GATEWAY_SECRET_VALUE_RESERVED_KEYS = frozenset({"api_base"})
+
+
+def _validate_gateway_secret_auth_config(
+    auth_config: dict[str, Any] | None,
+) -> dict[str, Any] | None:
     """Validate the user-controlled ``auth_config`` of an AI Gateway secret on write.
 
     Only ``api_base`` (see ``mlflow.gateway.config._AuthConfigKey.API_BASE``) names an
-    outbound target, so it is the only key checked. An empty value is treated as unset,
-    matching how the providers fall back to their default base URL.
+    outbound target, so it is the only key checked. Returns a normalized copy: a blank
+    ``api_base`` means "use the provider default", so the key is dropped rather than stored,
+    because providers select the default by truthiness and a whitespace-only string would
+    otherwise become the upstream URL. ``None`` or an empty map returns ``None``.
     """
     if not auth_config:
-        return
-    api_base = auth_config.get("api_base")
-    if api_base is None or (isinstance(api_base, str) and not api_base.strip()):
-        return
+        return None
+    normalized = dict(auth_config)
+    api_base = normalized.get("api_base")
+    if isinstance(api_base, str):
+        api_base = api_base.strip()
+    if not api_base:
+        normalized.pop("api_base", None)
+        return normalized
     _validate_gateway_api_base(api_base)
+    normalized["api_base"] = api_base
+    return normalized
+
+
+def _validate_gateway_secret_value(secret_value: dict[str, Any] | None) -> None:
+    """Reject ``secret_value`` keys that would steer gateway egress.
+
+    Providers built from the LiteLLM fallback merge ``secret_value`` over ``auth_config``, so
+    an ``api_base`` smuggled into the encrypted map would override the validated one.
+    """
+    if not secret_value:
+        return
+    if reserved := sorted(_GATEWAY_SECRET_VALUE_RESERVED_KEYS & set(secret_value)):
+        raise MlflowException.invalid_parameter_value(
+            f"secret_value must not contain {', '.join(map(repr, reserved))}: these keys "
+            "configure where the gateway sends requests and belong in auth_config, where "
+            "they are validated."
+        )
 
 
 def _validate_mcp_icon_url(url: str) -> None:

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -930,13 +930,11 @@ def _is_ip_literal_like(hostname: str) -> bool:
 
 
 def _validate_canonical_ip_literal(hostname: str, field_name: str) -> None:
-    """Reject numeric hosts that are not canonical IP address literals.
+    """Reject numeric hosts that are not canonical IP literals.
 
-    ``socket`` accepts legacy spellings such as ``2130706433``, ``127.1`` or ``0177.0.0.1``
-    and maps them onto an address at connect time, but resolvers and validators can parse
-    them differently: ``0177.0.0.1`` is octal loopback to ``inet_aton`` and decimal
-    ``177.0.0.1`` to ``getaddrinfo``. Requiring the canonical form removes that parser
-    differential before any address check runs.
+    ``socket`` maps legacy spellings like ``127.1`` or ``0177.0.0.1`` onto an address at
+    connect time, and validators may parse them differently (``0177.0.0.1`` is loopback to
+    ``inet_aton`` but ``177.0.0.1`` to ``getaddrinfo``).
     """
     if not _is_ip_literal_like(hostname):
         return
@@ -1048,17 +1046,11 @@ def _validate_public_https_url(
 
 
 def _validate_gateway_api_base(url: str) -> None:
-    """Validate the ``api_base`` override supplied in an AI Gateway secret's ``auth_config``.
+    """Validate an AI Gateway secret's ``api_base``: public HTTPS only by default.
 
-    The gateway sends upstream requests to this URL, and the raw proxy route appends a
-    caller-supplied path to it, so an unrestricted value turns the gateway into an SSRF
-    primitive against internal services and cloud metadata endpoints. Default behavior
-    accepts only public HTTPS targets, following the webhook and icon URL policies.
-
-    Operators can further configure:
-    - ``MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES`` to allow schemes like ``http``
-    - ``MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS=true`` to allow localhost /
-      loopback / private-network targets
+    The gateway sends requests to this URL, so it follows the webhook and icon URL SSRF
+    policy. ``MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES`` and
+    ``MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS`` relax it.
     """
     _validate_public_https_url(
         url,
@@ -1068,21 +1060,18 @@ def _validate_gateway_api_base(url: str) -> None:
     )
 
 
-# Keys that configure where the gateway sends requests. They must live in ``auth_config``,
-# where they are validated, never in the encrypted ``secret_value`` map, which is stored as-is.
+# Egress-controlling keys belong in the validated ``auth_config``, never in the encrypted,
+# unvalidated ``secret_value`` map.
 _GATEWAY_SECRET_VALUE_RESERVED_KEYS = frozenset({"api_base"})
 
 
 def _validate_gateway_secret_auth_config(
     auth_config: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Validate the user-controlled ``auth_config`` of an AI Gateway secret on write.
+    """Validate a gateway secret's ``auth_config`` on write and return a normalized copy.
 
-    Only ``api_base`` (see ``mlflow.gateway.config._AuthConfigKey.API_BASE``) names an
-    outbound target, so it is the only key checked. Returns a normalized copy: a blank
-    ``api_base`` means "use the provider default", so the key is dropped rather than stored,
-    because providers select the default by truthiness and a whitespace-only string would
-    otherwise become the upstream URL. ``None`` or an empty map returns ``None``.
+    ``api_base`` is the only key naming an outbound target. A blank value is dropped rather
+    than stored, since providers fall back to their default by truthiness.
     """
     if not auth_config:
         return None
@@ -1099,11 +1088,7 @@ def _validate_gateway_secret_auth_config(
 
 
 def _validate_gateway_secret_value(secret_value: dict[str, Any] | None) -> None:
-    """Reject ``secret_value`` keys that would steer gateway egress.
-
-    Providers built from the LiteLLM fallback merge ``secret_value`` over ``auth_config``, so
-    an ``api_base`` smuggled into the encrypted map would override the validated one.
-    """
+    """Reject ``secret_value`` keys that would steer gateway egress (see reserved keys)."""
     if not secret_value:
         return
     if reserved := sorted(_GATEWAY_SECRET_VALUE_RESERVED_KEYS & set(secret_value)):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -21,6 +21,8 @@ from mlflow.environment_variables import (
     _MLFLOW_WEBHOOK_ALLOW_PRIVATE_IPS,
     _MLFLOW_WEBHOOK_ALLOWED_SCHEMES,
     MLFLOW_ARTIFACT_LOCATION_MAX_LENGTH,
+    MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS,
+    MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES,
     MLFLOW_ICON_URL_ALLOW_PRIVATE_IPS,
     MLFLOW_ICON_URL_ALLOWED_DOMAINS,
     MLFLOW_ICON_URL_ALLOWED_SCHEMES,
@@ -1017,6 +1019,42 @@ def _validate_public_https_url(
 
     if not allow_private_ips:
         _validate_hostname_resolves_to_public_ips(hostname, field_name)
+
+
+def _validate_gateway_api_base(url: str) -> None:
+    """Validate the ``api_base`` override supplied in an AI Gateway secret's ``auth_config``.
+
+    The gateway sends upstream requests to this URL, and the raw proxy route appends a
+    caller-supplied path to it, so an unrestricted value turns the gateway into an SSRF
+    primitive against internal services and cloud metadata endpoints. Default behavior
+    accepts only public HTTPS targets, following the webhook and icon URL policies.
+
+    Operators can further configure:
+    - ``MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES`` to allow schemes like ``http``
+    - ``MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS=true`` to allow localhost /
+      loopback / private-network targets
+    """
+    _validate_public_https_url(
+        url,
+        field_name="Gateway secret api_base",
+        allowed_schemes=MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES.get(),
+        allow_private_ips=MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS.get(),
+    )
+
+
+def _validate_gateway_secret_auth_config(auth_config: dict[str, Any] | None) -> None:
+    """Validate the user-controlled ``auth_config`` of an AI Gateway secret on write.
+
+    Only ``api_base`` (see ``mlflow.gateway.config._AuthConfigKey.API_BASE``) names an
+    outbound target, so it is the only key checked. An empty value is treated as unset,
+    matching how the providers fall back to their default base URL.
+    """
+    if not auth_config:
+        return
+    api_base = auth_config.get("api_base")
+    if api_base is None or (isinstance(api_base, str) and not api_base.strip()):
+        return
+    _validate_gateway_api_base(api_base)
 
 
 def _validate_mcp_icon_url(url: str) -> None:

--- a/tests/gateway/providers/test_ai21labs.py
+++ b/tests/gateway/providers/test_ai21labs.py
@@ -125,6 +125,7 @@ async def test_completions():
                 "prompt": "This is a test",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -161,6 +161,7 @@ async def test_completions():
                 "stop_sequences": ["foobazbardiddly"],
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -184,6 +185,7 @@ async def test_completions_with_default_max_tokens():
                 "prompt": "\n\nHuman: How does a car work?\n\nAssistant:",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -368,6 +370,7 @@ async def test_chat():
                 "temperature": 0.25,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -505,6 +508,7 @@ async def test_chat_function_calling():
                 ],
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -708,6 +712,7 @@ async def test_chat_stream():
                 "stream": True,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -883,6 +888,7 @@ async def test_chat_function_calling_stream():
                 "stream": True,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -1004,6 +1010,7 @@ async def test_passthrough_anthropic_messages():
                 "model": "claude-2.1",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
         # Verify provider headers are propagated correctly
@@ -1066,6 +1073,7 @@ async def test_passthrough_anthropic_messages_streaming():
                 "model": "claude-2.1",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
         # Verify provider headers are propagated correctly
@@ -1106,6 +1114,7 @@ async def test_proxy_anthropic_non_streaming():
         "https://api.anthropic.com/v1/messages",
         json=payload,
         timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+        allow_redirects=False,
     )
     assert captured_session_headers["x-api-key"] == "key"
     assert captured_session_headers["X-Request-ID"] == "req-001"

--- a/tests/gateway/providers/test_cohere.py
+++ b/tests/gateway/providers/test_cohere.py
@@ -108,6 +108,7 @@ async def test_chat():
                 "temperature": 1.25,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -144,6 +145,7 @@ async def test_chat_with_system_messages():
                 "temperature": 1.25,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -276,6 +278,7 @@ async def test_chat_stream():
                 "stream": True,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -345,6 +348,7 @@ async def test_completions():
                 "stop_sequences": ["foobar"],
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -460,6 +464,7 @@ async def test_completions_stream():
                 "stream": True,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -159,6 +159,7 @@ async def test_gemini_single_embedding():
         expected_url,
         json=expected_payload,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 
@@ -205,6 +206,7 @@ async def test_gemini_batch_embedding():
         expected_url,
         json=expected_payload,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 
@@ -271,6 +273,7 @@ async def test_gemini_completions():
         expected_url,
         json=expected_payload,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 
@@ -378,6 +381,7 @@ async def test_gemini_chat():
         expected_url,
         json=expected_payload,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 
@@ -568,6 +572,7 @@ async def test_gemini_chat_function_calling():
         expected_url,
         json=expected_payload,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 
@@ -692,6 +697,7 @@ async def test_gemini_chat_multi_function_calling():
         expected_url,
         json=mock.ANY,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 
@@ -832,6 +838,7 @@ async def test_gemini_chat_function_calling_second_turn():
         expected_url,
         json=expected_payload,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 
@@ -952,6 +959,7 @@ async def test_gemini_chat_function_calling_thought_signature():
         expected_url,
         json=expected_payload,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 
@@ -1046,6 +1054,7 @@ async def test_gemini_chat_stream(resp):
         expected_url,
         json=mock.ANY,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 
@@ -1117,6 +1126,7 @@ async def test_gemini_chat_function_calling_stream():
         expected_url,
         json=mock.ANY,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 
@@ -1192,6 +1202,7 @@ async def test_gemini_completions_stream(resp):
         expected_url,
         json=mock.ANY,
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 

--- a/tests/gateway/providers/test_huggingface.py
+++ b/tests/gateway/providers/test_huggingface.py
@@ -111,6 +111,7 @@ async def test_completions():
                 },
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 

--- a/tests/gateway/providers/test_litellm.py
+++ b/tests/gateway/providers/test_litellm.py
@@ -1,12 +1,14 @@
 from unittest import mock
 
 import pytest
+from fastapi import HTTPException
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import EndpointConfig
 from mlflow.gateway.providers.base import PassthroughAction
 from mlflow.gateway.providers.litellm import LiteLLMAdapter, LiteLLMProvider
 from mlflow.gateway.schemas import chat, embeddings
+from mlflow.gateway.ssrf import upstream_ssrf_protection
 
 TEST_MESSAGE = "This is a test"
 
@@ -986,3 +988,74 @@ def test_litellm_extract_streaming_token_usage_responses_api_with_cached_tokens(
         "total_tokens": 150,
         "cache_read_input_tokens": 40,
     }
+
+
+def _addrinfo(*ips: str):
+    return [(None, None, None, None, (ip, 0)) for ip in ips]
+
+
+@pytest.fixture
+def protected_request():
+    # Simulates a tracking-server request, where the middleware turns the upstream guard on.
+    token = upstream_ssrf_protection.set(True)
+    try:
+        yield
+    finally:
+        upstream_ssrf_protection.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_chat_blocks_private_api_base_when_upstream_protection_is_on(protected_request):
+    # LiteLLM uses its own HTTP client, so the aiohttp connect-time guard never sees this
+    # request; the provider must check the host itself before handing the URL to LiteLLM.
+    config = chat_config_with_api_base()
+    with (
+        mock.patch("litellm.acompletion") as mock_completion,
+        mock.patch(
+            "mlflow.gateway.ssrf._getaddrinfo", mock.AsyncMock(return_value=_addrinfo("10.0.0.1"))
+        ),
+    ):
+        provider = LiteLLMProvider(EndpointConfig(**config))
+        payload = {"messages": [{"role": "user", "content": TEST_MESSAGE}]}
+        with pytest.raises(HTTPException, match="not a public IP address") as exc:
+            await provider.chat(chat.RequestPayload(**payload))
+
+    assert exc.value.status_code == 502
+    mock_completion.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chat_reaches_public_api_base_when_upstream_protection_is_on(protected_request):
+    config = chat_config_with_api_base()
+    mock_response = mock_litellm_chat_response()
+    with (
+        mock.patch("litellm.acompletion", return_value=mock_response) as mock_completion,
+        mock.patch(
+            "mlflow.gateway.ssrf._getaddrinfo", mock.AsyncMock(return_value=_addrinfo("8.8.8.8"))
+        ),
+    ):
+        provider = LiteLLMProvider(EndpointConfig(**config))
+        payload = {"messages": [{"role": "user", "content": TEST_MESSAGE}]}
+        await provider.chat(chat.RequestPayload(**payload))
+
+    assert mock_completion.call_args[1]["api_base"] == "https://custom-api.example.com"
+
+
+@pytest.mark.asyncio
+async def test_embeddings_block_private_api_base_when_upstream_protection_is_on(
+    protected_request,
+):
+    config = chat_config_with_api_base()
+    config["endpoint_type"] = "llm/v1/embeddings"
+    with (
+        mock.patch("litellm.aembedding") as mock_embedding,
+        mock.patch(
+            "mlflow.gateway.ssrf._getaddrinfo",
+            mock.AsyncMock(return_value=_addrinfo("169.254.169.254")),
+        ),
+    ):
+        provider = LiteLLMProvider(EndpointConfig(**config))
+        with pytest.raises(HTTPException, match="not a public IP address"):
+            await provider.embeddings(embeddings.RequestPayload(input="hello"))
+
+    mock_embedding.assert_not_called()

--- a/tests/gateway/providers/test_mistral.py
+++ b/tests/gateway/providers/test_mistral.py
@@ -94,6 +94,7 @@ async def test_completions():
                 "model": "mistral-tiny",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -435,6 +436,7 @@ async def _run_test_chat_stream(resp, provider):
                 **payload,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 

--- a/tests/gateway/providers/test_mlflow.py
+++ b/tests/gateway/providers/test_mlflow.py
@@ -73,6 +73,7 @@ async def test_completions():
                 },
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -205,6 +206,7 @@ async def test_embeddings():
             "http://127.0.0.1:2000/invocations",
             json={"inputs": ["test1", "test2"]},
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -291,6 +293,7 @@ async def test_chat():
                 "params": {"n": 1},
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 

--- a/tests/gateway/providers/test_mosaicml.py
+++ b/tests/gateway/providers/test_mosaicml.py
@@ -69,6 +69,7 @@ async def test_completions():
                 "parameters": {"n": 1, "max_new_tokens": 1000},
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -198,6 +199,7 @@ async def test_chat(payload, expected_llm_input):
             "https://models.hosted-on.mosaicml.hosting/llama2-70b-chat/v1/predict",
             json=expected_llm_input,
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -130,6 +130,7 @@ async def _run_test_chat(provider):
                 **payload,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -286,6 +287,7 @@ async def _run_test_chat_stream(resp, provider):
                 **payload,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -452,6 +454,7 @@ async def _run_test_completions(resp, provider):
                 "prompt": "This is a test",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -574,6 +577,7 @@ async def _run_test_completions_stream(resp, provider):
                 "stream_options": {"include_usage": True},
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -648,6 +652,7 @@ async def _run_test_embeddings(provider):
             "https://api.openai.com/v1/embeddings",
             json={"model": "text-embedding-ada-002", "input": "This is a test"},
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -728,6 +733,7 @@ async def test_embeddings_batch_input():
                 "input": ["1", "2"],
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -782,6 +788,7 @@ async def test_azure_openai():
                 "prompt": "This is a test",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -818,6 +825,7 @@ async def test_azuread_openai():
                 "prompt": "This is a test",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -1423,6 +1431,7 @@ async def test_proxy_non_streaming():
         "https://api.openai.com/v1/chat/completions",
         json={"messages": [{"role": "user", "content": "Hello"}]},
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 

--- a/tests/gateway/providers/test_openai_compatible.py
+++ b/tests/gateway/providers/test_openai_compatible.py
@@ -298,6 +298,7 @@ async def test_proxy_non_streaming():
         "https://api.test-provider.com/v1/chat/completions",
         json={"messages": [{"role": "user", "content": "Hello"}]},
         timeout=mock.ANY,
+        allow_redirects=False,
     )
 
 

--- a/tests/gateway/providers/test_palm.py
+++ b/tests/gateway/providers/test_palm.py
@@ -83,6 +83,7 @@ async def test_completions():
                 "stopSequences": ["foobar"],
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -201,6 +202,7 @@ async def test_chat(payload, expected_llm_input):
             "https://generativelanguage.googleapis.com/v1beta3/models/chat-bison:generateMessage",
             json=expected_llm_input,
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 

--- a/tests/gateway/providers/test_provider_utils.py
+++ b/tests/gateway/providers/test_provider_utils.py
@@ -95,6 +95,23 @@ async def test_aiohttp_post_uses_timeout_from_env_var(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_aiohttp_post_never_follows_redirects():
+    # A redirect from the upstream could otherwise steer the request to an internal host
+    # that the SSRF guard never saw.
+    mock_client = mock_http_client(MockAsyncResponse({}))
+    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+        async with _aiohttp_post(
+            headers={"Authorization": "Bearer key"},
+            base_url="https://api.example.com",
+            path="/v1/chat",
+            payload={"model": "x"},
+        ):
+            pass
+
+    assert mock_client.post.call_args.kwargs["allow_redirects"] is False
+
+
+@pytest.mark.asyncio
 async def test_aiohttp_post_sets_read_bufsize_for_large_sse_lines():
     mock_client = mock_http_client(MockAsyncResponse({}))
     with mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_session_cls:

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -116,6 +116,7 @@ async def test_completions():
                 "n": 1,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -231,6 +232,7 @@ async def test_completions_stream(resp):
                 "prompt": "This is a test",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -375,6 +377,7 @@ async def test_embeddings():
                 "model": "togethercomputer/m2-bert-80M-8k-retrieval",
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -455,6 +458,7 @@ async def test_chat():
                 "n": 1,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )
 
 
@@ -595,4 +599,5 @@ async def test_chat_stream(resp):
                 "n": 1,
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+            allow_redirects=False,
         )

--- a/tests/gateway/providers/test_vertex_ai.py
+++ b/tests/gateway/providers/test_vertex_ai.py
@@ -493,6 +493,7 @@ async def test_claude_chat_uses_raw_predict_endpoint():
             "anthropic_version": "vertex-2023-10-16",
         },
         timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+        allow_redirects=False,
     )
 
 
@@ -668,6 +669,7 @@ async def test_maas_chat_uses_openai_format():
             "messages": [{"role": "user", "content": "Hello"}],
         },
         timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS.get()),
+        allow_redirects=False,
     )
 
 

--- a/tests/gateway/test_ssrf.py
+++ b/tests/gateway/test_ssrf.py
@@ -11,6 +11,7 @@ from mlflow.gateway.providers.utils import _aiohttp_post, send_request
 from mlflow.gateway.ssrf import (
     GatewaySSRFProtectionError,
     SSRFGuardedResolver,
+    assert_public_upstream_host,
     assert_public_upstream_url,
     build_ssrf_guarded_connector,
     upstream_ssrf_protection,
@@ -230,3 +231,69 @@ async def test_send_request_explicit_bypass_reaches_private_upstream(upstream):
     )
     assert result == {"ok": True, "path": "/v1/chat"}
     assert upstream.hits == ["/v1/chat"]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://2130706433/v1",
+        "https://127.1/v1",
+        "https://0177.0.0.1/v1",
+        "https://0/v1",
+        "https://127.000.000.001/v1",
+    ],
+)
+def test_assert_public_upstream_url_rejects_noncanonical_ip_literals(url):
+    # aiohttp treats an all-numeric host as an IP literal and skips the resolver, so these
+    # would otherwise reach socket.connect, which maps them onto loopback.
+    with pytest.raises(GatewaySSRFProtectionError, match="not a canonical IP address literal"):
+        assert_public_upstream_url(url)
+
+
+def _addrinfo(*ips: str):
+    return [(None, None, None, None, (ip, 0)) for ip in ips]
+
+
+@pytest.mark.asyncio
+async def test_assert_public_upstream_host_rejects_hostname_resolving_to_private_ip():
+    with mock.patch(
+        "mlflow.gateway.ssrf._getaddrinfo",
+        mock.AsyncMock(return_value=_addrinfo("8.8.8.8", "169.254.169.254")),
+    ):
+        with pytest.raises(GatewaySSRFProtectionError, match="169.254.169.254"):
+            await assert_public_upstream_host("https://metadata.example/latest")
+
+
+@pytest.mark.asyncio
+async def test_assert_public_upstream_host_accepts_public_hostname():
+    getaddrinfo = mock.AsyncMock(return_value=_addrinfo("8.8.8.8", "2001:4860:4860::8888"))
+    with mock.patch("mlflow.gateway.ssrf._getaddrinfo", getaddrinfo):
+        await assert_public_upstream_host("https://api.example.com/v1")
+    getaddrinfo.assert_awaited_once_with("api.example.com")
+
+
+@pytest.mark.asyncio
+async def test_assert_public_upstream_host_rejects_unresolvable_hostname():
+    with mock.patch(
+        "mlflow.gateway.ssrf._getaddrinfo",
+        mock.AsyncMock(side_effect=socket.gaierror("Name or service not known")),
+    ):
+        with pytest.raises(GatewaySSRFProtectionError, match="Cannot resolve"):
+            await assert_public_upstream_host("https://does-not-exist.invalid/v1")
+
+
+@pytest.mark.asyncio
+async def test_assert_public_upstream_host_checks_ip_literals_without_lookup():
+    with mock.patch("mlflow.gateway.ssrf._getaddrinfo") as getaddrinfo:
+        with pytest.raises(GatewaySSRFProtectionError, match="not a public IP address"):
+            await assert_public_upstream_host("https://10.0.0.1/v1")
+        await assert_public_upstream_host("https://8.8.8.8/v1")
+    getaddrinfo.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_assert_public_upstream_host_skipped_when_private_ips_allowed(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS", "true")
+    with mock.patch("mlflow.gateway.ssrf._getaddrinfo") as getaddrinfo:
+        await assert_public_upstream_host("http://localhost:11434/v1")
+    getaddrinfo.assert_not_called()

--- a/tests/gateway/test_ssrf.py
+++ b/tests/gateway/test_ssrf.py
@@ -1,0 +1,232 @@
+import socket
+from unittest import mock
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from fastapi import HTTPException
+
+from mlflow.gateway.providers.utils import _aiohttp_post, send_request
+from mlflow.gateway.ssrf import (
+    GatewaySSRFProtectionError,
+    SSRFGuardedResolver,
+    assert_public_upstream_url,
+    build_ssrf_guarded_connector,
+    upstream_ssrf_protection,
+)
+
+
+@pytest.fixture(autouse=True)
+def protected_request():
+    # Simulates running inside a tracking-server request, where the middleware turns the
+    # upstream guard on.
+    token = upstream_ssrf_protection.set(True)
+    try:
+        yield
+    finally:
+        upstream_ssrf_protection.reset(token)
+
+
+def _resolve_result(ip: str, port: int = 0):
+    return {
+        "hostname": "upstream.example",
+        "host": ip,
+        "port": port,
+        "family": socket.AF_INET6 if ":" in ip else socket.AF_INET,
+        "proto": 0,
+        "flags": 0,
+    }
+
+
+def _inner_resolver(*ips: str):
+    resolver = mock.AsyncMock()
+    resolver.resolve.return_value = [_resolve_result(ip) for ip in ips]
+    return resolver
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "127.0.0.1",
+        "10.0.0.1",
+        "172.16.0.1",
+        "192.168.1.1",
+        "169.254.169.254",
+        "100.64.0.1",
+        "::1",
+        "fc00::1",
+        "64:ff9b::169.254.169.254",
+        "::ffff:10.0.0.1",
+    ],
+)
+@pytest.mark.asyncio
+async def test_guarded_resolver_rejects_private_addresses(ip):
+    resolver = SSRFGuardedResolver(_inner_resolver(ip))
+    with pytest.raises(GatewaySSRFProtectionError, match="not a public IP address"):
+        await resolver.resolve("upstream.example", 443)
+
+
+@pytest.mark.asyncio
+async def test_guarded_resolver_rejects_if_any_address_is_private():
+    resolver = SSRFGuardedResolver(_inner_resolver("8.8.8.8", "10.0.0.1"))
+    with pytest.raises(GatewaySSRFProtectionError, match="10.0.0.1"):
+        await resolver.resolve("upstream.example", 443)
+
+
+@pytest.mark.asyncio
+async def test_guarded_resolver_returns_public_addresses():
+    inner = _inner_resolver("8.8.8.8", "2001:4860:4860::8888")
+    resolver = SSRFGuardedResolver(inner)
+    results = await resolver.resolve("upstream.example", 443, family=socket.AF_UNSPEC)
+    assert [r["host"] for r in results] == ["8.8.8.8", "2001:4860:4860::8888"]
+    inner.resolve.assert_awaited_once_with("upstream.example", 443, family=socket.AF_UNSPEC)
+    await resolver.close()
+    inner.close.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://127.0.0.1/v1",
+        "http://169.254.169.254/latest/meta-data/",
+        "https://[::1]:8443/v1",
+        "https://[64:ff9b::169.254.169.254]/v1",
+        "https://192.168.1.10:11434/v1",
+    ],
+)
+def test_assert_public_upstream_url_rejects_private_ip_literals(url):
+    with pytest.raises(GatewaySSRFProtectionError, match="not a public IP address"):
+        assert_public_upstream_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.openai.com/v1",
+        "https://8.8.8.8/v1",
+        "https://[2001:4860:4860::8888]/v1",
+        # Hostnames are deferred to the resolver, so no DNS lookup happens here.
+        "https://localhost:11434/v1",
+    ],
+)
+def test_assert_public_upstream_url_accepts_public_literals_and_hostnames(url):
+    with mock.patch("socket.getaddrinfo") as getaddrinfo:
+        assert_public_upstream_url(url)
+    getaddrinfo.assert_not_called()
+
+
+def test_assert_public_upstream_url_rejects_missing_hostname():
+    with pytest.raises(GatewaySSRFProtectionError, match="must include a hostname"):
+        assert_public_upstream_url("https:///v1")
+
+
+def test_assert_public_upstream_url_skipped_when_private_ips_allowed(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS", "true")
+    assert_public_upstream_url("http://169.254.169.254/latest/meta-data/")
+
+
+@pytest.mark.asyncio
+async def test_build_connector_uses_guarded_resolver_by_default():
+    connector = build_ssrf_guarded_connector()
+    try:
+        assert isinstance(connector._resolver, SSRFGuardedResolver)
+    finally:
+        await connector.close()
+
+
+def test_build_connector_disabled_when_private_ips_allowed(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS", "true")
+    assert build_ssrf_guarded_connector() is None
+
+
+def test_protection_is_off_outside_a_protected_request():
+    # The standalone gateway and direct provider use are not tracking-server requests, so
+    # they keep aiohttp's default resolver and may target private upstreams.
+    token = upstream_ssrf_protection.set(False)
+    try:
+        assert build_ssrf_guarded_connector() is None
+        assert_public_upstream_url("http://127.0.0.1:11434/v1")
+    finally:
+        upstream_ssrf_protection.reset(token)
+
+
+# -- End-to-end through the gateway's egress choke point against a real local upstream --
+
+
+@pytest_asyncio.fixture
+async def upstream():
+    hits = []
+
+    async def handler(request):
+        hits.append(request.path)
+        return web.json_response({"ok": True, "path": request.path})
+
+    async def redirect(request):
+        hits.append(request.path)
+        raise web.HTTPFound("/internal/secret")
+
+    app = web.Application()
+    app.router.add_post("/redirect", redirect)
+    app.router.add_post("/{tail:.*}", handler)
+    server = TestServer(app, host="127.0.0.1")
+    await server.start_server()
+    server.hits = hits
+    try:
+        yield server
+    finally:
+        await server.close()
+
+
+@pytest.mark.asyncio
+async def test_send_request_blocks_private_ip_literal_upstream(upstream):
+    with pytest.raises(HTTPException, match="not a public IP address") as exc:
+        await send_request({}, str(upstream.make_url("")), "/v1/chat", {"model": "x"})
+    assert exc.value.status_code == 502
+    assert "not a public IP address" in exc.value.detail
+    assert upstream.hits == []
+
+
+@pytest.mark.asyncio
+async def test_send_request_blocks_hostname_that_resolves_to_private_ip(upstream):
+    # Simulates DNS rebinding: whatever the hostname resolved to when the secret was
+    # written, the address handed to the connector at request time is private.
+    rebinding = _inner_resolver("127.0.0.1")
+    rebinding.resolve.return_value = [_resolve_result("127.0.0.1", upstream.port)]
+    with mock.patch("mlflow.gateway.ssrf.DefaultResolver", return_value=rebinding):
+        with pytest.raises(HTTPException, match="rebind.example") as exc:
+            await send_request(
+                {}, f"http://rebind.example:{upstream.port}", "/v1/chat", {"model": "x"}
+            )
+    assert exc.value.status_code == 502
+    assert "'rebind.example' resolves to 127.0.0.1" in exc.value.detail
+    rebinding.resolve.assert_awaited()
+    assert upstream.hits == []
+
+
+@pytest.mark.asyncio
+async def test_send_request_reaches_private_upstream_when_allowed(upstream, monkeypatch):
+    monkeypatch.setenv("MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS", "true")
+    result = await send_request({}, str(upstream.make_url("")), "/v1/chat", {"model": "x"})
+    assert result == {"ok": True, "path": "/v1/chat"}
+    assert upstream.hits == ["/v1/chat"]
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_post_does_not_follow_upstream_redirects(upstream, monkeypatch):
+    monkeypatch.setenv("MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS", "true")
+    async with _aiohttp_post({}, str(upstream.make_url("")), "/redirect", {}) as response:
+        assert response.status == 302
+        assert response.headers["Location"] == "/internal/secret"
+        assert response.history == ()
+    assert upstream.hits == ["/redirect"]
+
+
+@pytest.mark.asyncio
+async def test_send_request_explicit_bypass_reaches_private_upstream(upstream):
+    # Used for the server calling itself (guardrail sanitization), never for provider hosts.
+    result = await send_request(
+        {}, str(upstream.make_url("")), "/v1/chat", {"model": "x"}, ssrf_protect=False
+    )
+    assert result == {"ok": True, "path": "/v1/chat"}
+    assert upstream.hits == ["/v1/chat"]

--- a/tests/server/test_fastapi_app.py
+++ b/tests/server/test_fastapi_app.py
@@ -6,7 +6,12 @@ from starlette.websockets import WebSocketDisconnect
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.constants import MLFLOW_GATEWAY_DURATION_HEADER
-from mlflow.server.fastapi_app import add_mcp_exception_handlers, create_fastapi_app
+from mlflow.gateway.ssrf import upstream_ssrf_protection
+from mlflow.server.fastapi_app import (
+    add_gateway_upstream_protection_middleware,
+    add_mcp_exception_handlers,
+    create_fastapi_app,
+)
 from mlflow.server.handlers import STATIC_PREFIX_ENV_VAR
 from mlflow.tracing.utils.otlp import OTLP_TRACES_PATH
 
@@ -83,3 +88,21 @@ def test_gateway_timing_header_present_for_prefixed_route(monkeypatch):
 
     response = client.post("/myprefix/gateway/mlflow/v1/chat/completions", json={})
     assert MLFLOW_GATEWAY_DURATION_HEADER in response.headers
+
+
+def test_gateway_upstream_protection_middleware_marks_requests_as_protected():
+    app = FastAPI()
+    add_gateway_upstream_protection_middleware(app)
+
+    @app.get("/probe")
+    async def probe():
+        return {"protected": upstream_ssrf_protection.get()}
+
+    assert TestClient(app).get("/probe").json() == {"protected": True}
+    # Scoped to the request: nothing leaks into the caller's context.
+    assert upstream_ssrf_protection.get() is False
+
+
+def test_create_fastapi_app_enables_gateway_upstream_protection():
+    app = create_fastapi_app()
+    assert app.state.gateway_upstream_protection_middleware_added is True

--- a/tests/server/test_fastapi_app.py
+++ b/tests/server/test_fastapi_app.py
@@ -6,12 +6,7 @@ from starlette.websockets import WebSocketDisconnect
 
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.constants import MLFLOW_GATEWAY_DURATION_HEADER
-from mlflow.gateway.ssrf import upstream_ssrf_protection
-from mlflow.server.fastapi_app import (
-    add_gateway_upstream_protection_middleware,
-    add_mcp_exception_handlers,
-    create_fastapi_app,
-)
+from mlflow.server.fastapi_app import add_mcp_exception_handlers, create_fastapi_app
 from mlflow.server.handlers import STATIC_PREFIX_ENV_VAR
 from mlflow.tracing.utils.otlp import OTLP_TRACES_PATH
 
@@ -88,21 +83,3 @@ def test_gateway_timing_header_present_for_prefixed_route(monkeypatch):
 
     response = client.post("/myprefix/gateway/mlflow/v1/chat/completions", json={})
     assert MLFLOW_GATEWAY_DURATION_HEADER in response.headers
-
-
-def test_gateway_upstream_protection_middleware_marks_requests_as_protected():
-    app = FastAPI()
-    add_gateway_upstream_protection_middleware(app)
-
-    @app.get("/probe")
-    async def probe():
-        return {"protected": upstream_ssrf_protection.get()}
-
-    assert TestClient(app).get("/probe").json() == {"protected": True}
-    # Scoped to the request: nothing leaks into the caller's context.
-    assert upstream_ssrf_protection.get() is False
-
-
-def test_create_fastapi_app_enables_gateway_upstream_protection():
-    app = create_fastapi_app()
-    assert app.state.gateway_upstream_protection_middleware_added is True

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -49,11 +49,13 @@ from mlflow.gateway.providers.openai import OpenAIProvider
 from mlflow.gateway.providers.portkey import PortkeyProvider
 from mlflow.gateway.providers.utils import provider_call_duration_ms
 from mlflow.gateway.schemas import chat, embeddings
+from mlflow.gateway.ssrf import assert_public_upstream_url, upstream_ssrf_protection
 from mlflow.server.fastapi_app import add_gateway_timing_middleware
 from mlflow.server.gateway_api import (
     _build_endpoint_config,
     _create_provider_from_endpoint_name,
     _decompress_zstd,
+    _enable_upstream_ssrf_protection,
     _get_request_username,
     anthropic_passthrough_messages,
     chat_completions,
@@ -509,6 +511,72 @@ def test_create_provider_from_endpoint_name_litellm_with_api_base(store: SqlAlch
         == "https://custom-api.example.com"
     )
     assert provider.config.model.config.litellm_provider == "litellm"
+
+
+@pytest.fixture(autouse=True)
+def reset_upstream_ssrf_protection():
+    # Provider creation sets the request-scoped flag; tests share one context, so clear it.
+    yield
+    upstream_ssrf_protection.set(False)
+
+
+def _create_endpoint(store: SqlAlchemyStore, name: str, provider: str, auth_config=None):
+    secret = store.create_gateway_secret(
+        secret_name=f"{name}-key",
+        secret_value={"api_key": "k"},
+        provider=provider,
+        auth_config=auth_config,
+    )
+    model_def = store.create_gateway_model_definition(
+        name=f"{name}-model",
+        secret_id=secret.secret_id,
+        provider=provider,
+        model_name="m",
+    )
+    return store.create_gateway_endpoint(
+        name=name,
+        model_configs=[
+            GatewayEndpointModelConfig(
+                model_definition_id=model_def.model_definition_id,
+                linkage_type=GatewayModelLinkageType.PRIMARY,
+                weight=1.0,
+            ),
+        ],
+    )
+
+
+def test_upstream_ssrf_protection_enabled_for_user_supplied_api_base(store: SqlAlchemyStore):
+    endpoint = _create_endpoint(
+        store, "custom-base", "openai", auth_config={"api_base": "https://llm.example.com/v1"}
+    )
+    assert upstream_ssrf_protection.get() is False
+
+    _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
+
+    assert upstream_ssrf_protection.get() is True
+    with pytest.raises(Exception, match="not a public IP address"):
+        assert_public_upstream_url("http://127.0.0.1:11434/v1")
+
+
+def test_upstream_ssrf_protection_not_enabled_for_provider_default_on_typed_routes(
+    store: SqlAlchemyStore,
+):
+    # Ollama's built-in base URL is localhost; the typed routes must keep reaching it.
+    endpoint = _create_endpoint(store, "local-ollama", "ollama")
+
+    provider, endpoint_config = _create_provider_from_endpoint_name(
+        store, endpoint.name, EndpointType.LLM_V1_CHAT
+    )
+
+    assert provider.config.model.config.api_base is None
+    assert upstream_ssrf_protection.get() is False
+    assert_public_upstream_url("http://127.0.0.1:11434/v1")
+
+    # The raw proxy also lets the caller choose the path, so it guards the default too.
+    _enable_upstream_ssrf_protection(endpoint_config, raw_proxy=True)
+    assert upstream_ssrf_protection.get() is True
+    with pytest.raises(Exception, match="not a public IP address"):
+        assert_public_upstream_url("http://127.0.0.1:11434/v1")
 
 
 def test_create_provider_from_endpoint_name_litellm_ignores_api_base_in_secret_value(

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -511,6 +511,43 @@ def test_create_provider_from_endpoint_name_litellm_with_api_base(store: SqlAlch
     assert provider.config.model.config.litellm_provider == "litellm"
 
 
+def test_create_provider_from_endpoint_name_litellm_ignores_api_base_in_secret_value(
+    store: SqlAlchemyStore,
+):
+    # Simulates a row written before the handler rejected api_base inside secret_value: the
+    # encrypted map is never validated, so it must not override the validated auth_config.
+    secret = store.create_gateway_secret(
+        secret_name="litellm-smuggled-key",
+        secret_value={"api_key": "litellm-key", "api_base": "http://169.254.169.254/latest"},
+        provider="litellm",
+        auth_config={"api_base": "https://custom-api.example.com"},
+    )
+    model_def = store.create_gateway_model_definition(
+        name="litellm-smuggled-model",
+        secret_id=secret.secret_id,
+        provider="litellm",
+        model_name="custom-model",
+    )
+    endpoint = store.create_gateway_endpoint(
+        name="test-litellm-smuggled-endpoint",
+        model_configs=[
+            GatewayEndpointModelConfig(
+                model_definition_id=model_def.model_definition_id,
+                linkage_type=GatewayModelLinkageType.PRIMARY,
+                weight=1.0,
+            ),
+        ],
+    )
+
+    provider, _ = _create_provider_from_endpoint_name(
+        store, endpoint.name, EndpointType.LLM_V1_CHAT
+    )
+
+    auth_config = provider.config.model.config.litellm_auth_config
+    assert auth_config["api_base"] == "https://custom-api.example.com"
+    assert auth_config["api_key"] == "litellm-key"
+
+
 @pytest.mark.parametrize(
     "input_url",
     [

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -37,6 +37,7 @@ from mlflow.entities.gateway_budget_policy import (
     BudgetTargetScope,
     BudgetUnit,
 )
+from mlflow.entities.gateway_secrets import GatewaySecretInfo
 from mlflow.entities.model_registry import (
     ModelVersion,
     ModelVersionTag,
@@ -121,6 +122,7 @@ from mlflow.protos.service_pb2 import (
     BatchGetTraces,
     CalculateTraceFilterCorrelation,
     CreateExperiment,
+    CreateGatewaySecret,
     DeleteScorer,
     DeleteTraceTag,
     DeleteTraceTagV3,
@@ -142,6 +144,7 @@ from mlflow.protos.service_pb2 import (
     SetTraceTag,
     SetTraceTagV3,
     TraceLocation,
+    UpdateGatewaySecret,
 )
 from mlflow.protos.service_pb2 import (
     FallbackStrategy as ProtoFallbackStrategy,
@@ -170,6 +173,7 @@ from mlflow.server.handlers import (
     _create_artifact_file_response,
     _create_dataset_handler,
     _create_experiment,
+    _create_gateway_secret,
     _create_issue,
     _create_model_version,
     _create_presigned_download_url,
@@ -242,6 +246,7 @@ from mlflow.server.handlers import (
     _set_trace_tag,
     _set_trace_tag_v3,
     _transition_stage,
+    _update_gateway_secret,
     _update_issue,
     _update_model_version,
     _update_registered_model,
@@ -8531,3 +8536,122 @@ def test_set_review_queue_item_status_stamps_completed_by(
         assert call_kwargs["completed_by"] == expected_completed_by
         # Pin status pass-through too, so a regression that mangles status is caught.
         assert call_kwargs["status"] == status
+
+
+def _gateway_secret_info(auth_config=None):
+    return GatewaySecretInfo(
+        secret_id="s-123",
+        secret_name="my-secret",
+        masked_values={"api_key": "sk-...123"},
+        created_at=1,
+        last_updated_at=1,
+        provider="openai",
+        auth_config=auth_config,
+    )
+
+
+def _create_gateway_secret_request(auth_config):
+    return CreateGatewaySecret(
+        secret_name="my-secret",
+        secret_value={"api_key": "sk-123"},
+        provider="openai",
+        auth_config=auth_config,
+    )
+
+
+def _update_gateway_secret_request(auth_config):
+    return UpdateGatewaySecret(secret_id="s-123", auth_config=auth_config)
+
+
+@pytest.mark.parametrize(
+    ("handler", "build_request"),
+    [
+        (_create_gateway_secret, _create_gateway_secret_request),
+        (_update_gateway_secret, _update_gateway_secret_request),
+    ],
+)
+@pytest.mark.parametrize(
+    ("api_base", "resolved_ip", "expected_match"),
+    [
+        ("https://169.254.169.254/latest", "169.254.169.254", "must not resolve to a non-public"),
+        ("https://localhost:11434/v1", "127.0.0.1", "must not resolve to a non-public"),
+        ("http://api.example.com/v1", "8.8.8.8", "Invalid Gateway secret api_base scheme"),
+        ("https://user:pw@api.example.com/v1", "8.8.8.8", "must not include embedded credentials"),
+    ],
+)
+def test_gateway_secret_handlers_reject_unsafe_api_base(
+    mock_get_request_message,
+    mock_tracking_store,
+    handler,
+    build_request,
+    api_base,
+    resolved_ip,
+    expected_match,
+):
+    mock_get_request_message.return_value = build_request({
+        "auth_mode": "api_key",
+        "api_base": api_base,
+    })
+    with mock.patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        return_value=[(None, None, None, None, (resolved_ip, 0))],
+    ):
+        response = handler()
+
+    assert response.status_code == 400
+    body = json.loads(response.get_data())
+    assert body["error_code"] == "INVALID_PARAMETER_VALUE"
+    assert expected_match in body["message"]
+    mock_tracking_store.create_gateway_secret.assert_not_called()
+    mock_tracking_store.update_gateway_secret.assert_not_called()
+
+
+def test_create_gateway_secret_accepts_public_api_base(
+    mock_get_request_message, mock_tracking_store
+):
+    auth_config = {"auth_mode": "api_key", "api_base": "https://my-resource.openai.azure.com"}
+    mock_get_request_message.return_value = _create_gateway_secret_request(auth_config)
+    mock_tracking_store.create_gateway_secret.return_value = _gateway_secret_info(auth_config)
+
+    with mock.patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("8.8.8.8", 0))],
+    ):
+        response = _create_gateway_secret()
+
+    assert response.status_code == 200
+    _, kwargs = mock_tracking_store.create_gateway_secret.call_args
+    assert kwargs["auth_config"] == auth_config
+    assert json.loads(response.get_data())["secret"]["secret_id"] == "s-123"
+
+
+def test_update_gateway_secret_accepts_public_api_base(
+    mock_get_request_message, mock_tracking_store
+):
+    auth_config = {"auth_mode": "api_key", "api_base": "https://my-resource.openai.azure.com"}
+    mock_get_request_message.return_value = _update_gateway_secret_request(auth_config)
+    mock_tracking_store.update_gateway_secret.return_value = _gateway_secret_info(auth_config)
+
+    with mock.patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("8.8.8.8", 0))],
+    ):
+        response = _update_gateway_secret()
+
+    assert response.status_code == 200
+    _, kwargs = mock_tracking_store.update_gateway_secret.call_args
+    assert kwargs["auth_config"] == auth_config
+
+
+def test_gateway_secret_handlers_skip_api_base_validation_when_unset(
+    mock_get_request_message, mock_tracking_store
+):
+    mock_get_request_message.return_value = _create_gateway_secret_request({"auth_mode": "api_key"})
+    mock_tracking_store.create_gateway_secret.return_value = _gateway_secret_info({
+        "auth_mode": "api_key"
+    })
+    with mock.patch("mlflow.utils.validation.socket.getaddrinfo") as mock_getaddrinfo:
+        response = _create_gateway_secret()
+
+    assert response.status_code == 200
+    mock_getaddrinfo.assert_not_called()

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -8655,3 +8655,60 @@ def test_gateway_secret_handlers_skip_api_base_validation_when_unset(
 
     assert response.status_code == 200
     mock_getaddrinfo.assert_not_called()
+
+
+def test_create_gateway_secret_rejects_api_base_in_secret_value(
+    mock_get_request_message, mock_tracking_store
+):
+    mock_get_request_message.return_value = CreateGatewaySecret(
+        secret_name="my-secret",
+        secret_value={"api_key": "sk-123", "api_base": "https://169.254.169.254/latest"},
+        provider="litellm",
+    )
+    response = _create_gateway_secret()
+
+    assert response.status_code == 400
+    assert "secret_value must not contain 'api_base'" in json.loads(response.get_data())["message"]
+    mock_tracking_store.create_gateway_secret.assert_not_called()
+
+
+def test_update_gateway_secret_rejects_api_base_in_secret_value(
+    mock_get_request_message, mock_tracking_store
+):
+    mock_get_request_message.return_value = UpdateGatewaySecret(
+        secret_id="s-123", secret_value={"api_key": "sk-123", "api_base": "http://10.0.0.1/v1"}
+    )
+    response = _update_gateway_secret()
+
+    assert response.status_code == 400
+    assert "secret_value must not contain 'api_base'" in json.loads(response.get_data())["message"]
+    mock_tracking_store.update_gateway_secret.assert_not_called()
+
+
+def test_create_gateway_secret_drops_blank_api_base_before_storing(
+    mock_get_request_message, mock_tracking_store
+):
+    mock_get_request_message.return_value = _create_gateway_secret_request({
+        "auth_mode": "api_key",
+        "api_base": "   ",
+    })
+    mock_tracking_store.create_gateway_secret.return_value = _gateway_secret_info({
+        "auth_mode": "api_key"
+    })
+    response = _create_gateway_secret()
+
+    assert response.status_code == 200
+    _, kwargs = mock_tracking_store.create_gateway_secret.call_args
+    assert kwargs["auth_config"] == {"auth_mode": "api_key"}
+
+
+def test_update_gateway_secret_blank_api_base_alone_clears_auth_config(
+    mock_get_request_message, mock_tracking_store
+):
+    mock_get_request_message.return_value = _update_gateway_secret_request({"api_base": ""})
+    mock_tracking_store.update_gateway_secret.return_value = _gateway_secret_info(None)
+    response = _update_gateway_secret()
+
+    assert response.status_code == 200
+    _, kwargs = mock_tracking_store.update_gateway_secret.call_args
+    assert kwargs["auth_config"] == {}

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -22,6 +22,7 @@ from mlflow.utils.validation import (
     _validate_experiment_name,
     _validate_gateway_api_base,
     _validate_gateway_secret_auth_config,
+    _validate_gateway_secret_value,
     _validate_list_param,
     _validate_mcp_icon_url,
     _validate_metric_name,
@@ -867,6 +868,26 @@ def test_validate_gateway_api_base_rejects_private_ips(url, resolved_ip):
             _validate_gateway_api_base(url)
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://2130706433/v1",
+        "https://127.1/v1",
+        "https://0177.0.0.1/v1",
+        "https://0/v1",
+        "https://127.000.000.001/v1",
+    ],
+)
+def test_validate_gateway_api_base_rejects_noncanonical_ip_literals(url):
+    # Legacy numeric spellings are parsed differently by getaddrinfo and by socket.connect
+    # (0177.0.0.1 is public 177.0.0.1 to the former and octal loopback to the latter), so
+    # they are refused outright rather than resolved.
+    with patch("mlflow.utils.validation.socket.getaddrinfo") as mock_getaddrinfo:
+        with pytest.raises(MlflowException, match="not a canonical IP address literal"):
+            _validate_gateway_api_base(url)
+    mock_getaddrinfo.assert_not_called()
+
+
 def test_validate_gateway_api_base_accepts_public_https_target():
     with patch(
         "mlflow.utils.validation.socket.getaddrinfo",
@@ -911,6 +932,34 @@ def test_validate_gateway_secret_auth_config_skips_when_api_base_unset(auth_conf
     with patch("mlflow.utils.validation.socket.getaddrinfo") as mock_getaddrinfo:
         _validate_gateway_secret_auth_config(auth_config)
     mock_getaddrinfo.assert_not_called()
+
+
+def test_validate_gateway_secret_auth_config_normalizes_api_base():
+    assert _validate_gateway_secret_auth_config(None) is None
+    assert _validate_gateway_secret_auth_config({}) is None
+    # Blank means "use the provider default", so the key is dropped rather than stored.
+    assert _validate_gateway_secret_auth_config({"auth_mode": "api_key", "api_base": "   "}) == {
+        "auth_mode": "api_key"
+    }
+    assert _validate_gateway_secret_auth_config({"api_base": ""}) == {}
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo("8.8.8.8"),
+    ):
+        assert _validate_gateway_secret_auth_config({
+            "api_base": " https://api.example.com/v1 "
+        }) == {"api_base": "https://api.example.com/v1"}
+
+
+@pytest.mark.parametrize("secret_value", [None, {}, {"api_key": "sk-x", "api_version": "1"}])
+def test_validate_gateway_secret_value_accepts_secret_keys(secret_value):
+    _validate_gateway_secret_value(secret_value)
+
+
+def test_validate_gateway_secret_value_rejects_api_base():
+    with pytest.raises(MlflowException, match="secret_value must not contain 'api_base'") as exc:
+        _validate_gateway_secret_value({"api_key": "sk-x", "api_base": "https://169.254.169.254/"})
+    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
 def test_validate_gateway_secret_auth_config_rejects_private_api_base():

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -20,6 +20,8 @@ from mlflow.utils.validation import (
     _validate_experiment_artifact_location,
     _validate_experiment_artifact_location_length,
     _validate_experiment_name,
+    _validate_gateway_api_base,
+    _validate_gateway_secret_auth_config,
     _validate_list_param,
     _validate_mcp_icon_url,
     _validate_metric_name,
@@ -820,3 +822,115 @@ def test_validate_public_https_url_accepts_public_ipv6_addresses(public_ipv6: st
     ) as mock_getaddrinfo:
         _validate_public_https_url("https://example.com/icon.png", field_name="Icon URL")
         mock_getaddrinfo.assert_called()
+
+
+# -- _validate_gateway_api_base / _validate_gateway_secret_auth_config tests --
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_match"),
+    [
+        (123, "Gateway secret api_base must be a string"),
+        ("", "Gateway secret api_base cannot be empty"),
+        ("http://api.example.com/v1", "Invalid Gateway secret api_base scheme"),
+        ("file:///etc/passwd", "Invalid Gateway secret api_base scheme"),
+        ("gopher://example.com", "Invalid Gateway secret api_base scheme"),
+        ("https://", "Gateway secret api_base must include a hostname"),
+        ("https://user:pass@api.example.com/v1", "must not include embedded credentials"),
+    ],
+)
+def test_validate_gateway_api_base_rejects_invalid_input(url, expected_match):
+    with pytest.raises(MlflowException, match=expected_match) as exc:
+        _validate_gateway_api_base(url)
+    assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+
+@pytest.mark.parametrize(
+    ("url", "resolved_ip"),
+    [
+        ("https://127.0.0.1/v1", "127.0.0.1"),
+        ("https://localhost:11434/v1", "127.0.0.1"),
+        ("https://[::1]/v1", "::1"),
+        ("https://internal.corp/v1", "10.0.0.1"),
+        ("https://internal.corp/v1", "192.168.1.1"),
+        ("https://169.254.169.254/latest/meta-data/", "169.254.169.254"),
+        ("https://metadata.internal/v1", "169.254.169.254"),
+        ("https://nat64-metadata.internal/v1", "64:ff9b::169.254.169.254"),
+    ],
+)
+def test_validate_gateway_api_base_rejects_private_ips(url, resolved_ip):
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo(resolved_ip),
+    ):
+        with pytest.raises(MlflowException, match="must not resolve to a non-public"):
+            _validate_gateway_api_base(url)
+
+
+def test_validate_gateway_api_base_accepts_public_https_target():
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo("8.8.8.8"),
+    ):
+        _validate_gateway_api_base("https://my-resource.openai.azure.com")
+
+
+def test_validate_gateway_api_base_allowed_schemes_env_var(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES", "http,https")
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo("8.8.8.8"),
+    ):
+        _validate_gateway_api_base("http://api.example.com/v1")
+        # Non-HTTP schemes stay rejected even with http enabled.
+        with pytest.raises(MlflowException, match="Invalid Gateway secret api_base scheme"):
+            _validate_gateway_api_base("ftp://api.example.com/v1")
+
+
+def test_validate_gateway_api_base_allow_private_ips_env_var(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS", "true")
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo("127.0.0.1"),
+    ) as mock_getaddrinfo:
+        _validate_gateway_api_base("https://localhost:11434/v1")
+    mock_getaddrinfo.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "auth_config",
+    [
+        None,
+        {},
+        {"auth_mode": "api_key"},
+        {"api_base": ""},
+        {"api_base": "   "},
+    ],
+)
+def test_validate_gateway_secret_auth_config_skips_when_api_base_unset(auth_config):
+    with patch("mlflow.utils.validation.socket.getaddrinfo") as mock_getaddrinfo:
+        _validate_gateway_secret_auth_config(auth_config)
+    mock_getaddrinfo.assert_not_called()
+
+
+def test_validate_gateway_secret_auth_config_rejects_private_api_base():
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo("169.254.169.254"),
+    ):
+        with pytest.raises(MlflowException, match="must not resolve to a non-public"):
+            _validate_gateway_secret_auth_config({
+                "auth_mode": "api_key",
+                "api_base": "https://169.254.169.254/latest",
+            })
+
+
+def test_validate_gateway_secret_auth_config_accepts_public_api_base():
+    with patch(
+        "mlflow.utils.validation.socket.getaddrinfo",
+        side_effect=_mock_getaddrinfo("8.8.8.8"),
+    ):
+        _validate_gateway_secret_auth_config({
+            "auth_mode": "api_key",
+            "api_base": "https://api.example.com/v1",
+        })


### PR DESCRIPTION
### Related Issues/PRs

Relates to https://github.com/advisories/GHSA-h7x2-h6g9-p789 (CVE-2026-71211)

### What changes are proposed in this pull request?

A gateway secret's `auth_config.api_base` was stored verbatim, and the raw proxy route sends caller-supplied paths to it and returns the response body, so any user who could create a secret could reach internal services and cloud metadata endpoints. This PR enforces a public-upstream policy at two layers:

- **Write time**: `_create_gateway_secret` / `_update_gateway_secret` validate `api_base` with `_validate_gateway_api_base` (HTTPS only, no embedded credentials, canonical IP literals, every resolved address public). `api_base` inside `secret_value` is rejected, and a blank value is dropped so providers fall back to their default.
- **Connect time** (`mlflow/gateway/ssrf.py`): `_aiohttp_post`, the egress point for all proxy and passthrough routes, uses a resolver that only returns public addresses, rejects non-canonical literals that aiohttp would dial without resolving, and never follows redirects. This covers DNS rebinding and rows stored before validation existed. LiteLLM uses its own HTTP client, so `LiteLLMProvider` resolves and checks `api_base` right before each call instead; the gap between that lookup and LiteLLM's own is documented as residual. Because that provider spreads a secret's `auth_config` into litellm kwargs, and litellm accepts `base_url` as an alias for `api_base` plus `model_list` / `fallbacks` / `custom_llm_provider` that also choose the destination, those keys (`GATEWAY_DESTINATION_KEYS`) are rejected in `auth_config` and `secret_value` on write, refused in any inference payload on the LiteLLM path regardless of arming, and, when armed, `base_url` is folded into `api_base` so the effective destination is what gets checked.
- Enforcement is scoped per request and turned on only when the endpoint's secret carries a user-supplied destination (`api_base`, or one of the LiteLLM alias keys above on rows stored before those were rejected), or on the raw proxy route, where the caller also controls the path. A provider's built-in base URL on the typed routes is operator code rather than attacker input, so it is left alone and the default Ollama setup (`localhost:11434`) keeps working with no configuration. The file-configured standalone gateway is unaffected, and the guardrail sanitization call, which targets this server's own gateway route, opts out explicitly with `ssrf_protect=False`.

Two env vars mirror the icon-URL policy: `MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES` (default `https`) and `MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS` (default `false`, disables both layers). Deployments using a private upstream through a DB-backed secret must set the latter.

`CreateGatewaySecret` stays open to authenticated users, matching the create-and-own pattern of `CreateExperiment` and `CreateRegisteredModel`; the fix is at the value and connection level rather than the permission model.

**Open question for reviewers.** Blocking private upstreams by default is the trade-off #23300 declined for `artifact_location`, and a duplicate advisory argues for an opt-in allowlist instead. Flipping the default is a one-line change plus docs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `tests/utils/test_validation.py` and `tests/server/test_handlers.py` (write-time validation, reserved keys, blank-value handling), `tests/gateway/test_ssrf.py` (guarded resolver, literals, end to end against a local aiohttp upstream including a DNS-rebinding simulation and redirects), `tests/gateway/providers/test_litellm.py` (private and public `api_base`, the `base_url` alias, stored `model_list`, and destination keys in request payloads for chat, embeddings and passthrough), and `tests/server/test_gateway_api.py` (arming on a user-supplied `api_base` or stored alias, not on provider defaults, always on the raw proxy). Existing provider tests were updated for `allow_redirects=False`.

Manually verified that a secret created with the opt-out and pointed at a local upstream is refused at connect time with HTTP 502 once the server restarts without it; that with no env vars set a typed request to an Ollama endpoint reaches `localhost:11434` while the raw proxy to the same endpoint is refused; and, with real litellm and a local upstream, that `api_base` or `base_url` in the inference payload of a key-only LiteLLM endpoint returns HTTP 400 without the upstream being contacted.

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The AI Gateway now blocks a secret's custom `api_base` from pointing at private, loopback and link-local addresses to prevent SSRF, validating the value on write and again at connect time with redirects disabled. The raw proxy route applies the same check to every upstream. Deployments whose custom base URL is private (in-cluster vLLM, Private Link endpoints, and similar) must set `MLFLOW_GATEWAY_API_BASE_ALLOW_PRIVATE_IPS=true`, plus `MLFLOW_GATEWAY_API_BASE_ALLOWED_SCHEMES=http,https` if it is plaintext. Providers' built-in base URLs, such as Ollama's `localhost:11434`, are unaffected on the chat, embeddings and passthrough routes. For providers routed through LiteLLM, `base_url`, `model_list`, `fallbacks` and `custom_llm_provider` are no longer accepted in a secret's configuration (use `api_base`), and inference requests can no longer override the upstream destination.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

This pull request and its description were written by Isaac.


