### PR TITLE
Fix `@mlflow.trace` leaking the stream span when a generator is stopped early

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -482,21 +482,32 @@ def _wrap_generator(
 
             i = 0
             outputs = []
-            while True:
+            try:
+                while True:
+                    try:
+                        # NB: Set the span to active only when the generator is running
+                        with safe_set_span_in_context(span):
+                            value = next(generator)
+                    except StopIteration:
+                        break
+                    except Exception as e:
+                        _end_stream_span(span, error=e)
+                        raise e
+                    else:
+                        outputs.append(value)
+                        _record_chunk_event(span, value, i)
+                        yield value
+                        i += 1
+            except GeneratorExit:
+                # The consumer stopped early (break, close(), or garbage collection), so the
+                # span would otherwise never be ended. Close the wrapped generator under the
+                # span so its cleanup is attributed correctly, then end with the partial output.
                 try:
-                    # NB: Set the span to active only when the generator is running
                     with safe_set_span_in_context(span):
-                        value = next(generator)
-                except StopIteration:
-                    break
-                except Exception as e:
-                    _end_stream_span(span, error=e)
-                    raise e
-                else:
-                    outputs.append(value)
-                    _record_chunk_event(span, value, i)
-                    yield value
-                    i += 1
+                        generator.close()
+                finally:
+                    _end_stream_span(span, inputs, outputs, output_reducer)
+                raise
             _end_stream_span(span, inputs, outputs, output_reducer)
 
     else:
@@ -509,20 +520,28 @@ def _wrap_generator(
 
             i = 0
             outputs = []
-            while True:
+            try:
+                while True:
+                    try:
+                        with safe_set_span_in_context(span):
+                            value = await generator.__anext__()
+                    except StopAsyncIteration:
+                        break
+                    except Exception as e:
+                        _end_stream_span(span, error=e)
+                        raise e
+                    else:
+                        outputs.append(value)
+                        _record_chunk_event(span, value, i)
+                        yield value
+                        i += 1
+            except GeneratorExit:
                 try:
                     with safe_set_span_in_context(span):
-                        value = await generator.__anext__()
-                except StopAsyncIteration:
-                    break
-                except Exception as e:
-                    _end_stream_span(span, error=e)
-                    raise e
-                else:
-                    outputs.append(value)
-                    _record_chunk_event(span, value, i)
-                    yield value
-                    i += 1
+                        await generator.aclose()
+                finally:
+                    _end_stream_span(span, inputs, outputs, output_reducer)
+                raise
             _end_stream_span(span, inputs, outputs, output_reducer)
 
     return _wrap_function_safe(fn, wrapper)

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1,4 +1,5 @@
 import asyncio
+import itertools
 import json
 import os
 import subprocess
@@ -622,6 +623,83 @@ def test_trace_handle_exception_during_streaming():
     assert len(spans[0].events) == 2
     assert spans[0].events[0].name == "mlflow.chunk.item.0"
     assert spans[0].events[1].name == "exception"
+
+
+def _assert_partial_stream_trace(expected_outputs):
+    traces = get_traces()
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.info.state == TraceState.OK
+    span = trace.data.spans[0]
+    assert span.outputs == expected_outputs
+    assert [e.name for e in span.events] == [
+        f"mlflow.chunk.item.{i}" for i in range(len(expected_outputs))
+    ]
+
+
+@pytest.mark.parametrize("stop_with_close", [False, True])
+def test_trace_stream_ended_when_consumer_stops_early(stop_with_close):
+    cleanup_span_active = []
+
+    @mlflow.trace
+    def stream():
+        try:
+            for i in range(5):
+                yield i
+        finally:
+            cleanup_span_active.append(mlflow.get_current_active_span() is not None)
+
+    if stop_with_close:
+        gen = stream()
+        assert next(gen) == 0
+        assert next(gen) == 1
+        gen.close()
+    else:
+        for chunk in stream():
+            if chunk == 1:
+                break
+
+    # The wrapped generator's cleanup must run while the stream span is active
+    assert cleanup_span_active == [True]
+    _assert_partial_stream_trace([0, 1])
+
+
+def test_trace_async_stream_ended_when_consumer_stops_early():
+    @mlflow.trace
+    async def astream():
+        for i in range(5):
+            yield i
+
+    async def consume():
+        gen = astream()
+        async for chunk in gen:
+            if chunk == 1:
+                break
+        await gen.aclose()
+
+    asyncio.run(consume())
+    _assert_partial_stream_trace([0, 1])
+
+
+def test_trace_nested_stream_ended_when_consumer_stops_early():
+    @mlflow.trace
+    def stream():
+        for i in range(5):
+            yield i
+
+    @mlflow.trace
+    def agent():
+        return list(itertools.islice(stream(), 2))
+
+    assert agent() == [0, 1]
+
+    traces = get_traces()
+    assert len(traces) == 1
+    spans = traces[0].data.spans
+    assert [s.name for s in spans] == ["agent", "stream"]
+    assert spans[1].parent_id == spans[0].span_id
+    assert spans[1].outputs == [0, 1]
+    assert spans[1].status.status_code == SpanStatusCode.OK
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Related Issues/PRs

Closes #25790

### What changes are proposed in this pull request?

When a function decorated with `@mlflow.trace` is a sync or async generator and the consumer stops before exhausting it (`break`, `gen.close()`, `itertools.islice`, dropping the generator), the stream span is never ended. In `_wrap_generator` (`mlflow/tracing/fluent.py`) the `yield value` sits outside the `try` that guards `next(generator)`, so the `GeneratorExit` raised at the `yield` propagates past the loop and `_end_stream_span(...)` never runs.

Effects today:

- Root-level early-stopped stream: **no trace is logged at all**.
- Nested early-stopped stream (e.g. an agent calling `islice(stream(), 2)`): the parent trace is logged but the `stream` span, its inputs, and its chunk events are gone.
- Each occurrence leaks the trace in `InMemoryTraceManager` and in `MlflowV3SpanExporter._deferred_root_spans` (which keeps waiting for the open span), so memory grows in long-running processes. With a Databricks destination the whole trace is never exported.

Stopping an LLM stream early is an everyday pattern, so this silently drops real traces.

This PR wraps the iteration loop in both wrappers so that on `GeneratorExit` we:

1. close the wrapped generator (`generator.close()` / `await generator.aclose()`) under the stream span, so any cleanup it performs is attributed to the right span;
2. end the span with the chunks produced so far (through `output_reducer` if one is set);
3. re-raise, as generator protocol requires.

Behavior for full consumption and for exceptions raised inside the generator is unchanged.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

New tests in `tests/tracing/test_fluent.py`:

- `test_trace_stream_ended_when_consumer_stops_early` (parametrized over `break` and explicit `close()`), which also asserts the wrapped generator's `finally` block runs while the stream span is active
- `test_trace_async_stream_ended_when_consumer_stops_early`
- `test_trace_nested_stream_ended_when_consumer_stops_early` (the `islice` case; asserts the child `stream` span is present with the partial outputs)

All three fail on `master` and pass with this change. Full `tests/tracing/test_fluent.py` passes (188 tests).

Manual reproduction (before → after):

```python
@mlflow.trace
def stream():
    for i in range(5):
        yield i

for x in stream():
    if x == 1:
        break
# traces logged: 0 → 1 (outputs [0, 1], two chunk events)

@mlflow.trace
def agent():
    return list(itertools.islice(stream(), 2))

agent()
# spans in trace: ['agent'] → ['agent', 'stream']
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Fixed `@mlflow.trace` on generator functions never ending the span (and silently dropping the trace) when the consumer stops iterating early, e.g. via `break`, `close()`, or `itertools.islice`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)