### PR TITLE
Support wrapped MCP registry server definitions

### DIFF
--- a/mlflow/server/js/src/mcp-registry/hooks/useCreateMCPServerVersionModal.tsx
+++ b/mlflow/server/js/src/mcp-registry/hooks/useCreateMCPServerVersionModal.tsx
@@ -25,7 +25,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import type { ConnectOptionsMap, MCPIcon, MCPServer, MCPServerVersion } from '../types';
 import { MCPStatus } from '../types';
 import { useCreateMCPServerVersionMutation } from './useCreateMCPServerVersionMutation';
-import { deriveConnectOptionKeys, validateServerJson } from '../utils';
+import { deriveConnectOptionKeys, unwrapServerJson, validateServerJson } from '../utils';
 import { LazyJsonRecordEditor } from '../../experiment-tracking/pages/experiment-evaluation-datasets-v2/components/LazyJsonRecordEditor';
 import { KeyValueTag } from '../../common/components/KeyValueTag';
 import type { KeyValueEntity } from '../../common/types';
@@ -122,8 +122,8 @@ export const useCreateMCPServerVersionModal = ({
 
   const serverJsonIcons = useMemo(() => {
     try {
-      const parsed = JSON.parse(formState.serverJsonText);
-      return Array.isArray(parsed?.icons) ? (parsed.icons as MCPIcon[]) : undefined;
+      const parsed = unwrapServerJson(JSON.parse(formState.serverJsonText));
+      return Array.isArray(parsed?.['icons']) ? (parsed['icons'] as MCPIcon[]) : undefined;
     } catch {
       return undefined;
     }

--- a/mlflow/server/js/src/mcp-registry/utils.test.ts
+++ b/mlflow/server/js/src/mcp-registry/utils.test.ts
@@ -16,6 +16,7 @@ import {
   buildRemoteConnectOptionKey,
   isServerDimmed,
   getServerPermissions,
+  unwrapServerJson,
 } from './utils';
 import { MCPStatus, TransportType } from './types';
 import { createMockMCPServer, createMockAccessEndpoint } from './test-utils';
@@ -152,12 +153,41 @@ describe('validateServerJson', () => {
     expect(result.parsed).toEqual({ name: 'io.github.test/server', version: '1.0.0' });
   });
 
+  it('unwraps a registry response and excludes registry metadata', () => {
+    const result = validateServerJson(`{
+      "server": {"name": "io.github.test/server", "version": "1.0.0", "title": "Test Server"},
+      "_meta": {"io.modelcontextprotocol.registry/official": {"status": "active"}}
+    }`);
+
+    expect(result.valid).toBe(true);
+    expect(result.parsed).toEqual({
+      name: 'io.github.test/server',
+      version: '1.0.0',
+      title: 'Test Server',
+    });
+  });
+
   it('preserves extra fields in parsed output', () => {
     const input = '{"name": "test", "version": "1.0.0", "title": "My Server", "packages": []}';
     const result = validateServerJson(input);
     expect(result.valid).toBe(true);
     expect(result.parsed?.title).toBe('My Server');
     expect(result.parsed?.packages).toEqual([]);
+  });
+});
+
+describe('unwrapServerJson', () => {
+  it('prefers a wrapped server definition when the outer object is incomplete', () => {
+    expect(
+      unwrapServerJson({
+        name: 'registry-response-name',
+        server: { name: 'io.github.test/server', version: '1.0.0' },
+      }),
+    ).toEqual({ name: 'io.github.test/server', version: '1.0.0' });
+  });
+
+  it('rejects an incomplete configuration with a non-object server property', () => {
+    expect(unwrapServerJson({ server: 'not-a-server-definition' })).toBeUndefined();
   });
 });
 

--- a/mlflow/server/js/src/mcp-registry/utils.ts
+++ b/mlflow/server/js/src/mcp-registry/utils.ts
@@ -131,6 +131,27 @@ interface ServerJsonValidationResult {
   parsed?: ServerJSONPayload;
 }
 
+const isJsonObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Registry API responses wrap server.json in a `server` property together with
+ * registry metadata. Prefer a direct server.json when both formats are present.
+ */
+export const unwrapServerJson = (value: unknown): Record<string, unknown> | undefined => {
+  if (!isJsonObject(value)) return undefined;
+
+  if ('name' in value && 'version' in value) {
+    return value;
+  }
+
+  if ('server' in value) {
+    return isJsonObject(value['server']) ? value['server'] : undefined;
+  }
+
+  return value;
+};
+
 export const validateServerJson = (value: string): ServerJsonValidationResult => {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -144,11 +165,10 @@ export const validateServerJson = (value: string): ServerJsonValidationResult =>
     return { valid: false, error: 'Invalid JSON format in server configuration' };
   }
 
-  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+  const obj = unwrapServerJson(parsed);
+  if (!obj) {
     return { valid: false, error: 'Server configuration must be a JSON object' };
   }
-
-  const obj = parsed as Record<string, unknown>;
 
   if (!obj['name'] || typeof obj['name'] !== 'string') {
     return { valid: false, error: 'Server configuration must include a "name" field' };


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Allow the MCP Registry UI to accept registry responses that wrap `server.json`
in a `server` property alongside `_meta` metadata. The UI normalizes the
payload before validation, icon extraction, and submission.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Ran:

- `yarn test mcp-registry/utils.test.ts --runInBand`
- `yarn test mcp-registry/hooks/useCreateMCPServerVersionModal.test.tsx --runInBand`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MCP Registry users can now paste wrapped server definitions directly from the
Model Context Protocol Registry.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release