### PR TITLE
Fix load_table matching artifact paths with LIKE wildcards

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -3649,6 +3649,30 @@ class MlflowClient:
             filter_string += f" and attributes.run_id IN ({list_run_ids})"
 
         runs = mlflow.search_runs(experiment_ids=[experiment_id], filter_string=filter_string)
+
+        # LIKE treats underscores and percent signs in artifact_file as wildcards. Filter the
+        # results against the parsed tag to make sure that the artifact path matches exactly.
+        logged_artifacts_column = f"tags.{MLFLOW_LOGGED_ARTIFACTS}"
+
+        def has_matching_table_artifact(tag_value):
+            if not isinstance(tag_value, str):
+                return False
+            try:
+                logged_artifacts = json.loads(tag_value)
+            except json.JSONDecodeError:
+                return False
+            return isinstance(logged_artifacts, list) and any(
+                isinstance(artifact, dict)
+                and artifact.get("path") == artifact_file
+                and artifact.get("type") == "table"
+                for artifact in logged_artifacts
+            )
+
+        if logged_artifacts_column in runs:
+            runs = runs[runs[logged_artifacts_column].apply(has_matching_table_artifact)]
+        else:
+            runs = runs.iloc[0:0]
+
         if run_ids and len(run_ids) != len(runs):
             _logger.warning(
                 "Not all runs have the specified table artifact. Some runs will be skipped."

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -1198,6 +1198,31 @@ def test_load_table(file_type):
     "MLFLOW_SKINNY" in os.environ,
     reason="Skinny client does not support the np or pandas dependencies",
 )
+@pytest.mark.parametrize(
+    ("artifact_file", "similar_artifact_file"),
+    [
+        ("eval_results.json", "eval-results.json"),
+        ("eval%results.json", "evalXresults.json"),
+    ],
+)
+def test_load_table_matches_exact_artifact_file(artifact_file, similar_artifact_file):
+    table_dict = {"value": ["expected"]}
+
+    with mlflow.start_run():
+        mlflow.log_table(data=table_dict, artifact_file=artifact_file)
+
+    with mlflow.start_run():
+        mlflow.log_table(data={"value": ["other"]}, artifact_file=similar_artifact_file)
+
+    loaded_table = mlflow.load_table(artifact_file=artifact_file)
+
+    assert loaded_table["value"].tolist() == ["expected"]
+
+
+@pytest.mark.skipif(
+    "MLFLOW_SKINNY" in os.environ,
+    reason="Skinny client does not support the np or pandas dependencies",
+)
 @pytest.mark.parametrize("file_type", ["json", "parquet"])
 def test_log_table_with_datetime_columns(file_type):
     import pandas as pd


### PR DESCRIPTION
### Related Issues/PRs

Relates to #8523

### What changes are proposed in this pull request?

Fix `load_table` selecting the wrong run when `artifact_file` contains SQL `LIKE` wildcard characters.

The existing server-side candidate query treats `_` and `%` in an artifact path as wildcards. For example, when both `eval_results.json` and `eval-results.json` are logged, loading `eval_results.json` can select the latter run and then fail with `Artifact eval_results.json not found`.

This change keeps the existing `LIKE` query for candidate selection, then parses `mlflow.loggedArtifacts` and requires an exact artifact path and `table` type before downloading artifacts.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Test results:

- `pytest -q tests/tracking/test_tracking.py -k 'load_table or log_table'` — 18 passed
- `pytest -q tests/tracking/test_tracking.py` — 103 passed, 1 skipped
- `ruff check mlflow/tracking/client.py tests/tracking/test_tracking.py`

Manual verification was performed with:

- FileStore tracking backend
- SQLite tracking backend
- HTTP tracking server with server-served artifacts

The regression test covers both `_` and `%` wildcard cases.

### Does this PR require documentation update?

- [x] No.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Does this PR require updating the [MLflow Skills](https://github.com/mlflow/skills) repository?

- [x] No.
- [ ] Yes. Please link the corresponding PR or explain how you plan to update it.

### Release Notes

#### Is this a user-facing change?

- [ ] No.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.load_table` now matches logged table artifact paths exactly when artifact filenames contain `_` or `%`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model serialization and serving
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and integrations
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: Documentation

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number
- [ ] `rn/breaking-change` - The PR will be mentioned in the Breaking Changes section
- [ ] `rn/feature` - A new user-facing feature
- [x] `rn/bug-fix` - A user-facing bug fix
- [ ] `rn/documentation` - A documentation change

#### Is this PR a critical bugfix or security fix that should go into the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor releases may contain larger changes, such as new features and improvements.
- Patch releases are typically reserved for critical fixes or major regressions.

</details>

- [ ] This PR is critical and needs to be in the next patch release
- [x] This PR can wait for the next minor release