### PR TITLE
Added mistral passthrough endpoint with prompt caching support

### DIFF
--- a/mlflow/gateway/config.py
+++ b/mlflow/gateway/config.py
@@ -98,6 +98,7 @@ class GatewayRequestType(str, Enum):
     PASSTHROUGH_MODEL_OPENAI_RESPONSES = "passthrough/model/openai-responses"
     PASSTHROUGH_MODEL_ANTHROPIC_MESSAGES = "passthrough/model/anthropic-messages"
     PASSTHROUGH_MODEL_GEMINI_GENERATE_CONTENT = "passthrough/model/gemini-generateContent"
+    PASSTHROUGH_MODEL_MISTRAL_CHAT = "passthrough/model/mistral-chat"
     RAW_PROXY = "proxy/raw"
 
 

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -29,6 +29,7 @@ class PassthroughAction(str, Enum):
     ANTHROPIC_MESSAGES = "anthropic_messages"
     GEMINI_GENERATE_CONTENT = "gemini_generate_content"
     GEMINI_STREAM_GENERATE_CONTENT = "gemini_stream_generate_content"
+    MISTRAL_CHAT = "mistral_chat"
 
 
 # Mapping of passthrough actions to their gateway API routes
@@ -40,6 +41,7 @@ PASSTHROUGH_ROUTES = {
     PassthroughAction.ANTHROPIC_MESSAGES: "/anthropic/v1/messages",
     PassthroughAction.GEMINI_GENERATE_CONTENT: "/gemini/v1beta/models/{endpoint_name}:generateContent",  # noqa: E501
     PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT: "/gemini/v1beta/models/{endpoint_name}:streamGenerateContent",  # noqa: E501
+    PassthroughAction.MISTRAL_CHAT: "/mistral/v1/chat/completions",
 }
 
 # User-agent prefixes for subscription-based CLI tools that carry their own credentials.

--- a/mlflow/gateway/providers/mistral.py
+++ b/mlflow/gateway/providers/mistral.py
@@ -15,10 +15,10 @@ from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat as chat_schema
 from mlflow.gateway.schemas import completions as completions_schema
 from mlflow.gateway.schemas import embeddings as embeddings_schema
-from mlflow.gateway.utils import handle_incomplete_chunks, strip_sse_prefix
+from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+from mlflow.gateway.utils import handle_incomplete_chunks, parse_sse_lines, strip_sse_prefix
 
-
-class MistralAdapter(ProviderAdapter):
+class MistralAdapter(ProviderAdapter, BaseProvider):
     @classmethod
     def model_to_completions(cls, resp, config):
         # Response example (https://docs.mistral.ai/api/#operation/createChatCompletion)
@@ -355,3 +355,33 @@ class MistralProvider(BaseProvider):
                 path=provider_path,
                 payload=payload,
             )
+
+    def _extract_passthrough_token_usage(
+        self, action: PassthroughAction, result: dict[str, Any]
+    ) -> dict[str, int] | None:
+        usage = result.get("usage")
+        if not usage:
+            return None
+        return self._extract_token_usage_from_dict(
+            usage,
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            cache_read_key="prompt_tokens_details.cached_tokens",
+        )
+
+    def _extract_streaming_token_usage(self, chunk: bytes) -> dict[str, int]:
+        for data in parse_sse_lines(chunk):
+            usage = data.get("usage")
+            if not usage:
+                continue
+            token_usage = self._extract_token_usage_from_dict(
+                usage,
+                "prompt_tokens",
+                "completion_tokens",
+                "total_tokens",
+                cache_read_key="prompt_tokens_details.cached_tokens",
+            )
+            if token_usage:
+                return token_usage
+        return {}

--- a/mlflow/gateway/providers/mistral.py
+++ b/mlflow/gateway/providers/mistral.py
@@ -4,7 +4,13 @@ from collections.abc import AsyncIterable
 from typing import Any
 
 from mlflow.gateway.config import EndpointConfig, MistralConfig
-from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
+from mlflow.gateway.providers.base import (
+    BaseProvider,
+    PassthroughAction,
+    ProviderAdapter,
+    _client_provides_auth,
+    _drop_client_auth_headers,
+)
 from mlflow.gateway.providers.utils import send_request, send_stream_request
 from mlflow.gateway.schemas import chat as chat_schema
 from mlflow.gateway.schemas import completions as completions_schema
@@ -201,6 +207,10 @@ class MistralProvider(BaseProvider):
     DISPLAY_NAME = "Mistral"
     CONFIG_TYPE = MistralConfig
 
+    PASSTHROUGH_PROVIDER_PATHS = {
+        PassthroughAction.MISTRAL_CHAT: "chat/completions",
+    }
+
     def __init__(self, config: EndpointConfig, enable_tracing: bool = False) -> None:
         super().__init__(config, enable_tracing=enable_tracing)
         if config.model.config is None or not isinstance(config.model.config, MistralConfig):
@@ -296,3 +306,52 @@ class MistralProvider(BaseProvider):
             MistralAdapter.embeddings_to_model(payload, self.config),
         )
         return MistralAdapter.model_to_embeddings(resp, self.config)
+
+
+    def _get_headers(
+        self,
+        payload: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        result_headers = self.headers.copy()
+
+        if headers:
+            client_headers = headers.copy()
+            client_headers.pop("host", None)
+            client_headers.pop("content-length", None)
+            if _client_provides_auth(headers):
+                result_headers.pop("authorization", None)
+            else:
+                client_headers = _drop_client_auth_headers(client_headers)
+            result_headers = client_headers | result_headers
+
+        return result_headers
+
+    async def _passthrough(
+        self,
+        action: PassthroughAction,
+        payload: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any] | AsyncIterable[Any]:
+        provider_path = self._validate_passthrough_action(action)
+
+        # Add model name from config
+        payload["model"] = self.config.model.name
+
+        request_headers = self._get_headers(payload, headers)
+
+        if payload.get("stream"):
+            stream = send_stream_request(
+                headers=request_headers,
+                base_url=self.base_url,
+                path=provider_path,
+                payload=payload,
+            )
+            return self._stream_passthrough_with_usage(stream)
+        else:
+            return await send_request(
+                headers=request_headers,
+                base_url=self.base_url,
+                path=provider_path,
+                payload=payload,
+            )

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -1705,3 +1705,114 @@ async def raw_proxy(endpoint_name: str, path: str, request: Request):
             safe_stream(_prepend(first, gen), as_bytes=True), media_type="text/event-stream"
         )
     return first
+
+
+@gateway_router.post(PASSTHROUGH_ROUTES[PassthroughAction.MISTRAL_CHAT], response_model=None)
+@translate_http_exception
+@_record_gateway_invocation(GatewayInvocationType.MISTRAL_PASSTHROUGH_CHAT)
+async def mistral_passthrough_chat(request: Request):
+    """
+    mistral passthrough endpoint for chat completions.
+
+    This endpoint accepts raw mistral API format and passes it through to the
+    mistral provider with the configured API key and model. The 'model' parameter
+    in the request specifies which MLflow endpoint to use.
+
+    Supports streaming responses when the 'stream' parameter is set to true.
+
+    Example:
+        POST /gateway/mistral/v1/chat/completions
+        {
+            model: "mistral-large-latest",
+            messages: [
+            {
+                role: "user",
+                content: "Who is the best French painter? Answer in one short sentence.",
+                },
+            ],
+        }
+    """
+    body = await _get_request_body(request)
+    user_metadata = _get_user_metadata(request)
+
+    endpoint_name = _extract_endpoint_name_from_model(body)
+    body.pop("model")
+    store = _get_store()
+    workspace = get_request_workspace()
+    _validate_store(store)
+    headers = dict(request.headers)
+    provider, endpoint_config = _create_provider_from_endpoint_name(
+        store, endpoint_name, EndpointType.LLM_V1_CHAT
+    )
+    _set_gateway_telemetry_state(request, endpoint_config)
+    check_budget_limit(
+        store, endpoint_config, workspace=workspace, username=_get_request_username(request)
+    )
+    guardrails, auth_headers = _get_guardrails_and_auth(store, endpoint_config, request)
+
+    if body.get("stream", False):
+        # Post-LLM guardrails are not applied to streaming responses.
+        async def _guarded_stream(body: dict[str, Any]):
+            request_dict = await run_pre_llm_guardrails(
+                guardrails,
+                body,
+                auth_headers=auth_headers,
+                usage_tracking=endpoint_config.usage_tracking,
+            )
+            stream = await provider.passthrough(
+                action=PassthroughAction.MISTRAL_CHAT, payload=request_dict, headers=headers
+            )
+            async for chunk in stream:
+                yield chunk
+
+        traced_stream = maybe_traced_gateway_call(
+            _guarded_stream,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_MISTRAL_CHAT,
+            on_complete=make_budget_on_complete(
+                store,
+                workspace,
+                endpoint_id=endpoint_config.endpoint_id,
+                username=_get_request_username(request),
+            ),
+        )
+        return StreamingResponse(
+            safe_stream(traced_stream(body), as_bytes=True), media_type="text/event-stream"
+        )
+
+    async def _guarded_passthrough(body: dict[str, Any]) -> dict[str, Any]:
+        body = await run_pre_llm_guardrails(
+            guardrails,
+            body,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+        response = await provider.passthrough(
+            action=PassthroughAction.MISTRAL_CHAT, payload=body, headers=headers
+        )
+        return await run_post_llm_guardrails_passthrough(
+            guardrails,
+            body,
+            response,
+            auth_headers=auth_headers,
+            usage_tracking=endpoint_config.usage_tracking,
+        )
+
+    try:
+        return await maybe_traced_gateway_call(
+            _guarded_passthrough,
+            endpoint_config,
+            user_metadata,
+            request_headers=headers,
+            request_type=GatewayRequestType.PASSTHROUGH_MODEL_MISTRAL_CHAT,
+            on_complete=make_budget_on_complete(
+                store,
+                workspace,
+                endpoint_id=endpoint_config.endpoint_id,
+                username=_get_request_username(request),
+            ),
+        )(body)
+    except GuardrailViolation as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -692,6 +692,7 @@ class GatewayInvocationType(str, Enum):
     ANTHROPIC_PASSTHROUGH_MESSAGES = "anthropic_passthrough_messages"
     GEMINI_PASSTHROUGH_GENERATE_CONTENT = "gemini_passthrough_generate_content"
     GEMINI_PASSTHROUGH_STREAM_GENERATE_CONTENT = "gemini_passthrough_stream_generate_content"
+    MISTRAL_PASSTHROUGH_CHAT = "mistral_passthrough_chat"
     RAW_PROXY = "raw_proxy"
 
 


### PR DESCRIPTION
 ### Related Issues/PRs

  Relates to https://github.com/mlflow/mlflow/issues/25630

  ### What changes are proposed in this pull request?

  Add a Mistral passthrough endpoint to the MLflow AI Gateway, following the same pattern as the existing OpenAI, Anthropic, and Gemini passthrough endpoints.

  - Register `PASSTHROUGH_MODEL_MISTRAL_CHAT` in `GatewayRequestType` and `PassthroughAction`
  - Add `PASSTHROUGH_PROVIDER_PATHS`, `_get_headers`, `_passthrough`, `_extract_passthrough_token_usage`, and `_extract_streaming_token_usage` to `MistralProvider`
  - Add the `mistral_passthrough_chat` route in `gateway_api.py` with guardrail, budget, tracing, and streaming support
  - Add `MISTRAL_PASSTHROUGH_CHAT` telemetry event

  ### How is this PR tested?

  - [x] Manual tests

  ### Does this PR require documentation update?

  - [x] No.

  ### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

  - [ ] No.

  ### Release Notes

  #### Is this a user-facing change?

  - [x] Yes. Add Mistral passthrough endpoint to the MLflow AI Gateway, enabling users to send raw Mistral API requests through the gateway with configured API keys, model routing,
  guardrails, and budget limits.

  #### What component(s), interfaces, languages, and integrations does this PR affect?

  Components

  - [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations

  <a name="release-note-category"></a>

  #### How should the PR be classified in the release notes? Choose one:

  - [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

  #### Is this PR a critical bugfix or security fix that should go into the next patch release?

  - [ ] This PR is critical and needs to be in the next patch release
  - [x] This PR can wait for the next minor release