### PR TITLE
Prioritize running SQL warehouses in `mlflow agent setup`

### DIFF
--- a/mlflow/agent/setup/setup.sh
+++ b/mlflow/agent/setup/setup.sh
@@ -607,15 +607,16 @@ s/"name"/\
 }
 
 json_warehouse_rows() {
-	awk '
-		/"id"[[:space:]]*:/ { line=$0; sub(/^.*"id"[[:space:]]*:[[:space:]]*"/, "", line); sub(/".*$/, "", line); id=line }
-		/"name"[[:space:]]*:/ { line=$0; sub(/^.*"name"[[:space:]]*:[[:space:]]*"/, "", line); sub(/".*$/, "", line); name=line }
-		/"state"[[:space:]]*:/ {
-			line=$0
-			sub(/^.*"state"[[:space:]]*:[[:space:]]*"/, "", line)
-			sub(/".*$/, "", line)
-			state=line
-			if (id != "" && name != "") {
+	sed '
+s/"id"[[:space:]]*:/\
+"id":/g
+s/"name"[[:space:]]*:/\
+"name":/g
+s/"state"[[:space:]]*:/\
+"state":/g
+' | awk '
+		function emit_if_complete() {
+			if (id != "" && name != "" && state != "") {
 				row=id "|" name "|" state
 				if (state == "RUNNING") { running[++running_count]=row }
 				else { not_running[++not_running_count]=row }
@@ -623,6 +624,27 @@ json_warehouse_rows() {
 				name=""
 				state=""
 			}
+		}
+		/"id"[[:space:]]*:/ {
+			line=$0
+			sub(/^.*"id"[[:space:]]*:[[:space:]]*"/, "", line)
+			sub(/".*$/, "", line)
+			id=line
+			emit_if_complete()
+		}
+		/"name"[[:space:]]*:/ {
+			line=$0
+			sub(/^.*"name"[[:space:]]*:[[:space:]]*"/, "", line)
+			sub(/".*$/, "", line)
+			name=line
+			emit_if_complete()
+		}
+		/"state"[[:space:]]*:/ {
+			line=$0
+			sub(/^.*"state"[[:space:]]*:[[:space:]]*"/, "", line)
+			sub(/".*$/, "", line)
+			state=line
+			emit_if_complete()
 		}
 		END {
 			for (i=1; i<=running_count; i++) print running[i]

--- a/mlflow/agent/setup/setup.sh
+++ b/mlflow/agent/setup/setup.sh
@@ -606,6 +606,31 @@ s/"name"/\
 	fi
 }
 
+json_warehouse_rows() {
+	awk '
+		/"id"[[:space:]]*:/ { line=$0; sub(/^.*"id"[[:space:]]*:[[:space:]]*"/, "", line); sub(/".*$/, "", line); id=line }
+		/"name"[[:space:]]*:/ { line=$0; sub(/^.*"name"[[:space:]]*:[[:space:]]*"/, "", line); sub(/".*$/, "", line); name=line }
+		/"state"[[:space:]]*:/ {
+			line=$0
+			sub(/^.*"state"[[:space:]]*:[[:space:]]*"/, "", line)
+			sub(/".*$/, "", line)
+			state=line
+			if (id != "" && name != "") {
+				row=id "|" name "|" state
+				if (state == "RUNNING") { running[++running_count]=row }
+				else { not_running[++not_running_count]=row }
+				id=""
+				name=""
+				state=""
+			}
+		}
+		END {
+			for (i=1; i<=running_count; i++) print running[i]
+			for (i=1; i<=not_running_count; i++) print not_running[i]
+		}
+	'
+}
+
 json_escape() {
 	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
 }
@@ -1233,11 +1258,7 @@ select_warehouse() {
 		selected_value="Enter a warehouse ID"
 	else
 		warehouse_json=$spinner_output
-		warehouse_rows=$(printf '%s\n' "$warehouse_json" | awk '
-		/"id"[[:space:]]*:/ { line=$0; sub(/^.*"id"[[:space:]]*:[[:space:]]*"/, "", line); sub(/".*$/, "", line); id=line }
-		/"name"[[:space:]]*:/ { line=$0; sub(/^.*"name"[[:space:]]*:[[:space:]]*"/, "", line); sub(/".*$/, "", line); name=line }
-		/"state"[[:space:]]*:/ { line=$0; sub(/^.*"state"[[:space:]]*:[[:space:]]*"/, "", line); sub(/".*$/, "", line); state=line; if (id != "" && name != "") { print id "|" name "|" state; id=""; name=""; state="" } }
-	')
+		warehouse_rows=$(printf '%s\n' "$warehouse_json" | json_warehouse_rows)
 		set -- "Enter a warehouse ID"
 		while IFS='|' read -r warehouse_id warehouse_name warehouse_state; do
 			[ -n "$warehouse_id" ] && set -- "$@" "$warehouse_name    $warehouse_state · $warehouse_id"

--- a/tests/agent/test_setup_sh_unit.py
+++ b/tests/agent/test_setup_sh_unit.py
@@ -210,11 +210,11 @@ printf '%s\n' '{
     assert result.stdout == "catalog.schema.prefix\n"
 
 
-def test_json_warehouse_rows_lists_running_warehouses_first():
-    result = run_shell(
-        """
-json_warehouse_rows <<'EOF'
-{
+@pytest.mark.parametrize(
+    "warehouse_json",
+    [
+        pytest.param(
+            """{
   "warehouses": [
     {
       "id": "stopped-1",
@@ -237,9 +237,35 @@ json_warehouse_rows <<'EOF'
       "state": "STOPPED"
     }
   ]
-}
-EOF
-"""
+}""",
+            id="pretty",
+        ),
+        pytest.param(
+            '{"warehouses": [{"id": "stopped-1", "name": "Stopped Warehouse", '
+            '"state": "STOPPED"}, {"id": "running-1", '
+            '"name": "First Running Warehouse", "state": "RUNNING"}, '
+            '{"id": "running-2", "name": "Second Running Warehouse", '
+            '"state": "RUNNING"}, {"id": "stopped-2", '
+            '"name": "Another Stopped Warehouse", "state": "STOPPED"}]}',
+            id="compact",
+        ),
+        pytest.param(
+            """{
+  "warehouses": [
+    {"state": "STOPPED", "name": "Stopped Warehouse", "id": "stopped-1"},
+    {"name": "First Running Warehouse", "state": "RUNNING", "id": "running-1"},
+    {"state": "RUNNING", "id": "running-2", "name": "Second Running Warehouse"},
+    {"name": "Another Stopped Warehouse", "id": "stopped-2", "state": "STOPPED"}
+  ]
+}""",
+            id="reordered-fields",
+        ),
+    ],
+)
+def test_json_warehouse_rows_lists_running_warehouses_first(warehouse_json: str):
+    result = run_shell(
+        """printf '%s\n' "$1" | json_warehouse_rows""",
+        warehouse_json,
     )
 
     assert result.returncode == 0, result.stderr

--- a/tests/agent/test_setup_sh_unit.py
+++ b/tests/agent/test_setup_sh_unit.py
@@ -210,6 +210,47 @@ printf '%s\n' '{
     assert result.stdout == "catalog.schema.prefix\n"
 
 
+def test_json_warehouse_rows_lists_running_warehouses_first():
+    result = run_shell(
+        """
+json_warehouse_rows <<'EOF'
+{
+  "warehouses": [
+    {
+      "id": "stopped-1",
+      "name": "Stopped Warehouse",
+      "state": "STOPPED"
+    },
+    {
+      "id": "running-1",
+      "name": "First Running Warehouse",
+      "state": "RUNNING"
+    },
+    {
+      "id": "running-2",
+      "name": "Second Running Warehouse",
+      "state": "RUNNING"
+    },
+    {
+      "id": "stopped-2",
+      "name": "Another Stopped Warehouse",
+      "state": "STOPPED"
+    }
+  ]
+}
+EOF
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "running-1|First Running Warehouse|RUNNING",
+        "running-2|Second Running Warehouse|RUNNING",
+        "stopped-1|Stopped Warehouse|STOPPED",
+        "stopped-2|Another Stopped Warehouse|STOPPED",
+    ]
+
+
 @pytest.mark.parametrize("value", ["catalog.schema.extra", ".schema", "catalog."])
 def test_validate_uc_schema_rejects_invalid_values(value: str):
     result = run_shell('validate_uc_schema "$1"', value)


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Group SQL warehouses in the `mlflow agent setup` selection menu so warehouses in the `RUNNING` state appear before non-running warehouses. Preserve the Databricks API order within each group.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added a regression test that verifies running warehouses are listed first and that relative ordering is preserved within the running and stopped groups.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. The `mlflow agent setup` wizard now shows running SQL warehouses first, making active compute easier to select.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
