### PR TITLE
Fix `ScorerVersion` experiment ID type after REST hydration

### DIFF
--- a/mlflow/entities/scorer.py
+++ b/mlflow/entities/scorer.py
@@ -163,7 +163,7 @@ class ScorerVersion(_MlflowObject):
         """
         return cls(
             # The proto stores experiment IDs as integers while the entity contract is str
-            experiment_id=proto.experiment_id,  # type: ignore[arg-type]
+            experiment_id=str(proto.experiment_id),
             scorer_name=proto.scorer_name,
             scorer_version=proto.scorer_version,
             serialized_scorer=proto.serialized_scorer,

--- a/tests/entities/test_scorer.py
+++ b/tests/entities/test_scorer.py
@@ -1,0 +1,16 @@
+from mlflow.entities.scorer import ScorerVersion
+from mlflow.protos.service_pb2 import Scorer as ProtoScorer
+
+
+def test_from_proto_converts_experiment_id_to_string():
+    scorer_version = ScorerVersion.from_proto(
+        ProtoScorer(
+            experiment_id=123,
+            scorer_name="accuracy_scorer",
+            scorer_version=1,
+            serialized_scorer="serialized_scorer",
+            creation_time=1640995200000,
+        )
+    )
+
+    assert scorer_version.experiment_id == "123"


### PR DESCRIPTION
### Related Issues/PRs

Relates to #25282

### What changes are proposed in this pull request?

`ScorerVersion` declares `experiment_id` as a string, but `from_proto` was assigning the
protobuf `int32` field directly. Scorers retrieved through the REST tracking store therefore
carried an integer experiment ID. When `start()` or `stop()` used that implicit ID to update
online scoring configuration, the server rejected the request because the API requires a
string experiment ID.

This change converts the experiment ID to a string at the protobuf-to-entity boundary. The
protobuf wire format is unchanged, and the conversion is covered by a regression test using
a real `ProtoScorer` message. This is distinct from #25282 and #25315, which address SQL Store
query parameter binding rather than REST hydration.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

The following checks were run:

- `pytest -q tests/entities tests/store/tracking/test_rest_store.py` (818 passed, 1 skipped)
- `pytest -q tests/genai/scorers/test_scorer_CRUD.py tests/genai/scorers/test_registered_scorers_scheduling.py` (60 passed)
- `ruff check mlflow/entities/scorer.py tests/entities/test_scorer.py`
- `ruff format --check mlflow/entities/scorer.py tests/entities/test_scorer.py`
- `git diff --check`

Manual end-to-end test with a real `mlflow server`, SQLite backend, and `MlflowClient`:

- On the unmodified base, retrieving a scorer produced an integer `experiment_id`, and an
  implicit `start()` request was rejected with HTTP 400.
- On this branch, retrieving the scorer produced `experiment_id='1'` with type `str`, and an
  implicit `stop()` request completed with HTTP 200.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Remote scorers can now update online scoring configuration without failing because their
experiment ID was returned from REST hydration as an integer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g. 1.2.0 -> 1.2.1).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g. 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
