### PR TITLE
feat: add topology spread constraints

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -185,3 +185,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints}}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -329,3 +329,5 @@ nodeSelector: {}
 tolerations: []
 # Affinity rules for pod scheduling.
 affinity: {}
+# Topology spread constraints for pod scheduling.
+topologySpreadConstraints: {}


### PR DESCRIPTION
<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #25774

### What changes are proposed in this pull request?

This PR adds optional support for [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) to the official Helm chart. This can be used to increase MLFlow resilience in case of outages by influencing how the Kubernetes scheduler spreads out pods across e.g. availability zones.

Without an explicit topology spread constraint, increasing the number of replicas does not guarantee resilience against an availability zone outage, since multiple replicas could be scheduled onto nodes in the same AZ. With topology spread constraints, users can configure the deployment to distribute replicas across multiple AZ, reducing the risk that an outage in a zone affects all replicas.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Created a test cluster:

```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4

nodes:
  - role: control-plane
  - role: worker
  - role: worker
  - role: worker
```

Labelled the workers (these are commonly provided by the cloud provider):

```sh
kubectl label node topology-test-worker topology.kubernetes.io/zone=zone-a
kubectl label node topology-test-worker2 topology.kubernetes.io/zone=zone-b
kubectl label node topology-test-worker3 topology.kubernetes.io/zone=zone-c
```

Set up a test database (required for MLFlow with multiple replicas):

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: pg
  name: pg
spec:
  replicas: 1
  selector:
    matchLabels:
      app: pg
  template:
    metadata:
      labels:
        app: pg
    spec:
      containers:
        - image: postgres:18-trixie
          name: postgres
          env:
            - name: POSTGRES_PASSWORD
              value: mlflow
          ports:
            - containerPort: 5432
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: pg
  name: pg
spec:
  ports:
  - port: 5432
    protocol: TCP
    targetPort: 5432
  selector:
    app: pg
```

Add the following changes to the `values.yaml` file in the MLFlow helm chart: 

```yaml
mlflow:
  backendStoreUri: "postgresql://postgres:mlflow@pg.default.svc.cluster.local/postgres"

replicaCount: 6

# Labels added to the MLflow pod.
podLabels:
  name: mlflow

# Topology spread constraints for pod scheduling.
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: DoNotSchedule
    minDomains: 3
    labelSelector:
      matchLabels:
        name: mlflow
```

Result:

```sh
NAME                             STATUS    NODE
mlflow-mlflow-59b6cf78f8-45www   Running   topology-test-worker3
mlflow-mlflow-59b6cf78f8-gp9h9   Running   topology-test-worker2
mlflow-mlflow-59b6cf78f8-q5sdb   Running   topology-test-worker
mlflow-mlflow-59b6cf78f8-qpl6k   Running   topology-test-worker3
mlflow-mlflow-59b6cf78f8-xkf4d   Running   topology-test-worker2
mlflow-mlflow-59b6cf78f8-xtv5j   Running   topology-test-worker
pg-6cc85d59cf-pjx9h              Running   topology-test-worker3
```

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Added TopologySpreadConstraints to the official helm chart, allowing replicas to be spread across failure domains such as availability zones or nodes.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
