### PR TITLE
Match Databricks auth profiles by workspace ID

### DIFF
--- a/mlflow/agent/setup/setup.sh
+++ b/mlflow/agent/setup/setup.sh
@@ -653,6 +653,63 @@ s/"state"[[:space:]]*:/\
 	'
 }
 
+json_databricks_profile_rows() {
+	if command -v jq >/dev/null 2>&1; then
+		jq -r '
+			.profiles[]?
+			| select((.name | type) == "string" and (.host | type) == "string")
+			| [.name, .host, ((.workspace_id // "") | tostring)]
+			| join("|")
+		'
+	else
+		tr '\n' ' ' | sed 's/}[[:space:]]*,[[:space:]]*{/}\
+{/g' | awk '
+			/"name"[[:space:]]*:/ && /"host"[[:space:]]*:/ {
+				name=$0
+				sub(/^.*"name"[[:space:]]*:[[:space:]]*"/, "", name)
+				sub(/".*$/, "", name)
+				host=$0
+				sub(/^.*"host"[[:space:]]*:[[:space:]]*"/, "", host)
+				sub(/".*$/, "", host)
+				workspace_id=""
+				if ($0 ~ /"workspace_id"[[:space:]]*:/) {
+					workspace_id=$0
+					sub(/^.*"workspace_id"[[:space:]]*:[[:space:]]*/, "", workspace_id)
+					if (workspace_id ~ /^"/) {
+						sub(/^"/, "", workspace_id)
+						sub(/".*$/, "", workspace_id)
+					} else {
+						sub(/[},].*$/, "", workspace_id)
+					}
+				}
+				if (host ~ /^https?:\/\//) print name "|" host "|" workspace_id
+			}
+		'
+	fi
+}
+
+json_databricks_profile_workspace_id() {
+	if command -v jq >/dev/null 2>&1; then
+		jq -r '.details.configuration.workspace_id.value // empty'
+	else
+		sed '
+s/"workspace_id"[[:space:]]*:/\
+"workspace_id":/g
+s/"value"[[:space:]]*:/\
+"value":/g
+' | awk '
+			/"workspace_id"[[:space:]]*:/ { in_workspace_id=1 }
+			in_workspace_id && /"value"[[:space:]]*:/ {
+				line=$0
+				sub(/^.*"value"[[:space:]]*:[[:space:]]*"/, "", line)
+				sub(/".*$/, "", line)
+				print line
+				exit
+			}
+		'
+	fi
+}
+
 json_escape() {
 	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
 }
@@ -680,6 +737,7 @@ normalize_tracking_uri() {
 }
 
 WORKSPACE_URL=""
+WORKSPACE_ID=""
 PROFILE=""
 TRACKING_URI=""
 EXPERIMENT_ID=""
@@ -688,6 +746,7 @@ UC_SCHEMA=""
 WAREHOUSE_ID=""
 AGENT_NAME=""
 WORKSPACE_URL_EXPLICIT="false"
+WORKSPACE_ID_EXPLICIT="false"
 PROFILE_EXPLICIT="false"
 
 usage() {
@@ -696,6 +755,7 @@ usage() {
 		"" \
 		"Options:" \
 		"  --workspace-url <url>         Databricks workspace URL" \
+		"  --workspace-id <id>           Databricks workspace ID" \
 		"  --profile <name>              Databricks CLI profile" \
 		"  --tracking-uri <url>          Existing OSS MLflow server" \
 		"  --experiment-id <id>          Existing experiment" \
@@ -713,6 +773,12 @@ parse_args() {
 			[ "$#" -ge 2 ] || die "$1 requires a value."
 			WORKSPACE_URL=$2
 			WORKSPACE_URL_EXPLICIT="true"
+			shift 2
+			;;
+		--workspace-id)
+			[ "$#" -ge 2 ] || die "$1 requires a value."
+			WORKSPACE_ID=$2
+			WORKSPACE_ID_EXPLICIT="true"
 			shift 2
 			;;
 		--profile)
@@ -805,7 +871,11 @@ show_manual_setup() {
 		if [ -n "$PROFILE" ]; then
 			primary_detail "Authenticate with: $DATABRICKS_BIN auth login --host $WORKSPACE_URL --profile $PROFILE"
 		else
-			primary_detail "Set DATABRICKS_HOST=$WORKSPACE_URL and authenticate with: $DATABRICKS_BIN auth login --host $WORKSPACE_URL"
+			primary_detail "Set DATABRICKS_HOST=$WORKSPACE_URL."
+			if [ -n "$WORKSPACE_ID" ]; then
+				primary_detail "Set DATABRICKS_WORKSPACE_ID=$WORKSPACE_ID."
+			fi
+			primary_detail "Authenticate with: $DATABRICKS_BIN auth login --host $WORKSPACE_URL"
 		fi
 		primary_detail "Enable tracing for your framework, run one request, and confirm the trace appears in MLflow."
 		;;
@@ -880,7 +950,7 @@ EOF
 
 choose_backend() {
 	configured_tracking_uri=${MLFLOW_TRACKING_URI:-}
-	if [ -n "$WORKSPACE_URL" ] || [ -n "$PROFILE" ]; then
+	if [ -n "$WORKSPACE_URL" ] || [ -n "$WORKSPACE_ID" ] || [ -n "$PROFILE" ]; then
 		backend="databricks"
 	elif [ -n "$TRACKING_URI" ]; then
 		backend="remote"
@@ -906,18 +976,24 @@ choose_backend() {
 	fi
 }
 
+databricks_cli_is_compatible() {
+	profiles_help=$("$1" auth profiles --help 2>/dev/null) || return 1
+	printf '%s\n' "$profiles_help" | grep -q -- '--workspace-id' || return 1
+	"$1" auth describe --help >/dev/null 2>&1
+}
+
 find_compatible_databricks_cli() {
 	for candidate_dir in "${XDG_BIN_HOME:-}" "$HOME/.local/bin" "${CARGO_HOME:-$HOME/.cargo}/bin"; do
 		[ -n "$candidate_dir" ] || continue
 		candidate="$candidate_dir/databricks"
-		if [ -x "$candidate" ] && "$candidate" auth profiles --help >/dev/null 2>&1; then
+		if [ -x "$candidate" ] && databricks_cli_is_compatible "$candidate"; then
 			printf '%s' "$candidate"
 			return
 		fi
 	done
 	if command -v databricks >/dev/null 2>&1; then
 		candidate=$(command -v databricks)
-		if "$candidate" auth profiles --help >/dev/null 2>&1; then
+		if databricks_cli_is_compatible "$candidate"; then
 			printf '%s' "$candidate"
 		fi
 	fi
@@ -973,9 +1049,9 @@ ensure_databricks_cli() {
 
 dbx_json() {
 	if [ -n "$PROFILE" ]; then
-		DATABRICKS_HOST= "$DATABRICKS_BIN" "$@" --output json --profile "$PROFILE"
+		DATABRICKS_HOST= DATABRICKS_WORKSPACE_ID= "$DATABRICKS_BIN" "$@" --output json --profile "$PROFILE"
 	elif [ -n "$WORKSPACE_URL" ]; then
-		DATABRICKS_CONFIG_PROFILE= DATABRICKS_HOST="$WORKSPACE_URL" "$DATABRICKS_BIN" "$@" --output json
+		DATABRICKS_CONFIG_PROFILE= DATABRICKS_HOST="$WORKSPACE_URL" DATABRICKS_WORKSPACE_ID="$WORKSPACE_ID" "$DATABRICKS_BIN" "$@" --output json
 	else
 		"$DATABRICKS_BIN" "$@" --output json
 	fi
@@ -983,9 +1059,9 @@ dbx_json() {
 
 databricks_token_user() {
 	if [ -n "$PROFILE" ]; then
-		token_json=$("$DATABRICKS_BIN" auth token "$PROFILE" --output json 2>/dev/null) || return
+		token_json=$(DATABRICKS_HOST= DATABRICKS_WORKSPACE_ID= "$DATABRICKS_BIN" auth token "$PROFILE" --output json 2>/dev/null) || return
 	elif [ -n "$WORKSPACE_URL" ]; then
-		token_json=$(DATABRICKS_CONFIG_PROFILE= DATABRICKS_HOST="$WORKSPACE_URL" "$DATABRICKS_BIN" auth token --output json 2>/dev/null) || return
+		token_json=$(DATABRICKS_CONFIG_PROFILE= DATABRICKS_HOST="$WORKSPACE_URL" DATABRICKS_WORKSPACE_ID="$WORKSPACE_ID" "$DATABRICKS_BIN" auth token --output json 2>/dev/null) || return
 	else
 		token_json=$("$DATABRICKS_BIN" auth token --output json 2>/dev/null) || return
 	fi
@@ -1013,14 +1089,48 @@ databricks_token_user() {
 }
 
 list_databricks_profiles() {
-	"$DATABRICKS_BIN" auth profiles --skip-validate 2>/dev/null | awk 'NR > 1 && $1 != "" && $2 ~ /^https?:\/\// { print $1 "|" $2 }'
+	"$DATABRICKS_BIN" auth profiles --skip-validate --output json 2>/dev/null | json_databricks_profile_rows | while IFS='|' read -r profile_name profile_host profile_workspace_id; do
+		[ -n "$profile_name" ] || continue
+		profile_host=$(normalize_workspace_url "$profile_host")
+		printf '%s|%s|%s\n' "$profile_name" "$profile_host" "$profile_workspace_id"
+	done
+}
+
+databricks_profile_workspace_id() {
+	DATABRICKS_CONFIG_PROFILE= DATABRICKS_HOST= DATABRICKS_WORKSPACE_ID= \
+		"$DATABRICKS_BIN" auth describe --profile "$1" --output json 2>/dev/null | json_databricks_profile_workspace_id
+}
+
+find_databricks_profile_by_workspace_id() {
+	profile_rows=$1
+	target_workspace_id=$2
+	target_workspace_host=${3:-}
+	for matching_host_only in true false; do
+		while IFS='|' read -r profile_name profile_host profile_workspace_id; do
+			[ -n "$profile_name" ] || continue
+			if [ "$matching_host_only" = "true" ]; then
+				[ -n "$target_workspace_host" ] && [ "$profile_host" = "$target_workspace_host" ] || continue
+			else
+				[ "$profile_host" != "$target_workspace_host" ] || continue
+			fi
+			if [ -z "$profile_workspace_id" ]; then
+				profile_workspace_id=$(databricks_profile_workspace_id "$profile_name" || true)
+			fi
+			if [ "$profile_workspace_id" = "$target_workspace_id" ]; then
+				printf '%s|%s|%s' "$profile_name" "$profile_host" "$profile_workspace_id"
+				return
+			fi
+		done <<EOF
+$profile_rows
+EOF
+	done
 }
 
 databricks_auth_valid() {
 	if [ -n "$PROFILE" ]; then
-		"$DATABRICKS_BIN" auth token "$PROFILE" --output json >/dev/null 2>&1
+		DATABRICKS_HOST= DATABRICKS_WORKSPACE_ID= "$DATABRICKS_BIN" auth token "$PROFILE" --output json >/dev/null 2>&1
 	elif [ -n "$WORKSPACE_URL" ]; then
-		DATABRICKS_CONFIG_PROFILE= DATABRICKS_HOST="$WORKSPACE_URL" "$DATABRICKS_BIN" auth token --output json >/dev/null 2>&1
+		DATABRICKS_CONFIG_PROFILE= DATABRICKS_HOST="$WORKSPACE_URL" DATABRICKS_WORKSPACE_ID="$WORKSPACE_ID" "$DATABRICKS_BIN" auth token --output json >/dev/null 2>&1
 	else
 		"$DATABRICKS_BIN" auth token --output json >/dev/null 2>&1
 	fi
@@ -1028,11 +1138,14 @@ databricks_auth_valid() {
 
 resolve_databricks_profile() {
 	profile_selection_needed="false"
-	if [ "$WORKSPACE_URL_EXPLICIT" = "false" ] && [ -z "$PROFILE" ] && [ -n "${DATABRICKS_CONFIG_PROFILE:-}" ]; then
+	if [ "$WORKSPACE_URL_EXPLICIT" = "false" ] && [ "$WORKSPACE_ID_EXPLICIT" = "false" ] && [ -z "$PROFILE" ] && [ -n "${DATABRICKS_CONFIG_PROFILE:-}" ]; then
 		PROFILE=$DATABRICKS_CONFIG_PROFILE
 	fi
 	if [ "$PROFILE_EXPLICIT" = "false" ] && [ -z "$WORKSPACE_URL" ] && [ -n "${DATABRICKS_HOST:-}" ]; then
 		WORKSPACE_URL=$DATABRICKS_HOST
+	fi
+	if [ "$WORKSPACE_URL_EXPLICIT" = "false" ] && [ "$PROFILE_EXPLICIT" = "false" ] && [ -z "$WORKSPACE_ID" ] && [ -n "${DATABRICKS_WORKSPACE_ID:-}" ]; then
+		WORKSPACE_ID=$DATABRICKS_WORKSPACE_ID
 	fi
 	if [ -n "$WORKSPACE_URL" ]; then
 		WORKSPACE_URL=$(normalize_workspace_url "$WORKSPACE_URL")
@@ -1055,27 +1168,58 @@ resolve_databricks_profile() {
 	fi
 	if [ -n "$PROFILE" ]; then
 		profile_host=$(printf '%s\n' "$profiles" | awk -F '|' -v profile="$PROFILE" '$1 == profile { print $2; exit }')
+		profile_workspace_id=$(printf '%s\n' "$profiles" | awk -F '|' -v profile="$PROFILE" '$1 == profile { print $3; exit }')
 		if [ -n "$profile_host" ]; then
 			profile_host=$(normalize_workspace_url "$profile_host")
 		fi
-		if [ -n "$WORKSPACE_URL" ] && [ -n "$profile_host" ] && [ "$WORKSPACE_URL" != "$profile_host" ]; then
+		if [ -n "$WORKSPACE_ID" ] && [ -n "$profile_host" ] && [ -z "$profile_workspace_id" ]; then
+			profile_workspace_id=$(databricks_profile_workspace_id "$PROFILE" || true)
+		fi
+		if [ -n "$WORKSPACE_ID" ] && [ -n "$profile_workspace_id" ] && [ "$WORKSPACE_ID" != "$profile_workspace_id" ]; then
+			die "Databricks profile '$PROFILE' points to workspace ID $profile_workspace_id, not $WORKSPACE_ID."
+		fi
+		if [ -n "$WORKSPACE_URL" ] && [ -n "$profile_host" ] && [ "$WORKSPACE_URL" != "$profile_host" ] && [ "$WORKSPACE_ID" != "$profile_workspace_id" ]; then
 			die "Databricks profile '$PROFILE' points to $profile_host, not $WORKSPACE_URL."
 		fi
-		if [ -z "$WORKSPACE_URL" ]; then
+		if [ -n "$profile_host" ]; then
 			WORKSPACE_URL=$profile_host
+		fi
+		if [ -z "$WORKSPACE_ID" ]; then
+			WORKSPACE_ID=$profile_workspace_id
 		fi
 		[ -n "$WORKSPACE_URL" ] || die "Databricks profile '$PROFILE' was not found."
 		return
 	fi
 	if [ -n "$WORKSPACE_URL" ]; then
-		PROFILE=$(printf '%s\n' "$profiles" | awk -F '|' -v host="$WORKSPACE_URL" '$2 == host { print $1; exit }')
+		if [ -n "$WORKSPACE_ID" ]; then
+			profile_match=$(find_databricks_profile_by_workspace_id "$profiles" "$WORKSPACE_ID" "$WORKSPACE_URL")
+		else
+			profile_match=$(printf '%s\n' "$profiles" | awk -F '|' -v host="$WORKSPACE_URL" '$2 == host { print; exit }')
+		fi
+		if [ -n "$profile_match" ]; then
+			PROFILE=${profile_match%%|*}
+			profile_remainder=${profile_match#*|}
+			WORKSPACE_URL=${profile_remainder%%|*}
+			profile_workspace_id=${profile_remainder#*|}
+			if [ -z "$WORKSPACE_ID" ]; then
+				WORKSPACE_ID=$profile_workspace_id
+			fi
+		fi
+		return
+	fi
+	if [ -n "$WORKSPACE_ID" ]; then
+		profile_match=$(find_databricks_profile_by_workspace_id "$profiles" "$WORKSPACE_ID")
+		[ -n "$profile_match" ] || die "No Databricks profile was found for workspace ID $WORKSPACE_ID."
+		PROFILE=${profile_match%%|*}
+		profile_remainder=${profile_match#*|}
+		WORKSPACE_URL=${profile_remainder%%|*}
 		return
 	fi
 	if [ "$loading_manual_selected" = "true" ]; then
 		selected_value="Enter a profile name or workspace URL"
 	else
 		set -- "Enter a profile name or workspace URL"
-		while IFS='|' read -r profile_name profile_url; do
+		while IFS='|' read -r profile_name profile_url profile_workspace_id; do
 			[ -n "$profile_name" ] && set -- "$@" "$profile_name    $(printf '%s' "$profile_url" | sed 's#https\{0,1\}://##')"
 		done <<EOF
 $profiles
@@ -1096,6 +1240,7 @@ EOF
 		if [ -n "$profile_host" ]; then
 			PROFILE=$entered_profile
 			WORKSPACE_URL=$profile_host
+			WORKSPACE_ID=$(printf '%s\n' "$profiles" | awk -F '|' -v profile="$PROFILE" '$1 == profile { print $3; exit }')
 		else
 			case "$entered_profile" in
 			http://* | https://* | *.*)
@@ -1109,6 +1254,7 @@ EOF
 		selected_profile=$(printf '%s' "$selected_value" | awk '{print $1}')
 		PROFILE=$selected_profile
 		WORKSPACE_URL=$(printf '%s\n' "$profiles" | awk -F '|' -v profile="$PROFILE" '$1 == profile { print $2; exit }')
+		WORKSPACE_ID=$(printf '%s\n' "$profiles" | awk -F '|' -v profile="$PROFILE" '$1 == profile { print $3; exit }')
 	fi
 }
 
@@ -1117,9 +1263,9 @@ authenticate_databricks() {
 	if ! databricks_auth_valid; then
 		progress "Sign in to Databricks" "Opening $WORKSPACE_URL in your browser…"
 		if [ -n "$PROFILE" ]; then
-			"$DATABRICKS_BIN" auth login --host "$WORKSPACE_URL" --profile "$PROFILE" <"$TTY_DEVICE" || die "Databricks authentication failed."
+			DATABRICKS_HOST= DATABRICKS_WORKSPACE_ID= "$DATABRICKS_BIN" auth login --host "$WORKSPACE_URL" --profile "$PROFILE" <"$TTY_DEVICE" || die "Databricks authentication failed."
 		else
-			DATABRICKS_CONFIG_PROFILE= "$DATABRICKS_BIN" auth login --host "$WORKSPACE_URL" <"$TTY_DEVICE" || die "Databricks authentication failed."
+			DATABRICKS_CONFIG_PROFILE= DATABRICKS_WORKSPACE_ID="$WORKSPACE_ID" "$DATABRICKS_BIN" auth login --host "$WORKSPACE_URL" <"$TTY_DEVICE" || die "Databricks authentication failed."
 		fi
 		databricks_auth_valid || die "Databricks authentication could not be verified."
 	fi
@@ -1359,7 +1505,9 @@ configure_databricks() {
 	else
 		TRACKING_URI="databricks"
 		DATABRICKS_HOST=$WORKSPACE_URL
-		export DATABRICKS_HOST
+		DATABRICKS_WORKSPACE_ID=$WORKSPACE_ID
+		DATABRICKS_CONFIG_PROFILE=
+		export DATABRICKS_HOST DATABRICKS_WORKSPACE_ID DATABRICKS_CONFIG_PROFILE
 	fi
 	resolve_databricks_experiment
 	if [ "$experiment_created" = "true" ]; then
@@ -1642,6 +1790,9 @@ build_agent_prompt() {
 			"MLFLOW_EXPERIMENT_ID=$EXPERIMENT_ID"
 		if [ -z "$PROFILE" ]; then
 			printf '%s\n' "DATABRICKS_HOST=$WORKSPACE_URL"
+			if [ -n "$WORKSPACE_ID" ]; then
+				printf '%s\n' "DATABRICKS_WORKSPACE_ID=$WORKSPACE_ID"
+			fi
 		fi
 		if [ -n "$WAREHOUSE_ID" ]; then
 			printf '%s\n' "MLFLOW_TRACING_SQL_WAREHOUSE_ID=$WAREHOUSE_ID"

--- a/tests/agent/test_setup_sh_databricks_e2e.py
+++ b/tests/agent/test_setup_sh_databricks_e2e.py
@@ -42,7 +42,14 @@ with calls_path.open("a") as calls:
         "args": args,
         "host": os.environ.get("DATABRICKS_HOST"),
         "profile": os.environ.get("DATABRICKS_CONFIG_PROFILE"),
+        "workspace_id": os.environ.get("DATABRICKS_WORKSPACE_ID"),
     }) + "\n")
+
+if args == ["auth", "profiles", "--help"]:
+    print("Global Flags:\n  --workspace-id string")
+    raise SystemExit(0)
+if args == ["auth", "describe", "--help"]:
+    raise SystemExit(0)
 
 if "--host" in args and args[:2] != ["auth", "login"]:
     print(f"unknown flag: --host for {' '.join(args[:2])}", file=sys.stderr)
@@ -117,6 +124,7 @@ def databricks_config(tmp_path: Path) -> DatabricksTestConfig:
     for name in (
         "DATABRICKS_CONFIG_PROFILE",
         "DATABRICKS_HOST",
+        "DATABRICKS_WORKSPACE_ID",
         "MLFLOW_TRACKING_URI",
     ):
         env.pop(name, None)
@@ -160,7 +168,15 @@ def _base_routes(
     return [
         {
             "args": ["auth", "profiles"],
-            "stdout": "Name Host Valid\nDEFAULT https://workspace.example.com YES",
+            "stdout": json.dumps({
+                "profiles": [
+                    {
+                        "name": "DEFAULT",
+                        "host": "https://workspace.example.com",
+                        "workspace_id": "111",
+                    }
+                ]
+            }),
         },
         {
             "args": ["auth", "token"],
@@ -535,7 +551,15 @@ def test_authentication_fallback_uses_host_and_profile_flags(
 @pytest.mark.timeout(30)
 def test_host_only_workspace_propagates_environment(databricks_config: DatabricksTestConfig):
     routes = _base_routes(token_responses=[{"returncode": 1}, {"stdout": "{}"}])
-    routes[0]["stdout"] = "Name Host Valid\nDEFAULT https://other.example.com YES"
+    routes[0]["stdout"] = json.dumps({
+        "profiles": [
+            {
+                "name": "DEFAULT",
+                "host": "https://other.example.com",
+                "workspace_id": "222",
+            }
+        ]
+    })
     _set_routes(
         databricks_config,
         routes
@@ -554,6 +578,8 @@ def test_host_only_workspace_propagates_environment(databricks_config: Databrick
             str(SETUP_SCRIPT),
             "--workspace-url",
             "https://workspace.example.com",
+            "--workspace-id",
+            "111",
             "--experiment-id",
             "existing-id",
             "--agent",
@@ -570,6 +596,7 @@ def test_host_only_workspace_propagates_environment(databricks_config: Databrick
     assert token_calls
     assert all(call["host"] == "https://workspace.example.com" for call in token_calls)
     assert all(call["profile"] == "" for call in token_calls)
+    assert all(call["workspace_id"] == "111" for call in token_calls)
     login_call = next(call for call in invocations if call["args"][:2] == ["auth", "login"])
     assert login_call["args"] == [
         "auth",
@@ -578,11 +605,62 @@ def test_host_only_workspace_propagates_environment(databricks_config: Databrick
         "https://workspace.example.com",
     ]
     assert login_call["profile"] == ""
+    assert login_call["workspace_id"] == "111"
     experiment_call = next(
         call for call in invocations if call["args"][:2] == ["experiments", "get-experiment"]
     )
     assert experiment_call["host"] == "https://workspace.example.com"
     assert experiment_call["profile"] == ""
+    assert experiment_call["workspace_id"] == "111"
+
+
+@pytest.mark.timeout(30)
+def test_spog_workspace_selects_profile_by_workspace_id(databricks_config: DatabricksTestConfig):
+    routes = _base_routes()
+    routes[0]["stdout"] = json.dumps({
+        "profiles": [
+            {
+                "name": "dogfood",
+                "host": "https://e2-dogfood.staging.cloud.databricks.com",
+                "workspace_id": "6051921418418893",
+            }
+        ]
+    })
+    _set_routes(
+        databricks_config,
+        routes
+        + [
+            {
+                "args": ["experiments", "get-experiment"],
+                "stdout": _experiment_json(trace_destination=None),
+            }
+        ],
+    )
+
+    result = _run_setup(
+        databricks_config,
+        "--workspace-url",
+        "https://dogfood.staging.databricks.com",
+        "--workspace-id",
+        "6051921418418893",
+        "--experiment-id",
+        "existing-id",
+        "--agent",
+        "codex",
+    )
+
+    assert result.returncode == 0, result.stderr
+    invocations = _read_invocations(databricks_config)
+    token_calls = [call for call in invocations if call["args"][:2] == ["auth", "token"]]
+    assert token_calls
+    assert all(call["args"][2] == "dogfood" for call in token_calls)
+    assert all(call["host"] == "" for call in token_calls)
+    assert all(call["workspace_id"] == "" for call in token_calls)
+    experiment_call = next(
+        call for call in invocations if call["args"][:2] == ["experiments", "get-experiment"]
+    )
+    assert experiment_call["args"][-2:] == ["--profile", "dogfood"]
+    assert "databricks://dogfood" in databricks_config.prompt_path.read_text()
 
 
 @pytest.mark.timeout(30)

--- a/tests/agent/test_setup_sh_unit.py
+++ b/tests/agent/test_setup_sh_unit.py
@@ -63,10 +63,12 @@ def test_parse_args():
     result = run_shell(
         """
 parse_args "$@"
-printf '%s\n' "$TRACKING_URI" "$EXPERIMENT_NAME" "$AGENT_NAME"
+printf '%s\n' "$TRACKING_URI" "$WORKSPACE_ID" "$EXPERIMENT_NAME" "$AGENT_NAME"
 """,
         "--tracking-uri",
         "mlflow.example.com/",
+        "--workspace-id",
+        "123456789",
         "--experiment-name",
         "tracing-test",
         "--agent",
@@ -76,6 +78,7 @@ printf '%s\n' "$TRACKING_URI" "$EXPERIMENT_NAME" "$AGENT_NAME"
     assert result.returncode == 0, result.stderr
     assert result.stdout.splitlines() == [
         "mlflow.example.com/",
+        "123456789",
         "tracing-test",
         "codex",
     ]
@@ -186,6 +189,7 @@ def test_build_host_only_databricks_prompt_includes_host():
 backend=databricks
 PROFILE=
 WORKSPACE_URL=https://workspace.example.com
+WORKSPACE_ID=123456789
 TRACKING_URI=databricks
 EXPERIMENT_ID=42
 EXPERIMENT_NAME=/Users/test/tracing-test
@@ -197,6 +201,7 @@ build_agent_prompt
 
     assert result.returncode == 0, result.stderr
     assert "DATABRICKS_HOST=https://workspace.example.com" in result.stdout
+    assert "DATABRICKS_WORKSPACE_ID=123456789" in result.stdout
 
 
 def test_json_tag_value():
@@ -280,6 +285,82 @@ def test_json_warehouse_rows_lists_running_warehouses_first(warehouse_json: str)
         "stopped-1|Stopped Warehouse|STOPPED",
         "stopped-2|Another Stopped Warehouse|STOPPED",
     ]
+
+
+@pytest.mark.parametrize(
+    "profiles_json",
+    [
+        pytest.param(
+            """{
+  "profiles": [
+    {
+      "name": "DEFAULT",
+      "host": "https://workspace-a.example.com",
+      "workspace_id": "111"
+    },
+    {
+      "name": "OTHER",
+      "host": "https://workspace-b.example.com"
+    }
+  ]
+}""",
+            id="pretty",
+        ),
+        pytest.param(
+            '{"profiles":[{"workspace_id":"111","host":"https://workspace-a.example.com",'
+            '"name":"DEFAULT"},{"host":"https://workspace-b.example.com","name":"OTHER"}]}',
+            id="compact-reordered",
+        ),
+    ],
+)
+def test_json_databricks_profile_rows(profiles_json: str):
+    result = run_shell("printf '%s\n' \"$1\" | json_databricks_profile_rows", profiles_json)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "DEFAULT|https://workspace-a.example.com|111",
+        "OTHER|https://workspace-b.example.com|",
+    ]
+
+
+def test_json_databricks_profile_rows_without_jq(tmp_path: Path):
+    for command in ("awk", "sed", "tr"):
+        (tmp_path / command).symlink_to(Path("/usr/bin") / command)
+    profiles_json = (
+        '{"profiles":[{"workspace_id":"111","host":"https://workspace-a.example.com",'
+        '"name":"DEFAULT"},{"host":"https://workspace-b.example.com","name":"OTHER"}]}'
+    )
+    result = run_shell(
+        """
+PATH=$1
+printf '%s\n' "$2" | json_databricks_profile_rows
+""",
+        str(tmp_path),
+        profiles_json,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "DEFAULT|https://workspace-a.example.com|111",
+        "OTHER|https://workspace-b.example.com|",
+    ]
+
+
+def test_json_databricks_profile_workspace_id_without_jq(tmp_path: Path):
+    for command in ("awk", "sed"):
+        (tmp_path / command).symlink_to(Path("/usr/bin") / command)
+    profile_json = '{"details":{"configuration":{"workspace_id":{"value":"111"}}}}'
+    result = run_shell(
+        """
+PATH=$1
+printf '%s\n' "$2" | json_databricks_profile_workspace_id
+""",
+        str(tmp_path),
+        profile_json,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "111\n"
 
 
 @pytest.mark.parametrize("value", ["catalog.schema.extra", ".schema", "catalog."])
@@ -392,7 +473,7 @@ WORKSPACE_URL=https://workspace-a.example.com
 WORKSPACE_URL_EXPLICIT=true
 PROFILE=
 DATABRICKS_CONFIG_PROFILE=OTHER
-run_with_spinner() { spinner_output='DEFAULT|https://workspace-b.example.com'; }
+run_with_spinner() { spinner_output='DEFAULT|https://workspace-b.example.com|'; }
 resolve_databricks_profile
 printf '%s\n' "$PROFILE" "$WORKSPACE_URL"
 """
@@ -409,7 +490,7 @@ PROFILE=DEFAULT
 PROFILE_EXPLICIT=true
 WORKSPACE_URL=
 DATABRICKS_HOST=https://workspace-b.example.com
-run_with_spinner() { spinner_output='DEFAULT|https://workspace-a.example.com'; }
+run_with_spinner() { spinner_output='DEFAULT|https://workspace-a.example.com|111'; }
 resolve_databricks_profile
 printf '%s\n' "$PROFILE" "$WORKSPACE_URL"
 """
@@ -426,7 +507,7 @@ PROFILE=DEFAULT
 PROFILE_EXPLICIT=true
 WORKSPACE_URL=https://workspace-b.example.com
 WORKSPACE_URL_EXPLICIT=true
-run_with_spinner() { spinner_output='DEFAULT|https://workspace-a.example.com'; }
+run_with_spinner() { spinner_output='DEFAULT|https://workspace-a.example.com|111'; }
 resolve_databricks_profile
 """
     )
@@ -435,11 +516,106 @@ resolve_databricks_profile
     assert "points to https://workspace-a.example.com" in result.stderr
 
 
+def test_workspace_id_matches_profile_with_different_spog_host():
+    result = run_shell(
+        """
+PROFILE=
+WORKSPACE_URL=https://spog.example.com
+WORKSPACE_ID=111
+run_with_spinner() { spinner_output='dogfood|https://workspace.example.com|111'; }
+resolve_databricks_profile
+printf '%s\n' "$PROFILE" "$WORKSPACE_URL" "$WORKSPACE_ID"
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["dogfood", "https://workspace.example.com", "111"]
+
+
+def test_workspace_id_prefers_profile_with_matching_host():
+    result = run_shell(
+        """
+PROFILE=
+WORKSPACE_URL=https://spog.example.com
+WORKSPACE_ID=111
+run_with_spinner() {
+    spinner_output='alias|https://workspace.example.com|111
+spog|https://spog.example.com|111'
+}
+resolve_databricks_profile
+printf '%s\n' "$PROFILE" "$WORKSPACE_URL"
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["spog", "https://spog.example.com"]
+
+
+def test_workspace_id_matches_legacy_profile_via_auth_describe(tmp_path: Path):
+    databricks = tmp_path / "databricks"
+    databricks.write_text(
+        """#!/bin/sh
+printf '%s\n' '{"details":{"configuration":{"workspace_id":{"value":"111"}}}}'
+"""
+    )
+    databricks.chmod(0o755)
+    result = run_shell(
+        """
+DATABRICKS_BIN=$1
+PROFILE=
+WORKSPACE_URL=https://spog.example.com
+WORKSPACE_ID=111
+run_with_spinner() { spinner_output='dogfood|https://workspace.example.com|'; }
+resolve_databricks_profile
+printf '%s\n' "$PROFILE" "$WORKSPACE_URL"
+""",
+        str(databricks),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["dogfood", "https://workspace.example.com"]
+
+
+def test_explicit_profile_accepts_spog_host_for_matching_workspace_id():
+    result = run_shell(
+        """
+PROFILE=dogfood
+PROFILE_EXPLICIT=true
+WORKSPACE_URL=https://spog.example.com
+WORKSPACE_URL_EXPLICIT=true
+WORKSPACE_ID=111
+run_with_spinner() { spinner_output='dogfood|https://workspace.example.com|111'; }
+resolve_databricks_profile
+printf '%s\n' "$PROFILE" "$WORKSPACE_URL"
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == ["dogfood", "https://workspace.example.com"]
+
+
+def test_explicit_profile_rejects_different_workspace_id():
+    result = run_shell(
+        """
+PROFILE=dogfood
+PROFILE_EXPLICIT=true
+WORKSPACE_URL=https://spog.example.com
+WORKSPACE_URL_EXPLICIT=true
+WORKSPACE_ID=222
+run_with_spinner() { spinner_output='dogfood|https://workspace.example.com|111'; }
+resolve_databricks_profile
+"""
+    )
+
+    assert result.returncode != 0
+    assert "points to workspace ID 111, not 222" in result.stderr
+
+
 def test_dbx_json_passes_host_through_environment(tmp_path: Path):
     databricks = tmp_path / "databricks"
     databricks.write_text(
         r"""#!/bin/sh
-printf '%s\n' "${DATABRICKS_HOST:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*"
+printf '%s\n' "${DATABRICKS_HOST:-}|${DATABRICKS_WORKSPACE_ID:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*"
 """
     )
     databricks.chmod(0o755)
@@ -449,6 +625,7 @@ printf '%s\n' "${DATABRICKS_HOST:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*"
 DATABRICKS_BIN=$1
 PROFILE=
 WORKSPACE_URL=https://workspace.example.com
+WORKSPACE_ID=111
 DATABRICKS_CONFIG_PROFILE=AMBIENT
 export DATABRICKS_CONFIG_PROFILE
 dbx_json experiments get-experiment 42
@@ -458,7 +635,7 @@ dbx_json experiments get-experiment 42
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == (
-        "https://workspace.example.com||experiments get-experiment 42 --output json"
+        "https://workspace.example.com|111||experiments get-experiment 42 --output json"
     )
 
 
@@ -466,7 +643,7 @@ def test_dbx_json_clears_ambient_host_for_profile(tmp_path: Path):
     databricks = tmp_path / "databricks"
     databricks.write_text(
         r"""#!/bin/sh
-printf '%s\n' "${DATABRICKS_HOST:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*"
+printf '%s\n' "${DATABRICKS_HOST:-}|${DATABRICKS_WORKSPACE_ID:-}|${DATABRICKS_CONFIG_PROFILE:-}|$*"
 """
     )
     databricks.chmod(0o755)
@@ -477,8 +654,9 @@ DATABRICKS_BIN=$1
 PROFILE=selected
 WORKSPACE_URL=https://workspace.example.com
 DATABRICKS_HOST=https://ambient.example.com
+DATABRICKS_WORKSPACE_ID=999
 DATABRICKS_CONFIG_PROFILE=AMBIENT
-export DATABRICKS_HOST DATABRICKS_CONFIG_PROFILE
+export DATABRICKS_HOST DATABRICKS_WORKSPACE_ID DATABRICKS_CONFIG_PROFILE
 dbx_json experiments get-experiment 42
 """,
         str(databricks),
@@ -486,7 +664,7 @@ dbx_json experiments get-experiment 42
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == (
-        "|AMBIENT|experiments get-experiment 42 --output json --profile selected"
+        "||AMBIENT|experiments get-experiment 42 --output json --profile selected"
     )
 
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Databricks workspaces can be reached through multiple valid hostnames, including a unified workspace URL and a cloud-specific URL stored in a local CLI profile. Matching profiles by exact hostname can therefore miss valid credentials for the same workspace.

This change:

- adds a `--workspace-id` setup option and uses it as the stable workspace identity
- reads Databricks auth profiles as JSON and matches profiles by workspace ID
- falls back to `databricks auth describe` for legacy profiles without a stored workspace ID
- prefers an exact-host profile when multiple profiles refer to the same workspace
- propagates `DATABRICKS_WORKSPACE_ID` for host-based CLI authentication

Exact hostname matching remains the fallback when no workspace ID is provided.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```console
.venv/bin/pytest tests/agent/test_setup_sh_unit.py tests/agent/test_setup_sh_databricks_e2e.py -q
52 passed
```

Manually verified that an alternate workspace URL and its workspace ID select a local profile configured with the workspace's canonical host.

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `mlflow agent setup` now finds Databricks auth profiles by workspace ID when the supplied workspace URL differs from the profile's configured host.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: A release that increments the second part of the version number (for example, 1.2.0 to 1.3.0).
- Patch release: A release that increments the third part of the version number (for example, 1.2.0 to 1.2.1).

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
