### PR TITLE
Fix S3 multipart upload encryption arguments

### DIFF
--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -165,6 +165,18 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         else:
             return None
 
+    def _get_multipart_upload_encryption_args(self):
+        extra_args = dict(self._s3_upload_extra_args)
+        if environ_extra_args := self.get_s3_file_upload_extra_args():
+            extra_args.update(environ_extra_args)
+        encryption_arg_names = {
+            "BucketKeyEnabled",
+            "ServerSideEncryption",
+            "SSEKMSKeyId",
+            "SSEKMSEncryptionContext",
+        }
+        return {key: value for key, value in extra_args.items() if key in encryption_arg_names}
+
     def _upload_file(self, s3_client, local_file, bucket, key):
         extra_args = {}
         extra_args.update(self._s3_upload_extra_args)
@@ -219,7 +231,10 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         # Create multipart upload
         s3_client = cloud_credential_info
         response = s3_client.create_multipart_upload(
-            Bucket=bucket, Key=key, **self._bucket_owner_params
+            Bucket=bucket,
+            Key=key,
+            **self._bucket_owner_params,
+            **self._get_multipart_upload_encryption_args(),
         )
         upload_id = response["UploadId"]
 

--- a/tests/store/artifact/test_optimized_s3_artifact_repo.py
+++ b/tests/store/artifact/test_optimized_s3_artifact_repo.py
@@ -245,6 +245,79 @@ def test_log_artifacts_in_parallel_when_necessary(
 
 
 @pytest.mark.parametrize(
+    ("repository_extra_args", "environment_extra_args", "expected_extra_args"),
+    [
+        (
+            {"ServerSideEncryption": "AES256"},
+            None,
+            {"ServerSideEncryption": "AES256"},
+        ),
+        (
+            {"ServerSideEncryption": "AES256"},
+            (
+                '{"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "key-id", '
+                '"SSEKMSEncryptionContext": "context", "BucketKeyEnabled": true}'
+            ),
+            {
+                "ServerSideEncryption": "aws:kms",
+                "SSEKMSKeyId": "key-id",
+                "SSEKMSEncryptionContext": "context",
+                "BucketKeyEnabled": True,
+            },
+        ),
+    ],
+)
+def test_multipart_upload_passes_s3_upload_encryption_args(
+    s3_artifact_root,
+    tmp_path,
+    monkeypatch,
+    repository_extra_args,
+    environment_extra_args,
+    expected_extra_args,
+):
+    if environment_extra_args:
+        monkeypatch.setenv("MLFLOW_S3_UPLOAD_EXTRA_ARGS", environment_extra_args)
+    s3_client = mock.Mock()
+    s3_client.create_multipart_upload.return_value = {"UploadId": "upload-id"}
+    local_file = tmp_path / "artifact"
+    local_file.touch()
+    repo = OptimizedS3ArtifactRepository(
+        posixpath.join(s3_artifact_root, "path"),
+        s3_upload_extra_args=repository_extra_args,
+    )
+
+    repo._multipart_upload(s3_client, local_file, "bucket", "path/artifact")
+
+    s3_client.create_multipart_upload.assert_called_once_with(
+        Bucket="bucket",
+        Key="path/artifact",
+        **expected_extra_args,
+    )
+
+
+def test_multipart_upload_does_not_pass_non_encryption_upload_args(
+    s3_artifact_root, tmp_path, monkeypatch
+):
+    monkeypatch.setenv(
+        "MLFLOW_S3_UPLOAD_EXTRA_ARGS",
+        '{"ServerSideEncryption": "AES256", "ACL": "bucket-owner-full-control"}',
+    )
+    s3_client = mock.Mock()
+    s3_client.create_multipart_upload.return_value = {"UploadId": "upload-id"}
+    local_file = tmp_path / "artifact"
+    local_file.touch()
+    repo = OptimizedS3ArtifactRepository(posixpath.join(s3_artifact_root, "path"))
+
+    repo._multipart_upload(s3_client, local_file, "bucket", "path/artifact")
+
+    s3_client.create_multipart_upload.assert_called_once_with(
+        Bucket="bucket",
+        Key="path/artifact",
+        ServerSideEncryption="AES256",
+    )
+
+
+@pytest.mark.parametrize(
     ("file_size", "is_parallel_download"),
     [(None, False), (100, False), (500 * 1024**2 - 1, False), (500 * 1024**2, True)],
 )


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Pass repository- and environment-provided server-managed encryption arguments to `CreateMultipartUpload` in `OptimizedS3ArtifactRepository`.

The regular upload path already passes these arguments to boto3's `upload_file`, but the explicit multipart path omitted them. As a result, S3 buckets with policies requiring SSE-S3 or SSE-KMS reject multipart initialization even when repository credentials provide encryption details or `MLFLOW_S3_UPLOAD_EXTRA_ARGS` is configured.

The implementation deliberately filters out generic transfer options and SSE-C fields because those are not universally valid on `CreateMultipartUpload` or require propagation to subsequent multipart operations.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added coverage for SSE-S3 and SSE-KMS arguments supplied through both the repository constructor and `MLFLOW_S3_UPLOAD_EXTRA_ARGS`, plus coverage that unrelated upload options are not forwarded.

```text
20 passed in 10.92s
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fix S3 multipart artifact uploads to honor configured SSE-S3 and SSE-KMS encryption arguments.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: A release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: A release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [x] This PR is critical and needs to be in the next patch release
- [ ] This PR can wait for the next minor release
