### PR TITLE
fix: treat .ipynb notebooks as text/plain in artifact preview

### DIFF
--- a/mlflow/server/js/src/common/utils/FileUtils.test.ts
+++ b/mlflow/server/js/src/common/utils/FileUtils.test.ts
@@ -19,4 +19,8 @@ describe('FileUtils', () => {
   test('supports pbtxt text previews', () => {
     expect(TEXT_EXTENSIONS.has('pbtxt')).toBe(true);
   });
+
+  test('supports ipynb text previews', () => {
+    expect(TEXT_EXTENSIONS.has('ipynb')).toBe(true);
+  });
 });

--- a/mlflow/server/js/src/common/utils/FileUtils.ts
+++ b/mlflow/server/js/src/common/utils/FileUtils.ts
@@ -52,6 +52,7 @@ export const TEXT_EXTENSIONS = new Set([
   MLPROJECT_FILE_NAME.toLowerCase(),
   MLMODEL_FILE_NAME.toLowerCase(),
   'jsonnet',
+  'ipynb',
 ]);
 export const MARKDOWN_EXTENSIONS = new Set(['md', 'markdown', 'mdx']);
 export const HTML_EXTENSIONS = new Set(['html']);

--- a/mlflow/utils/mime_type_utils.py
+++ b/mlflow/utils/mime_type_utils.py
@@ -32,6 +32,7 @@ def get_text_extensions():
         "tsv",
         "md",
         "rst",
+        "ipynb",
     ]
 
     if not IS_TRACING_SDK_ONLY:

--- a/tests/utils/test_mime_type_utils.py
+++ b/tests/utils/test_mime_type_utils.py
@@ -15,6 +15,7 @@ from mlflow.utils.os import is_windows
         ("/a/b/c.pdf", "application/pdf"),
         ("/a/b/MLmodel", "text/plain"),
         ("/a/b/mlproject", "text/plain"),
+        ("/a/b/notebook.ipynb", "text/plain"),
     ],
 )
 def test_guess_mime_type(file_path, expected_mime_type):


### PR DESCRIPTION
Closes #25710.

### Related Issues/PRs
Closes #25710

### What changes are proposed in this pull request?
Jupyter notebook (`.ipynb`) artifacts were served as `application/octet-stream` instead of `text/plain`, forcing a download instead of an inline preview in the artifact viewer.

This adds `ipynb` to both:
- `get_text_extensions()` in `mlflow/utils/mime_type_utils.py` (server-side content type detection)
- `TEXT_EXTENSIONS` in `mlflow/server/js/src/common/utils/FileUtils.ts` (client-side preview dispatch)

Both are required: `ShowArtifactPage.tsx` renders the inline text preview based on `TEXT_EXTENSIONS.has(extension)`, not the served `Content-Type`, so a server-only fix would not have enabled the preview (per @UgaTheDev's analysis on the issue).

### How is this PR tested?
- [x] New unit/integration tests

Added a new parametrized case to `tests/utils/test_mime_type_utils.py` and a new Jest test to `mlflow/server/js/src/common/utils/FileUtils.test.ts`.

Verified locally — notebook.ipynb renders inline as text instead of prompting a download:
<img width="1916" height="1006" alt="Screenshot 2026-09-17 192618" src="https://github.com/user-attachments/assets/e39d33b7-a903-40f3-9d15-8a339714c9b3" />


### Does this PR require documentation update?
- [x] No.

### Does this PR require updating the MLflow Skills repository?
- [x] No.

### Release Notes

#### Is this a user-facing change?
- [x] Yes. Fixed `.ipynb` notebook artifacts being treated as binary instead of previewable text in the artifact viewer.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

### How should the PR be classified in the release notes? Choose one:
- [x] rn/bug-fix - A user-facing bug fix worth mentioning in the release notes

### Is this PR a critical bugfix or security fix that should go into the next patch release?
- [x] This PR can wait for the next minor release
