### PR TITLE
Preserve Claude settings files that contain no MLflow config on `--disable`

### DIFF
--- a/mlflow/claude_code/plugin.py
+++ b/mlflow/claude_code/plugin.py
@@ -61,14 +61,17 @@ def disable_tracing_plugin(settings_path: Path) -> bool:
         return False
 
     config = load_claude_config(settings_path)
-    env_removed = _remove_mlflow_env(config)
+    # An unreadable or malformed file also loads as an empty dict, so only rewrite
+    # or delete the file once MLflow config has actually been found and removed.
+    if not _remove_mlflow_env(config):
+        return False
 
     if config:
         save_claude_config(settings_path, config)
     else:
         settings_path.unlink()
 
-    return env_removed
+    return True
 
 
 def _run_claude(target_dir: Path, *args: str) -> subprocess.CompletedProcess:

--- a/tests/claude_code/test_plugin.py
+++ b/tests/claude_code/test_plugin.py
@@ -27,6 +27,26 @@ def test_disable_tracing_plugin_removes_env_only(tmp_path):
     assert config == {"other": "keep-me"}
 
 
+def test_disable_tracing_plugin_keeps_settings_without_mlflow_env(tmp_path):
+    settings_path = tmp_path / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    original = json.dumps({"other": "keep-me"})
+    settings_path.write_text(original)
+
+    assert disable_tracing_plugin(settings_path) is False
+    assert settings_path.read_text() == original
+
+
+def test_disable_tracing_plugin_keeps_malformed_settings(tmp_path):
+    settings_path = tmp_path / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    original = '{"other": "keep-me",}'
+    settings_path.write_text(original)
+
+    assert disable_tracing_plugin(settings_path) is False
+    assert settings_path.read_text() == original
+
+
 def test_ensure_plugin_installed_runs_marketplace_add_and_install(tmp_path):
     completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 


### PR DESCRIPTION
### Related Issues/PRs

N/A. Found while reading through `mlflow/claude_code`, no existing issue filed.

### What changes are proposed in this pull request?

`mlflow autolog claude --disable` can delete a `.claude/settings.json` that MLflow never wrote to.

`load_claude_config` returns an empty dict for any file it cannot parse:

```python
except (json.JSONDecodeError, IOError):
    return {}
```

`disable_tracing_plugin` then reads that empty dict as "nothing left to keep" and unlinks the file:

```python
config = load_claude_config(settings_path)
env_removed = _remove_mlflow_env(config)

if config:
    save_claude_config(settings_path, config)
else:
    settings_path.unlink()
```

So a `settings.json` with a JSON syntax error loses every unrelated setting it held, such as `permissions`, `model`, or MCP server entries. The command still reports `No Claude configuration found - tracing was not enabled` while removing it.

The same path also rewrites files that parse fine but hold no MLflow keys, reformatting them through `json.dump(..., indent=2)` for no reason.

This PR returns early when `_remove_mlflow_env` reports that nothing was removed, so the file is only rewritten or deleted once MLflow config has actually been found.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Two regression tests were added to `tests/claude_code/test_plugin.py`. Both fail on `master`:

- `test_disable_tracing_plugin_keeps_malformed_settings` fails with `FileNotFoundError`
- `test_disable_tracing_plugin_keeps_settings_without_mlflow_env` fails on the reformatted contents

Manual check against a settings file holding a trailing comma and no MLflow keys:

```
# before
before -> exists: True
output: No Claude configuration found - tracing was not enabled
after  -> exists: False

# after
before -> exists: True
output: No Claude configuration found - tracing was not enabled
after  -> exists: True
```

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow autolog claude --disable` no longer deletes or rewrites Claude settings files that contain no MLflow configuration, including files that fail to parse as JSON.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
