### PR TITLE
Fix duplicated 'or' in pyspark autolog skip warning message

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -137,7 +137,7 @@ _log_model_allowlist = None
 
 def _get_warning_msg_for_skip_log_model(model):
     return (
-        f"Model {model.uid} will not be autologged because it is not allowlisted or or because "
+        f"Model {model.uid} will not be autologged because it is not allowlisted or because "
         "one or more of its nested models are not allowlisted. Call mlflow.spark.log_model() "
         "to explicitly log the model, or specify a custom allowlist via the "
         "spark.mlflow.pysparkml.autolog.logModelAllowlistFile Spark conf "


### PR DESCRIPTION
## Summary

Fixes a duplicated word ("or or") in the user-facing warning message emitted by `mlflow.pyspark.ml` autologging when a Spark model is skipped because it (or one of its nested models) is not in the allowlist.

## Change

- `mlflow/pyspark/ml/__init__.py`: `_get_warning_msg_for_skip_log_model()` now reads "...because it is not allowlisted or because one or more of its nested models are not allowlisted..." instead of "...not allowlisted **or or** because...".
- Single-line change, documentation/message-only — no behavior change.

## How I found it

Scanning the repo for duplicated words; this one is in a string shown to end users at runtime (it surfaces via `mlflow.spark.autolog()` warnings whenever a non-allowlisted model is encountered), so it's a real (if small) UX defect rather than a comment typo.

## Verification performed

- [x] `git diff --check` — clean
- [x] `python3 -m py_compile mlflow/pyspark/ml/__init__.py` — compiles
- [x] Confirmed no other occurrence of the duplicated phrase in the file
- [x] Diff is 1 line (1 insertion / 1 deletion)