### PR TITLE
fix: preserve scalar integer expectation values through the proto boundary

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -672,8 +672,17 @@ class ExpectationValue(_MlflowObject):
             )
 
     def _need_serialization(self):
-        # Values like None, lists, dicts, should be serialized as a JSON string
-        return self.value is not None and not isinstance(self.value, (int, float, bool, str))
+        # google.protobuf.Value holds every number in a double-precision number_value, which
+        # cannot represent an int losslessly (values beyond 2**53 are corrupted and every int
+        # reads back as a float), so scalar ints are serialized as a JSON string too. bool is a
+        # subclass of int but is stored losslessly via bool_value, so it stays on the Value path.
+        if isinstance(self.value, bool):
+            return False
+        if isinstance(self.value, int):
+            return True
+        # Lists and dicts are serialized as a JSON string. None, float, and str stay on the
+        # Value path (None is stored as null_value).
+        return self.value is not None and not isinstance(self.value, (float, str))
 
 
 @dataclass

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -338,6 +338,56 @@ def test_expectation_value_serialization(value):
     assert result.value == expectation.value
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        42,
+        0,
+        -7,
+        # Integers beyond 2**53 cannot be represented by a double, so a lossy number_value
+        # path both retypes them to float and corrupts their value.
+        9007199254740993,
+        12345678901234567,
+    ],
+)
+def test_expectation_scalar_int_round_trip_preserves_int(value):
+    expectation = ExpectationValue(value)
+    proto = expectation.to_proto()
+    assert proto.HasField("serialized_value")
+
+    result = ExpectationValue.from_proto(proto)
+    assert result.value == value
+    assert isinstance(result.value, int)
+
+    result = ExpectationValue.from_dictionary(expectation.to_dictionary())
+    assert result.value == value
+    assert isinstance(result.value, int)
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_expectation_bool_round_trip_stays_bool(value):
+    expectation = ExpectationValue(value)
+    proto = expectation.to_proto()
+    assert not proto.HasField("serialized_value")
+
+    result = ExpectationValue.from_proto(proto)
+    assert result.value is value
+    assert isinstance(result.value, bool)
+
+    result = ExpectationValue.from_dictionary(expectation.to_dictionary())
+    assert result.value is value
+    assert isinstance(result.value, bool)
+
+
+def test_expectation_none_round_trip_stays_on_value_path():
+    expectation = ExpectationValue(None)
+    proto = expectation.to_proto()
+    assert not proto.HasField("serialized_value")
+
+    assert ExpectationValue.from_proto(proto).value is None
+    assert ExpectationValue.from_dictionary(expectation.to_dictionary()).value is None
+
+
 def test_expectation_invalid_values():
     class CustomObject:
         pass


### PR DESCRIPTION
### Related Issues/PRs

Closes #25708

### What changes are proposed in this pull request?

`ExpectationValue.to_proto()` packed scalar values into `google.protobuf.Value`, whose only numeric slot is a double-precision `number_value`. As a result, a scalar integer expectation logged through a tracking server was retyped to `float` when read back (`from_proto`), and integers beyond `2**53` were silently corrupted:

- `mlflow.log_expectation(..., value=42)` read back as `42.0`
- `9007199254740993` read back as `9007199254740992`

A direct database tracking URI returned the correct `int`, because the SQL store persists expectation values via `json.dumps` (`mlflow/store/tracking/dbmodels/models.py`) and never goes through `google.protobuf.Value`. Only the REST/proto boundary was lossy, so the two representations of the same expectation disagreed. Expectations are ground truth for GenAI evaluation, so an integer label silently changing type or value breaks exact-match comparison against a model output.

This change routes scalar integers through the existing `serialized_value` JSON field, the same lossless path that lists and dicts already use (introduced in #15594). `bool` stays on the `Value` path since `bool_value` is lossless, and `None`/`float`/`str` are unchanged. `from_proto`/`from_dictionary` already read `serialized_value`, so no proto or schema change is required.

Notes for reviewers:
- At-rest data was never corrupted (the SQL store stores JSON), so no migration is needed. Integers that were already transmitted over the wire as `number_value` by an old client cannot be recovered, which is inherent and independent of this change.
- Follow-up (out of scope, frontend): the trace UI helper `getAssessmentValue` (`mlflow/server/js/.../assessments-pane/utils.tsx`) returns `serialized_value.value` verbatim without `JSON.parse`, unlike the sibling parse path. This is a pre-existing inconsistency that already affects list/dict expectations; scalar ints are now newly affected. Display via `.toString()` is unaffected, but the edit form's inferred input type shifts from `number` to `json` for int expectations. Worth a separate frontend pass.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Manual tests

Added parametrized round-trip tests asserting scalar ints (including `0`, negatives, and values beyond `2**53`) preserve both value and `int` type through proto and dict conversion, that `bool` stays a `bool`, and that `None` stays on the `Value` path. Manually verified end to end against a local `mlflow server` (sqlite backend): `log_expectation` with `42`, `9007199254740993`, `3.14`, `True`, and `"x"` all read back with the original value and type.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Integer expectation values logged through a tracking server are now returned as integers instead of being retyped to float (and are no longer corrupted beyond 2**53).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release