### PR TITLE
Fix empty `Models` column for runs beyond the first `SearchLoggedModels` page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useLoggedModelsForExperimentRunsTable.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useLoggedModelsForExperimentRunsTable.test.tsx
@@ -48,6 +48,40 @@ describe('useLoggedModelsForExperimentRunsTable', () => {
     );
   });
 
+  test('should fetch all pages so runs beyond the first page still get their models', async () => {
+    // SearchLoggedModels returns a bounded page (50 by default), so a run's models can sit on any
+    // page. Serve two pages and assert the hook drains both instead of stopping at the first.
+    const requestedPageTokens: (string | undefined)[] = [];
+    server.use(
+      rest.post('/ajax-api/2.0/mlflow/logged-models/search', (req, res, ctx) => {
+        const pageToken = (req.body as { page_token?: string } | undefined)?.page_token;
+        requestedPageTokens.push(pageToken);
+        if (!pageToken) {
+          return res(
+            ctx.json({
+              models: [{ info: { source_run_id: 'run-on-page-1', model_id: 'model-id-1' } }],
+              next_page_token: 'page-2-token',
+            }),
+          );
+        }
+        return res(ctx.json({ models: [{ info: { source_run_id: 'run-on-page-2', model_id: 'model-id-2' } }] }));
+      }),
+    );
+
+    const { result } = renderHook(() => useLoggedModelsForExperimentRunsTable({ experimentIds: ['test-experiment'] }), {
+      wrapper: ({ children }) => <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>,
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        'run-on-page-1': [{ info: expect.objectContaining({ model_id: 'model-id-1' }) }],
+        'run-on-page-2': [{ info: expect.objectContaining({ model_id: 'model-id-2' }) }],
+      });
+    });
+
+    expect(requestedPageTokens).toEqual([undefined, 'page-2-token']);
+  });
+
   test('should return logged models for experiment runs', async () => {
     const { result } = renderHook(() => useLoggedModelsForExperimentRunsTable({ experimentIds: ['test-experiment'] }), {
       wrapper: ({ children }) => <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useLoggedModelsForExperimentRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useLoggedModelsForExperimentRunsTable.tsx
@@ -1,6 +1,13 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSearchLoggedModelsQuery } from '../../../hooks/logged-models/useSearchLoggedModelsQuery';
 import type { LoggedModelProto } from '../../../types';
+
+/**
+ * Upper bound on the number of pages fetched automatically. `SearchLoggedModels` defaults to 50
+ * models per page, so this covers experiments with up to ~1000 logged models while keeping the
+ * number of requests bounded for very large experiments.
+ */
+const MAX_AUTO_FETCHED_PAGES = 20;
 
 export const useLoggedModelsForExperimentRunsTable = ({
   experimentIds,
@@ -9,12 +16,30 @@ export const useLoggedModelsForExperimentRunsTable = ({
   experimentIds: string[];
   enabled?: boolean;
 }) => {
-  const { data: loggedModelsData } = useSearchLoggedModelsQuery(
+  const {
+    data: loggedModelsData,
+    nextPageToken,
+    pageCount,
+    isFetching,
+    loadMoreResults,
+  } = useSearchLoggedModelsQuery(
     { experimentIds },
     {
       enabled,
     },
   );
+
+  // This hook feeds the "Models" column for every run in the table, so a single page of results
+  // is not enough: the models belonging to a run can sit on any page. Keep draining pages until
+  // the backend stops returning a page token, otherwise runs whose models fall outside the first
+  // page render an empty cell.
+  const shouldFetchNextPage = enabled && Boolean(nextPageToken) && !isFetching && pageCount < MAX_AUTO_FETCHED_PAGES;
+
+  useEffect(() => {
+    if (shouldFetchNextPage) {
+      loadMoreResults();
+    }
+  }, [shouldFetchNextPage, loadMoreResults]);
 
   const loggedModelsByRunId = useMemo(
     () =>

--- a/mlflow/server/js/src/experiment-tracking/hooks/logged-models/useSearchLoggedModelsQuery.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/logged-models/useSearchLoggedModelsQuery.tsx
@@ -87,6 +87,7 @@ export const useSearchLoggedModelsQuery = (
     isFetching,
     data: modelsData,
     nextPageToken,
+    pageCount: data?.pages.length ?? 0,
     refetch,
     error,
     loadMoreResults: fetchNextPage,


### PR DESCRIPTION
### Related Issues/PRs

Closes #25766

Filed that issue alongside this PR. I'm aware of the triage policy in the UI bug template — happy to hold this until a maintainer applies the `ready` label, or to close it if you'd rather take a different approach.

### What changes are proposed in this pull request?

The experiment runs table renders an empty `Models` cell for most runs once an experiment has more than a page worth of logged models.

`useLoggedModelsForExperimentRunsTable` populates that column, and it reads only the first page of `useSearchLoggedModelsQuery`:

```ts
const { data: loggedModelsData } = useSearchLoggedModelsQuery({ experimentIds }, { enabled });
```

`useSearchLoggedModelsQuery` is a `useInfiniteQuery` that already exposes `loadMoreResults` and `nextPageToken`, but this caller ignores both, so exactly one request is ever issued. Since `SearchLoggedModels.max_results` has a protobuf default of `50`, and the server handler passes `request_message.max_results or None` (an omitted field arrives as `50`, which is truthy, so the store's own default is never reached), that single page holds at most 50 models.

The result is that only the 50 most recently created logged models in an experiment are available to the table. Every run whose models fall outside that page renders an empty cell, so the column silently under-reports. The cutoff row is roughly `50 / (models per run)` — with one model per run the `Models` column goes blank from row 51 onward.

This affects all OSS users: `shouldUseGetLoggedModelsBatchAPI()` returns `false`, so the V1 hook is the only code path, and `useLoggedModelsForExperimentRunsTableV2` (which scopes the fetch to the models referenced by the displayed runs) is never used.

This PR makes the hook keep fetching until the backend stops returning a page token, so a run's models are found no matter which page they land on. The number of automatic requests is bounded by `MAX_AUTO_FETCHED_PAGES` (20, i.e. ~1000 models at the default page size) so a very large experiment cannot trigger unlimited requests. `useSearchLoggedModelsQuery` also now returns `pageCount`, which lets that bound be derived from query state and reset naturally when the query changes, instead of being tracked in a ref.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New test `should fetch all pages so runs beyond the first page still get their models` serves two pages and asserts both the merged result and the exact page tokens requested (`[undefined, 'page-2-token']`). It fails on `master` (the page-2 run is absent from the result) and passes with this change.

Manual test with the dev server (`uv run dev/run_dev_server.py`), against an experiment seeded with 120 runs logging one model each (120 models, past the 50-per-page default). `logged-models/search` with no `max_results` returns 50 models plus a `next_page_token`, confirming the page boundary.

| | Requests to `logged-models/search` | Rows showing a model |
| --- | --- | --- |
| Before (v3.16.0 build) | 1 | rows 1–50 only; rows 51+ render `-` |
| After (this branch) | 3 (120 models / 50 per page) | all rows; 0 blank |

The screenshots below are the same server, same data and same view (sorted by start time ascending, so the oldest runs — whose models are on the last page — come first). The only difference is this commit.

**Before** — the `Models` column is empty for every visible row (only 29 of the 99 rendered rows have a model, all of them at the bottom):

![Models column before the fix](https://raw.githubusercontent.com/hyukkyukang/mlflow-fork/pr-assets/models_before.png)

**After** — every row shows its model (99 of 99):

![Models column after the fix](https://raw.githubusercontent.com/hyukkyukang/mlflow-fork/pr-assets/models_after.png)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed the `Models` column in the experiment runs table showing no models for runs whose logged models fell outside the first page of `SearchLoggedModels` results.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - The PR will be mentioned in the "Bug Fixes" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
