### PR TITLE
Fix custom trace views in the session trace drawer

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { renderWithIntl, waitFor } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { describe, expect, jest, test, beforeEach } from '@jest/globals';
+import { shouldEnableModelTraceExplorerCustomTraceView } from '@databricks/web-shared/model-trace-explorer';
+import { CustomViewDefinitionProvider } from '@databricks/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext';
+
+import ExperimentSingleChatSessionPage from './ExperimentSingleChatSessionPage';
+
+const mockExperimentCustomViewProvider = jest.fn(
+  ({ children, experimentId }: { children: React.ReactNode; experimentId?: string }) => (
+    <div data-testid="custom-view-provider" data-experiment-id={experimentId}>
+      {children}
+    </div>
+  ),
+);
+
+jest.mock('@databricks/web-shared/genai-traces-table', () => ({
+  CUSTOM_METADATA_COLUMN_ID: 'metadata',
+  FilterOperator: {
+    CONTAINS: 'CONTAINS',
+    EQUALS: 'EQUALS',
+  },
+  createTraceLocationForExperiment: jest.fn((experimentId: string) => ({ experimentId })),
+  createTraceLocationForDestinationPath: jest.fn(),
+  doesTraceSupportV4API: jest.fn(() => false),
+  useGetTraces: jest.fn(() => ({
+    data: [],
+    isLoading: false,
+    invalidateSingleTraceQuery: jest.fn(),
+  })),
+  useSearchMlflowTraces: jest.fn(() => ({
+    data: [],
+    isLoading: false,
+  })),
+}));
+
+jest.mock('@databricks/web-shared/model-trace-explorer', () => ({
+  getModelTraceId: jest.fn(
+    (trace: { info?: { trace_id?: string }; trace_id?: string }) => trace?.info?.trace_id ?? trace?.trace_id,
+  ),
+  isEvaluatingTracesInDetailsViewEnabled: jest.fn(() => false),
+  isV3ModelTraceInfo: jest.fn(() => true),
+  ModelTraceExplorer: jest.fn(() => null),
+  ModelTraceExplorerContextProvider: ({ children }: { children: React.ReactNode }) => children,
+  ModelTraceExplorerDrawer: ({ children }: { children: React.ReactNode }) => children,
+  ModelTraceExplorerRunJudgesContextProvider: ({ children }: { children: React.ReactNode }) => children,
+  ModelTraceExplorerUpdateTraceContextProvider: ({ children }: { children: React.ReactNode }) => children,
+  ModelTraceExplorerPreferencesProvider: ({ children }: { children: React.ReactNode }) => children,
+  shouldEnableAssessmentsInSessions: jest.fn(() => false),
+  shouldEnableModelTraceExplorerCustomTraceView: jest.fn(),
+  shouldUseTracesV4API: jest.fn(() => false),
+}));
+
+jest.mock('../../../hooks/useExperimentQuery', () => ({
+  useGetExperimentQuery: jest.fn(() => ({ loading: false })),
+}));
+
+jest.mock('@mlflow/mlflow/src/common/utils/RoutingUtils', () => ({
+  useLocation: () => ({ search: '' }),
+  useParams: () => ({ experimentId: 'experiment-123', sessionId: 'session-456' }),
+}));
+
+jest.mock('@mlflow/mlflow/src/assistant', () => ({
+  useRegisterAssistantContext: jest.fn(),
+}));
+
+jest.mock('../../../components/experiment-page/components/traces-v3/TracesV3Toolbar', () => ({
+  TracesV3Toolbar: () => <div data-testid="traces-toolbar" />,
+}));
+
+jest.mock('./ExperimentSingleChatSessionSidebar', () => ({
+  ExperimentSingleChatSessionSidebar: () => <div data-testid="chat-sidebar" />,
+  ExperimentSingleChatSessionSidebarSkeleton: () => <div data-testid="chat-sidebar-skeleton" />,
+}));
+
+jest.mock('./ExperimentSingleChatConversation', () => ({
+  ExperimentSingleChatConversation: () => <div data-testid="chat-conversation" />,
+  ExperimentSingleChatConversationSkeleton: () => <div data-testid="chat-conversation-skeleton" />,
+}));
+
+jest.mock('./ExperimentSingleChatSessionMetrics', () => ({
+  ExperimentSingleChatSessionMetrics: () => null,
+}));
+
+jest.mock('./ExperimentSingleChatSessionScoreResults', () => ({
+  ExperimentSingleChatSessionScoreResults: () => null,
+}));
+
+jest.mock('../../experiment-evaluation-datasets/components/ExportTracesToDatasetModal', () => ({
+  ExportTracesToDatasetModal: () => null,
+}));
+
+jest.mock('../../experiment-scorers/hooks/useRunScorerInTracesViewConfiguration', () => ({
+  useRunScorerInTracesViewConfiguration: jest.fn(() => ({})),
+}));
+
+jest.mock('./useExperimentSingleChatMetrics', () => ({
+  useExperimentSingleChatMetrics: jest.fn(() => ({})),
+}));
+
+jest.mock('@mlflow/mlflow/src/experiment-tracking/utils/TraceUtils', () => ({
+  getTrace: jest.fn(),
+}));
+
+jest.mock('../../../components/experiment-page/components/traces-v3/ExperimentCustomViewProvider', () => ({
+  ExperimentCustomViewProvider: (props: { children: React.ReactNode; experimentId?: string }) =>
+    mockExperimentCustomViewProvider(props),
+}));
+
+const renderPage = (withCustomViewProvider = false) =>
+  renderWithIntl(
+    <DesignSystemProvider>
+      {withCustomViewProvider ? (
+        <CustomViewDefinitionProvider views={[]} isLoaded>
+          <ExperimentSingleChatSessionPage />
+        </CustomViewDefinitionProvider>
+      ) : (
+        <ExperimentSingleChatSessionPage />
+      )}
+    </DesignSystemProvider>,
+  );
+
+describe('ExperimentSingleChatSessionPage', () => {
+  beforeEach(() => {
+    mockExperimentCustomViewProvider.mockClear();
+  });
+
+  test('mounts ExperimentCustomViewProvider with the current experiment ID when custom trace view is enabled', async () => {
+    jest.mocked(shouldEnableModelTraceExplorerCustomTraceView).mockReturnValue(true);
+
+    const { getByTestId } = renderPage();
+
+    await waitFor(() => {
+      expect(mockExperimentCustomViewProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ experimentId: 'experiment-123' }),
+      );
+    });
+    expect(getByTestId('custom-view-provider')).toHaveAttribute('data-experiment-id', 'experiment-123');
+  });
+
+  test('omits ExperimentCustomViewProvider when custom trace view is disabled', async () => {
+    jest.mocked(shouldEnableModelTraceExplorerCustomTraceView).mockReturnValue(false);
+
+    const { queryByTestId } = renderPage();
+
+    await waitFor(() => {
+      expect(mockExperimentCustomViewProvider).not.toHaveBeenCalled();
+      expect(queryByTestId('custom-view-provider')).not.toBeInTheDocument();
+    });
+  });
+
+  test('reuses an outer custom view definition instead of mounting a nested provider', async () => {
+    jest.mocked(shouldEnableModelTraceExplorerCustomTraceView).mockReturnValue(true);
+
+    const { queryByTestId } = renderPage(true);
+
+    await waitFor(() => {
+      expect(mockExperimentCustomViewProvider).not.toHaveBeenCalled();
+      expect(queryByTestId('custom-view-provider')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -13,7 +13,7 @@ import {
 import { useParams, useLocation } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import invariant from 'invariant';
 import { useGetExperimentQuery } from '../../../hooks/useExperimentQuery';
-import { useCallback, useMemo, useRef, useState, useEffect } from 'react';
+import React, { useCallback, useMemo, useRef, useState, useEffect } from 'react';
 import { ExperimentSingleChatSessionScoreResults } from './ExperimentSingleChatSessionScoreResults';
 import { TracesV3Toolbar } from '../../../components/experiment-page/components/traces-v3/TracesV3Toolbar';
 import type { ModelTrace, ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
@@ -28,6 +28,7 @@ import {
   ModelTraceExplorerUpdateTraceContextProvider,
   ModelTraceExplorerPreferencesProvider,
   shouldEnableAssessmentsInSessions,
+  shouldEnableModelTraceExplorerCustomTraceView,
   shouldUseTracesV4API,
 } from '@databricks/web-shared/model-trace-explorer';
 import {
@@ -40,7 +41,7 @@ import {
   ExperimentSingleChatConversation,
   ExperimentSingleChatConversationSkeleton,
 } from './ExperimentSingleChatConversation';
-import { useDesignSystemTheme } from '@databricks/design-system';
+import { GenericSkeleton, useDesignSystemTheme } from '@databricks/design-system';
 import { SELECTED_TRACE_ID_QUERY_PARAM } from '../../../constants';
 import { useExperimentSingleChatMetrics } from './useExperimentSingleChatMetrics';
 import { ExperimentSingleChatSessionMetrics } from './ExperimentSingleChatSessionMetrics';
@@ -49,16 +50,38 @@ import { ExportTracesToDatasetModal } from '../../experiment-evaluation-datasets
 import { AssistantAwareDrawer } from '@mlflow/mlflow/src/common/components/AssistantAwareDrawer';
 import { first } from 'lodash';
 import { useRunScorerInTracesViewConfiguration } from '../../experiment-scorers/hooks/useRunScorerInTracesViewConfiguration';
+import { useOptionalCustomViewDefinition } from '@databricks/web-shared/model-trace-explorer/custom-view/CustomViewDefinitionContext';
+
+// Custom View pulls in @a2ui (ESM-only) transitively via ExperimentCustomViewProvider.
+// Lazy-load it so the chat-session route only pulls @a2ui into the graph when enabled.
+const LazyExperimentCustomViewProvider = React.lazy(() =>
+  import('../../../components/experiment-page/components/traces-v3/ExperimentCustomViewProvider').then((module) => ({
+    default: module.ExperimentCustomViewProvider,
+  })),
+);
 
 const ContextProviders = ({
   children,
+  experimentId,
   invalidateTraceQuery,
 }: {
   children: React.ReactNode;
+  experimentId: string;
   invalidateTraceQuery?: (traceId?: string) => void;
 }) => {
   const renderCustomExportTracesToDatasetsModal = ExportTracesToDatasetModal;
   const DrawerComponent = AssistantAwareDrawer;
+  const existingCustomViewDefinition = useOptionalCustomViewDefinition();
+  const content =
+    shouldEnableModelTraceExplorerCustomTraceView() && existingCustomViewDefinition === undefined ? (
+      <React.Suspense fallback={<GenericSkeleton css={{ flex: 1, margin: 16 }} />}>
+        <LazyExperimentCustomViewProvider key={experimentId} experimentId={experimentId}>
+          {children}
+        </LazyExperimentCustomViewProvider>
+      </React.Suspense>
+    ) : (
+      children
+    );
 
   return (
     <ModelTraceExplorerPreferencesProvider>
@@ -67,7 +90,7 @@ const ContextProviders = ({
         DrawerComponent={DrawerComponent}
       >
         <ModelTraceExplorerUpdateTraceContextProvider invalidateTraceQuery={invalidateTraceQuery}>
-          {children}
+          {content}
         </ModelTraceExplorerUpdateTraceContextProvider>
       </ModelTraceExplorerContextProvider>
     </ModelTraceExplorerPreferencesProvider>
@@ -145,6 +168,7 @@ const ExperimentSingleChatSessionPageImpl = () => {
   return (
     <ContextProviders
       // prettier-ignore
+      experimentId={experimentId}
       invalidateTraceQuery={invalidateSingleTraceQuery}
     >
       <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>


### PR DESCRIPTION
### Related Issues/PRs

Relates to the reported Sessions trace-drawer regression.

### What changes are proposed in this pull request?

Mount `ExperimentCustomViewProvider` around the standalone session trace drawer so saved and new custom trace views are available from Sessions → View full trace.

Verification note: standalone trace-drawer routes must mount the custom-view provider whenever custom views are enabled.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

- Focused Jest tests cover enabled and disabled provider paths.
- TypeScript, ESLint, Prettier, and i18n checks pass.
- Playwright verified Sessions → View full trace exposes the saved `Span review` view and `Create custom view`.

![Custom views available in the session trace drawer](https://github.com/user-attachments/assets/6df40586-b978-4775-a432-2484b512f0a2)

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Saved and new custom trace views are available again when opening a full trace from a session.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release

cc @aaronteo-db

