### PR TITLE
Fix positional Series alignment in `eval_results_table`

### DIFF
--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -764,6 +764,9 @@ class BuiltInEvaluator(ModelEvaluator):
         ):
             return
 
+        if isinstance(y_pred, pd.Series):
+            y_pred = y_pred.to_numpy()
+
         metric_prefix = self.evaluator_config.get("metric_prefix", "")
         if not isinstance(metric_prefix, str):
             metric_prefix = ""
@@ -790,7 +793,7 @@ class BuiltInEvaluator(ModelEvaluator):
         # Include other_output_columns used in evaluation to the eval table
         if other_output_columns is not None and len(self.other_output_columns_for_eval) > 0:
             for column in self.other_output_columns_for_eval:
-                data[column] = other_output_columns[column]
+                data[column] = other_output_columns[column].to_numpy()
 
         columns = {}
         for metric_name, metric_value in self.metrics_values.items():

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -2052,6 +2052,60 @@ def validate_question_answering_logged_data(
         assert logged_data["answer"].tolist() == ["words random", "This is a sentence."]
 
 
+@pytest.mark.parametrize("multi_output", [False, True])
+def test_evaluation_table_preserves_row_alignment(multi_output):
+    data = pd.DataFrame({"feature": [1, 2], "target": [101, 202]}, index=[10, 20])
+
+    if multi_output:
+
+        def model(_data):
+            return pd.DataFrame({
+                "prediction": [101.0, 202.0],
+                "auxiliary": [0.1, 0.2],
+            })
+
+        def row_metric(predictions, auxiliary):
+            return MetricValue(scores=auxiliary.tolist())
+
+        model_type = None
+        predictions = "prediction"
+        expected_metric_scores = [0.1, 0.2]
+    else:
+
+        def model(_data):
+            return pd.Series([101.0, 202.0])
+
+        def row_metric(predictions, targets=None):
+            return MetricValue(scores=predictions.tolist())
+
+        model_type = "regressor"
+        predictions = None
+        expected_metric_scores = [101.0, 202.0]
+
+    with mlflow.start_run():
+        result = mlflow.models.evaluate(
+            model,
+            data,
+            targets="target",
+            model_type=model_type,
+            predictions=predictions,
+            evaluators="default",
+            evaluator_config={"log_model_explainability": False},
+            extra_metrics=[
+                make_metric(eval_fn=row_metric, greater_is_better=True, name="row_metric")
+            ],
+        )
+
+    eval_table = pd.DataFrame(**result.artifacts["eval_results_table"].content)
+    prediction_column = "prediction" if multi_output else "outputs"
+    assert eval_table["feature"].tolist() == [1, 2]
+    assert eval_table["target"].tolist() == [101, 202]
+    assert eval_table[prediction_column].tolist() == [101.0, 202.0]
+    assert eval_table["row_metric/score"].tolist() == expected_metric_scores
+    if multi_output:
+        assert eval_table["auxiliary"].tolist() == [0.1, 0.2]
+
+
 def test_missing_args_raises_exception():
     def dummy_fn1(param_1, param_2, targets, metrics):
         pass


### PR DESCRIPTION
### Related Issues/PRs

Closes #25649

### What changes are proposed in this pull request?

Attach pandas prediction outputs to evaluation-table rows by position instead of index label. This keeps `eval_results_table` consistent with metric computation when input data has a non-default index. The same handling covers selected multi-output predictions and auxiliary output columns.

Prediction and auxiliary-output Series are attached in returned order: a permuted index is ignored, and a length mismatch raises instead of silently filling unmatched labels with nulls. Pandas extension dtypes are preserved while dropping only the Series index semantics.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

`uv run pytest -q tests/evaluate/test_default_evaluator.py -k "evaluation_table_preserves_row_alignment or evaluation_table_preserves_nullable_integer_outputs"` — 4 passed.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Evaluation result tables now attach pandas prediction and auxiliary-output Series by position, matching metric computation. Permuted indexes are ignored, and length mismatches raise instead of silently filling unmatched rows with nulls.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
