### PR TITLE
Fix Gemini 3 thoughtSignature placement for multi-turn function calling

### DIFF
--- a/mlflow/gateway/providers/gemini.py
+++ b/mlflow/gateway/providers/gemini.py
@@ -166,12 +166,12 @@ class GeminiAdapter(ProviderAdapter):
                                 "name": tool_call["function"]["name"],
                                 "args": json.loads(tool_call["function"]["arguments"]),
                             }
+                            part = {"functionCall": fc}
                             if tool_call["id"] in call_id_to_thought_signature_map:
-                                fc["thoughtSignature"] = call_id_to_thought_signature_map[
+                                part["thoughtSignature"] = call_id_to_thought_signature_map[
                                     tool_call["id"]
                                 ]
-
-                            gemini_function_calls.append({"functionCall": fc})
+                            gemini_function_calls.append(part)
                 if gemini_function_calls:
                     contents.append({"role": "model", "parts": gemini_function_calls})
                 else:
@@ -261,8 +261,13 @@ class GeminiAdapter(ProviderAdapter):
             func_name = function_call["name"]
             func_arguments = json.dumps(function_call["args"])
             call_id = function_call.get("id")
-            thought_sig = function_call.get("thoughtSignature") or function_call.get(
-                "thought_signature"
+            # Gemini 3.x nests thoughtSignature at Part-level; fall back to the
+            # Gemini 2.5 functionCall-level location.
+            thought_sig = (
+                part.get("thoughtSignature")
+                or part.get("thought_signature")
+                or function_call.get("thoughtSignature")
+                or function_call.get("thought_signature")
             )
             if call_id is None:
                 # Gemini model response might not contain function call id,

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -924,8 +924,8 @@ async def test_gemini_chat_function_calling_thought_signature():
                             "id": "call_001",
                             "name": "get_weather",
                             "args": {"location": "Singapore"},
-                            "thoughtSignature": "opaque_thought_sig_token",
-                        }
+                        },
+                        "thoughtSignature": "opaque_thought_sig_token",
                     }
                 ],
             },
@@ -967,6 +967,91 @@ async def test_gemini_chat_function_calling_thought_signature():
         json=expected_payload,
         timeout=mock.ANY,
     )
+
+
+@pytest.mark.parametrize(
+    ("native_part", "expected_sig", "description"),
+    [
+        # Gemini 3.x: thoughtSignature is a sibling of functionCall on the Part.
+        (
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": {"city": "Seattle"},
+                    "id": "call_426398",
+                },
+                "thoughtSignature": "opaque-sig-token",
+            },
+            "opaque-sig-token",
+            "Gemini 3 (Part-level thoughtSignature)",
+        ),
+        # Gemini 2.5: thoughtSignature is nested inside functionCall.
+        (
+            {
+                "functionCall": {
+                    "name": "get_weather",
+                    "args": {"city": "Seattle"},
+                    "id": "call_426398",
+                    "thoughtSignature": "opaque-sig-token",
+                },
+            },
+            "opaque-sig-token",
+            "Gemini 2.5 (functionCall-level thoughtSignature)",
+        ),
+    ],
+    ids=["gemini-3-part-level", "gemini-2.5-functioncall-level"],
+)
+def test_gemini_function_call_thought_signature_response(native_part, expected_sig, description):
+    # The adapter must capture thoughtSignature from both the Gemini 3.x Part-level
+    # location and the 2.5 functionCall-level location so it is not silently dropped
+    # on the way out to the OpenAI-compatible client.
+    choice = GeminiAdapter._convert_function_call_to_openai_choice(
+        content_parts=[native_part],
+        finish_reason="stop",
+        choice_idx=0,
+        stream=False,
+    )
+    tc = choice.message.tool_calls[0]
+
+    assert tc.thought_signature == expected_sig, f"thought_signature was dropped for {description}"
+
+
+def test_chat_to_model_thought_signature_emitted_as_part_sibling():
+    # When the client echoes thought_signature back at the top level of the OpenAI
+    # tool_call, the adapter must emit thoughtSignature as a sibling of functionCall
+    # on the Gemini Part (the 3.x shape). Nesting it inside functionCall (the 2.5
+    # shape) is rejected by Gemini 3 with:
+    #   Unknown name "thoughtSignature" at 'contents[1].parts[0].function_call'
+    payload = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_426398",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Seattle"}',
+                        },
+                        "thought_signature": "opaque-sig-token",
+                    }
+                ],
+            }
+        ]
+    }
+
+    gemini_payload = GeminiAdapter.chat_to_model(payload, EndpointConfig(**chat_config()))
+    part = gemini_payload["contents"][0]["parts"][0]
+
+    assert "thoughtSignature" in part, (
+        "thoughtSignature should be a sibling of functionCall on the Part (Gemini 3)"
+    )
+    assert "thoughtSignature" not in part["functionCall"], (
+        "thoughtSignature must NOT be nested inside functionCall (Gemini 3 rejects it)"
+    )
+    assert part["thoughtSignature"] == "opaque-sig-token"
 
 
 def chat_stream_response():


### PR DESCRIPTION
## Problem
For Gemini 3 thinking models, multi-turn function calling through the OpenAI-compatible endpoint fails with HTTP 400 on the second turn:
`Function call is missing a thought_signature in functionCall parts.`
Gemini 3 moved `thoughtSignature` out of the `functionCall` object and up to the `Part` object (sibling of `functionCall`). The request-side adapter still nested it inside `functionCall` (the 2.5 shape), which Gemini 3 rejects.
## Changes
- **Request side** (`chat_to_model`): emit `thoughtSignature` as a sibling of `functionCall` on the `Part` (3.x shape) instead of nesting it inside `functionCall` (2.5 shape).
- **Response side**: already reads `thoughtSignature` from the `Part` with a 2.5 fallback — verified and covered by new tests.
- Updated `test_gemini_chat_function_calling_thought_signature` to expect the new part-level request shape.
- Added parametrized `test_gemini_function_call_thought_signature_response` covering both Gemini 3.x (Part-level) and 2.5 (functionCall-level) response shapes.
- Added `test_chat_to_model_thought_signature_emitted_as_part_sibling` (request side, asserts `thoughtSignature` is a Part sibling, not nested in `functionCall`).

<!--
Do not remove any sections. Remove unused checkboxes except for the patch release section at the bottom.
Use backticks for code references and file paths in the PR title (e.g., `ClassName`, `function_name`, `utils.py`).
-->

### Related Issues/PRs

<!-- 🚨 Choose either "Closes" (auto-close on merge) or "Relates to" (reference only). 🚨 -->

Closes #25745

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
```
# Run the thought_signature tests (4 cases: 2 parametrized response + 1 request + 1 integration)
python -m pytest tests/gateway/providers/test_gemini.py -k "thought_signature" -v

# Run the full Gemini gateway test file to check for regressions
python -m pytest tests/gateway/providers/test_gemini.py -v
```
### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

<!-- When updating APIs or feature usage, please ensure the MLflow Skills repository reflects those changes. -->

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

<!-- Provide the link to the Skills repository PR or a brief explanation of the changes needed. -->

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

```
Fixed Gemini 3 multi-turn function calling by emitting thoughtSignature at the Part level (3.x shape) instead of inside functionCall (2.5 shape). 
This affects the OpenAI-compatible chat completions endpoint and MLflow GenAI judges/metrics/evaluation paths that use the adapter.
```

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Minor releases are expected to contain larger changes, such as new features and improvements. Non-critical bug fixes and doc updates can be included as well. By default, your PR should target the next minor release.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Patch releases are typically only performed when there has been a major regression or bug in the latest release. For the sake of stability, your PR should not be included in a patch release unless it is a critical fix, or if the risk level of your PR is exceedingly low.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
