### PR TITLE
fix: treat .ipynb notebooks as text/plain in artifact preview

### DIFF
--- a/mlflow/server/js/src/common/utils/FileUtils.test.ts
+++ b/mlflow/server/js/src/common/utils/FileUtils.test.ts
@@ -19,4 +19,8 @@ describe('FileUtils', () => {
   test('supports pbtxt text previews', () => {
     expect(TEXT_EXTENSIONS.has('pbtxt')).toBe(true);
   });
+
+  test('supports ipynb text previews', () => {
+    expect(TEXT_EXTENSIONS.has('ipynb')).toBe(true);
+  });
 });

--- a/mlflow/server/js/src/common/utils/FileUtils.ts
+++ b/mlflow/server/js/src/common/utils/FileUtils.ts
@@ -52,6 +52,7 @@ export const TEXT_EXTENSIONS = new Set([
   MLPROJECT_FILE_NAME.toLowerCase(),
   MLMODEL_FILE_NAME.toLowerCase(),
   'jsonnet',
+  'ipynb',
 ]);
 export const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown', 'mdx']);
 export const HTML_EXTENSIONS = new Set(['html']);

--- a/mlflow/utils/mime_type_utils.py
+++ b/mlflow/utils/mime_type_utils.py
@@ -32,6 +32,7 @@ def get_text_extensions():
         "tsv",
         "md",
         "rst",
+        "ipynb",
     ]
 
     if not IS_TRACING_SDK_ONLY:

--- a/tests/utils/test_mime_type_utils.py
+++ b/tests/utils/test_mime_type_utils.py
@@ -15,6 +15,7 @@ from mlflow.utils.os import is_windows
         ("/a/b/c.pdf", "application/pdf"),
         ("/a/b/MLmodel", "text/plain"),
         ("/a/b/mlproject", "text/plain"),
+        ("/a/b/notebook.ipynb", "text/plain"),
     ],
 )
 def test_guess_mime_type(file_path, expected_mime_type):


### PR DESCRIPTION
Closes #25710. Adds ipynb to both mime_type_utils.py's get_text_extensions() and FileUtils.ts's TEXT_EXTENSIONS, since the UI's inline preview is driven by the latter, not the served Content-Type (per @UgaTheDev's analysis on the issue). Includes a Python test and a Jest test.