### PR TITLE
Bound `_hard_delete_run` memory with bulk deletes

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1233,8 +1233,17 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
         This is used by the ``mlflow gc`` command line and is not intended to be used elsewhere.
         """
         with self.ManagedSessionMaker(read_only=False) as session:
-            run = self._get_run(run_uuid=run_id, session=session)
-            session.delete(run)
+            # ORM delete cascades load every child row into the session, which can exhaust memory
+            # for runs with large metric histories. Bulk deletes keep memory usage independent of
+            # history size.
+            self._get_run(run_uuid=run_id, session=session)
+            for model in (SqlMetric, SqlLatestMetric, SqlParam, SqlTag):
+                session.query(model).filter(model.run_uuid == run_id).delete(
+                    synchronize_session=False
+                )
+            session.query(SqlRun).filter(SqlRun.run_uuid == run_id).delete(
+                synchronize_session=False
+            )
 
     def _get_deleted_runs(self, older_than=0):
         """

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
@@ -376,6 +376,38 @@ def test_hard_delete_run(store: SqlAlchemyStore):
         assert actual_param is None
         actual_tag = session.query(models.SqlTag).filter_by(run_uuid=run.info.run_id).first()
         assert actual_tag is None
+        actual_latest_metric = (
+            session.query(models.SqlLatestMetric).filter_by(run_uuid=run.info.run_id).first()
+        )
+        assert actual_latest_metric is None
+
+
+def test_hard_delete_run_does_not_load_child_rows(store: SqlAlchemyStore):
+    run = _run_factory(store)
+    store.log_metric(
+        run.info.run_id,
+        entities.Metric("metric", 1.0, get_current_time_millis(), 0),
+    )
+    store.log_param(run.info.run_id, entities.Param("param", "value"))
+    store.set_tag(run.info.run_id, entities.RunTag("tag", "value"))
+
+    statements = []
+
+    def capture_statement(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement.lower())
+
+    sqlalchemy.event.listen(store.engine, "before_cursor_execute", capture_statement)
+    try:
+        store._hard_delete_run(run.info.run_id)
+    finally:
+        sqlalchemy.event.remove(store.engine, "before_cursor_execute", capture_statement)
+
+    child_tables = ("metrics", "latest_metrics", "params", "tags")
+    assert not any(
+        statement.lstrip().startswith("select") and f"from {table}" in statement
+        for statement in statements
+        for table in child_tables
+    )
 
 
 def test_get_deleted_runs(store: SqlAlchemyStore):


### PR DESCRIPTION
### Related Issues/PRs

Closes #25615

### What changes are proposed in this pull request?

Replace ORM cascade deletion in `SqlAlchemyStore._hard_delete_run()` with explicit bulk deletes for `SqlMetric`, `SqlLatestMetric`, `SqlParam`, and `SqlTag`, followed by a bulk delete of `SqlRun`.

`session.delete(run)` loads every related child row into SQLAlchemy's identity map before deletion. Runs with large metric histories can therefore consume tens of GiB of memory during `mlflow gc`. Set-based deletes preserve transactional deletion behavior without materializing child ORM objects.

The change uses `synchronize_session=False`, as recommended in #25615, because no loaded child objects need synchronization during this maintenance operation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added a regression test that captures generated SQL and verifies hard deletion does not select from child tables. Extended existing coverage to verify deletion from `latest_metrics`.

Validation performed:

- `tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py`: 268 passed, 8 skipped
- Relevant `tests/test_cli.py` GC tests: 6 passed, 1 skipped
- Ruff lint and formatting checks passed

Manual SQLite benchmark using directly inserted metric rows:

| Metric rows | Existing ORM cascade | Bulk delete |
| ---: | ---: | ---: |
| 300,000 | 1.12 GiB peak RSS, 9.66s | 254 MiB peak RSS, 0.47s |
| 1,000,000 | 3.09 GiB peak RSS, 33.58s | 270 MiB peak RSS, 1.69s |

All child rows and the run row were removed successfully.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow gc` now uses bounded application memory when hard-deleting runs with large metric histories.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

---

*This code was generated using GPT-5.6-sol in Pi Coding Agent.*
