### PR TITLE
Fix `search_logged_models` pagination with metric filters

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -3591,7 +3591,11 @@ class SqlAlchemyStore(SqlAlchemyMCPServerRegistryMixin, SqlAlchemyGatewayStoreMi
                 if dataset_filters:
                     metric_filters.append(sqlalchemy.or_(*dataset_filters))
                 non_attr_filters.append(
-                    session.query(SqlLoggedModelMetric).filter(*metric_filters).subquery()
+                    session
+                    .query(SqlLoggedModelMetric.model_id)
+                    .filter(*metric_filters)
+                    .distinct()
+                    .subquery()
                 )
             elif comp.entity.type == EntityType.PARAM:
                 non_attr_filters.append(

--- a/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
+++ b/tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py
@@ -4007,6 +4007,52 @@ def test_search_logged_models_invalid_operator_lists_applicable_operators(store:
         store.search_logged_models(experiment_ids=[exp_id], filter_string="metrics.loss LIKE 'x'")
 
 
+def test_search_logged_models_metric_filter_pagination(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    logged_models = []
+    for i in range(3):
+        run = store.create_run(
+            experiment_id=exp_id, user_id="user", start_time=i, run_name=f"run-{i}", tags=[]
+        )
+        model = store.create_logged_model(
+            experiment_id=exp_id, name=f"model-{i}", source_run_id=run.info.run_id
+        )
+        for step in range(2):
+            store.log_metric(
+                run.info.run_id,
+                entities.Metric(
+                    key="loss",
+                    value=1.0,
+                    timestamp=step + 1,
+                    step=step,
+                    model_id=model.model_id,
+                ),
+            )
+        logged_models.append(model)
+
+    first_page = store.search_logged_models(
+        experiment_ids=[exp_id],
+        filter_string="metrics.loss >= 0",
+        max_results=2,
+        order_by=[{"field_name": "name"}],
+    )
+    assert [model.name for model in first_page] == ["model-0", "model-1"]
+    assert first_page.token is not None
+
+    second_page = store.search_logged_models(
+        experiment_ids=[exp_id],
+        filter_string="metrics.loss >= 0",
+        max_results=2,
+        order_by=[{"field_name": "name"}],
+        page_token=first_page.token,
+    )
+    assert [model.name for model in second_page] == ["model-2"]
+    assert second_page.token is None
+    assert {model.model_id for model in first_page + second_page} == {
+        model.model_id for model in logged_models
+    }
+
+
 def test_search_runs_returns_outputs(store: SqlAlchemyStore):
     exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
 


### PR DESCRIPTION
### Related Issues/PRs

Relates to #15041

### What changes are proposed in this pull request?

Fix SQLAlchemy `search_logged_models` pagination when a metric filter matches multiple historical metric rows for one logged model. The metric-filter subquery now selects distinct `model_id` values before joining, so `max_results` and `next_page_token` count logged models rather than duplicate metric rows.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Added a regression test covering three logged models with two matching metric rows each, including both workspace-disabled and workspace-enabled SQLAlchemy stores.

Validation:

- `pytest -q tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py` — 268 passed, 8 skipped
- `ruff check mlflow/store/tracking/sqlalchemy_store.py tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py`
- `ruff format --check mlflow/store/tracking/sqlalchemy_store.py tests/store/tracking/sqlalchemy_store/test_sqlalchemy_store_runs.py`

### Does this PR require documentation update?

- [x] No.

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Logged-model searches using metric filters now paginate without dropping matching models.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Logged model search pagination

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix`

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release
