### PR TITLE
Fix `strands.autolog` crash on foreign OpenTelemetry spans

### DIFF
--- a/mlflow/strands/autolog.py
+++ b/mlflow/strands/autolog.py
@@ -54,6 +54,8 @@ class StrandsSpanProcessor(SimpleSpanProcessor):
 
             tracer.span_processor.on_start(span, parent_context)
             trace_id = get_otel_attribute(span, SpanAttributeKey.REQUEST_ID)
+            if trace_id is None:
+                return
             mlflow_span = create_mlflow_span(span, trace_id)
             InMemoryTraceManager.get_instance().register_span(mlflow_span)
         finally:

--- a/tests/strands/test_strands_tracing.py
+++ b/tests/strands/test_strands_tracing.py
@@ -2,6 +2,7 @@ import json
 from collections.abc import AsyncIterator, Sequence
 from typing import Any
 
+from opentelemetry import trace as otel_trace
 from strands import Agent
 from strands.models.model import Model
 from strands.tools.tools import PythonAgentTool
@@ -326,3 +327,23 @@ def test_strands_autolog_shared_provider_no_recursion(monkeypatch):
     agent_span = next(span for span in spans if span.span_type == SpanType.AGENT)
     assert agent_span.inputs == [{"role": "user", "content": [{"text": "hello"}]}]
     assert agent_span.outputs.strip() == "hi"
+
+
+def test_strands_autolog_shared_provider_skips_foreign_span(monkeypatch):
+    monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "false")
+
+    mlflow.strands.autolog()
+
+    parent = otel_trace.SpanContext(
+        trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+        span_id=0x1234567890ABCDEF,
+        is_remote=True,
+        trace_flags=otel_trace.TraceFlags(otel_trace.TraceFlags.SAMPLED),
+    )
+    context = otel_trace.set_span_in_context(otel_trace.NonRecordingSpan(parent))
+
+    tracer = otel_trace.get_tracer("external")
+    with tracer.start_as_current_span("foreign-server-span", context=context):
+        pass
+
+    assert not get_traces()


### PR DESCRIPTION
### Related Issues/PRs

Closes #25663

### What changes are proposed in this pull request?

When MLflow uses a shared OpenTelemetry provider, the Strands span processor also receives spans created by other instrumentation. The base MLflow processor skips unknown child spans, leaving no MLflow request ID, but the Strands processor still tried to register that span and raised `KeyError(None)`.

Return early when the request ID is absent so foreign spans stay outside MLflow tracing. The regression test exercises a remote-parent span through a shared provider and verifies that it is ignored.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

The new test failed on the unpatched current master with `KeyError(None)` and passes with the guard. The full `tests/strands/test_strands_tracing.py` suite passes (7 tests).

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Shared-provider Strands autologging no longer raises when it receives a foreign OpenTelemetry span.
- [ ] No.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, model serving, and project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
